### PR TITLE
fix(im): render WeCom resource images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,8 @@ DOCREADER_TRANSPORT=grpc
 # 内网 IP 和 localhost 对飞书/企微/Slack 等 IM 平台不可达；本地开发请用 ngrok/cloudflared/frp。
 # APP_EXTERNAL_URL=
 # 前端外部 origin，用于邀请链接等绝对 URL（留空走 host-relative）。
+# 如果 APP_EXTERNAL_URL 未设置，单体部署会将此值作为图片 /r/ 外链的兜底；
+# 仅当该 origin 同时由前端 nginx 代理 /r/ 时才适用。
 # FRONTEND_BASE_URL=
 # API 响应里文件引用的默认形式：handle（默认）/ public。
 #   handle — 返回内部 resource://<handle>，客户端需再调用带鉴权的 /files 代理取图。

--- a/docs/IM集成开发文档.md
+++ b/docs/IM集成开发文档.md
@@ -48,7 +48,8 @@ IM 渠道绑定到 Agent，一个 Agent 可接入多个 IM 渠道，所有配置
 
 > **回复图片需公网可达**：IM 显示知识库图片需让 IM 端拿到公网 http 图片 URL，二选一——
 > (A) 存储后端本身公网可达（对象存储公网 endpoint / `MINIO_ENDPOINT` 设为公网）；
-> (B) 配 `APP_EXTERNAL_URL`，图片走 WeKnora 的 `/r/` 短链（nginx 已内置 `/r/` 代理）。
+> (B) 配 `APP_EXTERNAL_URL`，图片走 WeKnora 的 `/r/` 短链（nginx 已内置 `/r/` 代理）。单体部署若已配置
+> `FRONTEND_BASE_URL`，且该 origin 同样代理 `/r/`，也可作为 `APP_EXTERNAL_URL` 的兜底。
 > 默认 MinIO 部署走 (B) 最简单。详见 `.env.example` 中 `APP_EXTERNAL_URL` 说明。
 
 ### 企业微信接入

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -426,7 +426,7 @@ docker run -d -p 8081:8081 weknora-docs
 
 注意事项：
 
-- 直链依赖 `APP_EXTERNAL_URL`（或存储后端本身公网可达）才能生成；无法生成时该引用会保持 `resource://` 原样，客户端仍可回退到 `/files`。
+- 直链依赖 `APP_EXTERNAL_URL`（单体部署也可用同时代理 `/r/` 的 `FRONTEND_BASE_URL`）或存储后端本身公网可达才能生成；无法生成时该引用会保持 `resource://` 原样，客户端仍可回退到 `/files`。
 - `public` 会为每个被引用文件签发**限时匿名可读**链接（WeKnora 侧 2 小时，MinIO 24 小时），请评估是否符合你的安全要求。
 - 匿名的 embed 渠道与限定了知识库范围的 API Key **始终返回 handle**，不受该变量影响。
 - 建议同时配置 `SYSTEM_AES_KEY`，以便复用 grant 行、稳定直链 URL 并降低读接口的写入压力。

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -95,7 +95,8 @@ X-Request-ID: unique_request_id
 
 ### 注意事项
 
-- **需要外链能力。** 直链由存储后端预签名，或由 `APP_EXTERNAL_URL` + `/r/<token>` 提供。二者都不
+- **需要外链能力。** 直链由存储后端预签名，或由 `APP_EXTERNAL_URL`（单体部署可回退到同时代理 `/r/` 的
+  `FRONTEND_BASE_URL`）+ `/r/<token>` 提供。二者都不
   可用时（例如 local 存储且未设 `APP_EXTERNAL_URL`），该引用**保持 `resource://` 原样**，客户端
   仍可回退到 `/files` 代理。详见 `.env.example` 中的 `APP_EXTERNAL_URL` 说明。
 - **直链是限时匿名可读的**（WeKnora 签发的 grant 2 小时，MinIO 预签名 24 小时）。任何拿到链接的

--- a/internal/application/service/file/factory.go
+++ b/internal/application/service/file/factory.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
@@ -47,7 +48,7 @@ func NewFileServiceFromStorageConfig(
 				}
 			}
 		}
-		externalURL := strings.TrimSpace(os.Getenv("APP_EXTERNAL_URL"))
+		externalURL := config.ConfiguredExternalURL()
 		return NewLocalFileService(baseDir, externalURL), p, nil
 
 	case "minio":

--- a/internal/application/service/file/resource_catalog.go
+++ b/internal/application/service/file/resource_catalog.go
@@ -8,11 +8,11 @@ import (
 	"io"
 	"mime"
 	"mime/multipart"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 )
@@ -37,7 +37,7 @@ func NewResourceCatalogFileService(
 	return &resourceCatalogFileService{
 		inner:       inner,
 		catalog:     catalog,
-		externalURL: strings.TrimRight(strings.TrimSpace(os.Getenv("APP_EXTERNAL_URL")), "/"),
+		externalURL: config.ConfiguredExternalURL(),
 	}
 }
 

--- a/internal/application/service/file/resource_catalog_test.go
+++ b/internal/application/service/file/resource_catalog_test.go
@@ -109,3 +109,17 @@ func TestResourceCatalogFileServiceReturnsShortExternalGrantURL(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "https://weknora.example.com/r/GrantTokenAbCdEfGhIjKl", externalURL)
 }
+
+func TestResourceCatalogFileServiceUsesFrontendBaseURLFallback(t *testing.T) {
+	t.Setenv("APP_EXTERNAL_URL", "")
+	t.Setenv("FRONTEND_BASE_URL", "https://frontend.example.com///")
+	inner := &physicalFileStub{savedPath: "local://7/exports/a.png"}
+	catalog := &catalogStub{}
+	svc := NewResourceCatalogFileService(inner, catalog)
+
+	ref, err := svc.SaveBytes(context.Background(), []byte("image"), 7, "a.png", false)
+	require.NoError(t, err)
+	externalURL, err := svc.GetFileURL(context.Background(), ref)
+	require.NoError(t, err)
+	require.Equal(t, "https://frontend.example.com/r/GrantTokenAbCdEfGhIjKl", externalURL)
+}

--- a/internal/config/external_url.go
+++ b/internal/config/external_url.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+// ConfiguredExternalURL returns the public origin used by URLs that must be
+// fetched by a third-party client, such as an IM platform. APP_EXTERNAL_URL
+// is the explicit setting. FRONTEND_BASE_URL is a compatible fallback for
+// single-origin deployments where the frontend proxy also exposes /r/.
+//
+// APP_EXTERNAL_URL wins when both variables are set so existing deployments
+// keep their current behaviour.
+func ConfiguredExternalURL() string {
+	for _, name := range []string{"APP_EXTERNAL_URL", "FRONTEND_BASE_URL"} {
+		if value := strings.TrimRight(strings.TrimSpace(os.Getenv(name)), "/"); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/config/external_url_test.go
+++ b/internal/config/external_url_test.go
@@ -1,0 +1,19 @@
+package config
+
+import "testing"
+
+func TestConfiguredExternalURLPrefersAppURL(t *testing.T) {
+	t.Setenv("APP_EXTERNAL_URL", " https://app.example.com/// ")
+	t.Setenv("FRONTEND_BASE_URL", "https://frontend.example.com")
+	if got := ConfiguredExternalURL(); got != "https://app.example.com" {
+		t.Fatalf("ConfiguredExternalURL() = %q, want APP_EXTERNAL_URL", got)
+	}
+}
+
+func TestConfiguredExternalURLFallsBackToFrontendURL(t *testing.T) {
+	t.Setenv("APP_EXTERNAL_URL", "  ")
+	t.Setenv("FRONTEND_BASE_URL", " https://frontend.example.com/ ")
+	if got := ConfiguredExternalURL(); got != "https://frontend.example.com" {
+		t.Fatalf("ConfiguredExternalURL() = %q, want FRONTEND_BASE_URL", got)
+	}
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -1091,7 +1091,7 @@ func initRawFileService(_ *config.Config) (interfaces.FileService, error) {
 		if baseDir == "" {
 			baseDir = "/data/files"
 		}
-		externalURL := strings.TrimSpace(os.Getenv("APP_EXTERNAL_URL"))
+		externalURL := config.ConfiguredExternalURL()
 		return file.NewLocalFileService(baseDir, externalURL), nil
 	case "dummy":
 		return file.NewDummyFileService(), nil

--- a/internal/im/im_config_warning_test.go
+++ b/internal/im/im_config_warning_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// imImageConfigWarning warns only when IM channels are active AND APP_EXTERNAL_URL
-// is unset — the config state that silently breaks resource:// images in IM.
+// imImageConfigWarning warns only when IM channels are active AND neither
+// public-origin setting is configured — the config state that silently breaks
+// resource:// images in IM.
 func TestIMImageConfigWarning(t *testing.T) {
 	t.Run("no channels -> silent", func(t *testing.T) {
 		assert.Empty(t, imImageConfigWarning(0, ""))
@@ -21,6 +22,7 @@ func TestIMImageConfigWarning(t *testing.T) {
 	t.Run("channels active but external URL empty -> warns with count", func(t *testing.T) {
 		msg := imImageConfigWarning(2, "")
 		assert.Contains(t, msg, "APP_EXTERNAL_URL")
+		assert.Contains(t, msg, "FRONTEND_BASE_URL")
 		assert.Contains(t, msg, "2 IM channel")
 		assert.Contains(t, msg, "/r/")
 	})

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -925,7 +925,7 @@ func (s *Service) dedupCleanupLoop() {
 }
 
 // imImageConfigWarning returns an operator warning when IM channels are active
-// but APP_EXTERNAL_URL is unset. resource:// images then render only if the
+// but neither APP_EXTERNAL_URL nor FRONTEND_BASE_URL is set. resource:// images then render only if the
 // storage backend is itself publicly reachable (e.g. a cloud bucket with a
 // public endpoint); on the default MinIO (internal minio:9000) or local
 // deployment it is not, so images silently break. Advisory only; returns ""
@@ -935,9 +935,9 @@ func imImageConfigWarning(activeChannels int, externalURL string) string {
 	if activeChannels == 0 || strings.TrimSpace(externalURL) != "" {
 		return ""
 	}
-	return fmt.Sprintf("[IM] %d IM channel(s) active but APP_EXTERNAL_URL is unset; "+
+	return fmt.Sprintf("[IM] %d IM channel(s) active but APP_EXTERNAL_URL and FRONTEND_BASE_URL are unset; "+
 		"resource:// images render only if the storage backend is publicly reachable — "+
-		"otherwise set APP_EXTERNAL_URL so they route through nginx /r/",
+		"otherwise set APP_EXTERNAL_URL (or FRONTEND_BASE_URL for a single-origin proxy) so they route through nginx /r/",
 		activeChannels)
 }
 
@@ -951,7 +951,7 @@ func (s *Service) LoadAndStartChannels() error {
 		return fmt.Errorf("load im channels: %w", err)
 	}
 
-	if msg := imImageConfigWarning(len(channels), os.Getenv("APP_EXTERNAL_URL")); msg != "" {
+	if msg := imImageConfigWarning(len(channels), config.ConfiguredExternalURL()); msg != "" {
 		logger.Warnf(ctx, "%s", msg)
 	}
 

--- a/internal/storageurl/resolver.go
+++ b/internal/storageurl/resolver.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	filesvc "github.com/Tencent/WeKnora/internal/application/service/file"
+	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
@@ -118,7 +119,7 @@ func BuildFileServiceForProvider(
 		return svc
 	}
 	if provider == "local" {
-		externalURL := strings.TrimSpace(os.Getenv("APP_EXTERNAL_URL"))
+		externalURL := config.ConfiguredExternalURL()
 		return filesvc.NewLocalFileService(baseDir, externalURL)
 	}
 	if defaultSvc != nil {


### PR DESCRIPTION
## Description

修复企业微信等第三方 IM 客户端收到 resource:// 图片引用后无法直接渲染的问题。新增统一的外部访问地址解析：显式 APP_EXTERNAL_URL 优先，未设置时兼容单体部署使用的 FRONTEND_BASE_URL，并让本地文件、资源目录、存储 URL 解析和 IM 配置告警使用同一规则。同步补充配置说明和测试。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2583

## Testing

- gofmt、git diff --check 通过。
- 已尝试 go test ./internal/config -run TestConfiguredExternalURL -count=1。
- Go 测试被仓库现有 internal/utils/inject.go 对 pg_query.Parse 和 pg_query.Deparse 的 CGo 绑定错误阻塞；当前 Windows 环境也没有可用 C 编译器。
- 未使用真实企业微信机器人做端到端发送验证。

## Checklist

- [x] git diff --check origin/main...HEAD passes
- [x] Changed source files are formatted
- [ ] Targeted Go tests are blocked by the documented environment issue
- [ ] Diff-scoped lint was not run locally
- [ ] Full-repository checks were not run; environment limitation is documented above
- [x] Self-reviewed the code
- [x] Added tests covering external URL fallback
- [x] Updated related documentation
- [x] No breaking changes

## Screenshots / Recordings

未附截图；需要真实企业微信机器人和可访问部署地址才能完成端到端展示验证。