### PR TITLE
feat(im): add clickable Feishu citations

### DIFF
--- a/internal/application/service/datasource_service.go
+++ b/internal/application/service/datasource_service.go
@@ -1254,6 +1254,12 @@ func (s *DataSourceService) ingestItem(ctx context.Context, ds *types.DataSource
 	for k, v := range item.Metadata {
 		metadata[k] = v
 	}
+	// Preserve the user-facing source URL for search results and IM citations.
+	// Put it after connector metadata so the canonical FetchedItem URL cannot be
+	// accidentally shadowed by a stale source_url value.
+	if sourceURL := strings.TrimSpace(item.URL); sourceURL != "" {
+		metadata[types.MetadataKeySourceURL] = sourceURL
+	}
 
 	// Check if a knowledge item with this external_id already exists → delete it first (update)
 	isUpdate := false

--- a/internal/application/service/datasource_service_test.go
+++ b/internal/application/service/datasource_service_test.go
@@ -499,6 +499,7 @@ func TestIngestItem_URLCreationAttachesDataSourceMetadata(t *testing.T) {
 	require.Len(t, repo.metadataUpdates, 1)
 	assert.Equal(t, ds.ID, repo.metadataUpdates[0]["datasource_id"])
 	assert.Equal(t, "url:1", repo.metadataUpdates[0]["external_id"])
+	assert.Equal(t, "https://example.com/doc", repo.metadataUpdates[0][types.MetadataKeySourceURL])
 }
 
 func TestProcessSync_SyncDeletionsDeletesMatchingKnowledge(t *testing.T) {

--- a/internal/im/adapter.go
+++ b/internal/im/adapter.go
@@ -114,12 +114,25 @@ const (
 type ReplyMessage struct {
 	// Content is the text content (Markdown).
 	Content string
+	// Citations contains source links that can be rendered as platform-native
+	// links. Adapters that do not support structured citations may ignore it.
+	Citations []ReplyCitation
 	// IsStreaming indicates whether this is a streaming chunk.
 	IsStreaming bool
 	// IsFinal marks the last chunk of a streaming reply.
 	IsFinal bool
 	// Extra holds platform-specific fields.
 	Extra map[string]string
+}
+
+// ReplyCitation is a source link attached to an IM reply.
+//
+// Label is the stable citation label shown to the user (for example, "S1").
+// Title is the human-readable source title and URL is the original source URL.
+type ReplyCitation struct {
+	Label string
+	Title string
+	URL   string
 }
 
 // Adapter is the interface every IM platform must implement.

--- a/internal/im/citations.go
+++ b/internal/im/citations.go
@@ -1,0 +1,219 @@
+package im
+
+import (
+	"fmt"
+	"html"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+var imCitationAttributeRe = regexp.MustCompile(`(?i)\b([a-z][a-z0-9_-]*)\s*=\s*"([^"]*)"`)
+
+// BuildReplyCitations extracts the sources explicitly cited in an answer.
+//
+// Knowledge references are emitted before the model answer and may include
+// retrieved chunks that the model did not use. Restricting the result to the
+// canonical <kb/> / <web/> tags keeps IM replies aligned with the sources the
+// answer actually cites instead of dumping every retrieved result.
+func BuildReplyCitations(answer string, refs []*types.SearchResult) []ReplyCitation {
+	if strings.TrimSpace(answer) == "" {
+		return nil
+	}
+
+	refsByChunkID := make(map[string]*types.SearchResult, len(refs))
+	refsByKnowledgeID := make(map[string][]*types.SearchResult)
+	for _, ref := range refs {
+		if ref == nil {
+			continue
+		}
+		if id := strings.TrimSpace(ref.ID); id != "" {
+			refsByChunkID[id] = ref
+		}
+		if id := strings.TrimSpace(ref.KnowledgeID); id != "" {
+			refsByKnowledgeID[id] = append(refsByKnowledgeID[id], ref)
+		}
+	}
+
+	var citations []ReplyCitation
+	seenURLs := make(map[string]struct{})
+	for _, tag := range imCitationTagRe.FindAllString(answer, -1) {
+		attrs := parseIMCitationAttributes(tag)
+		name := strings.ToLower(strings.TrimSpace(tagName(tag)))
+
+		var (
+			citationURL string
+			title       string
+		)
+		switch name {
+		case "web":
+			citationURL = attrs["url"]
+			title = attrs["title"]
+		case "kb":
+			ref := matchIMKnowledgeReference(attrs, refsByChunkID, refsByKnowledgeID)
+			if ref == nil {
+				continue
+			}
+			citationURL = ref.Metadata[types.MetadataKeySourceURL]
+			title = firstNonEmptyIMString(ref.KnowledgeTitle, ref.KnowledgeFilename, attrs["doc"])
+		default:
+			continue
+		}
+
+		citationURL = normalizeIMCitationURL(citationURL)
+		if citationURL == "" {
+			continue
+		}
+		if _, seen := seenURLs[citationURL]; seen {
+			continue
+		}
+		seenURLs[citationURL] = struct{}{}
+		if strings.TrimSpace(title) == "" {
+			title = citationURL
+		}
+		citations = append(citations, ReplyCitation{
+			Label: fmt.Sprintf("S%d", len(citations)+1),
+			Title: strings.TrimSpace(html.UnescapeString(title)),
+			URL:   citationURL,
+		})
+	}
+	return citations
+}
+
+func parseIMCitationAttributes(tag string) map[string]string {
+	attrs := make(map[string]string)
+	for _, match := range imCitationAttributeRe.FindAllStringSubmatch(tag, -1) {
+		if len(match) != 3 {
+			continue
+		}
+		attrs[strings.ToLower(match[1])] = html.UnescapeString(strings.TrimSpace(match[2]))
+	}
+	return attrs
+}
+
+func tagName(tag string) string {
+	trimmed := strings.TrimSpace(strings.TrimPrefix(tag, "<"))
+	if idx := strings.IndexAny(trimmed, " \t\r\n>"); idx >= 0 {
+		return trimmed[:idx]
+	}
+	return trimmed
+}
+
+func matchIMKnowledgeReference(
+	attrs map[string]string,
+	refsByChunkID map[string]*types.SearchResult,
+	refsByKnowledgeID map[string][]*types.SearchResult,
+) *types.SearchResult {
+	for _, key := range []string{"chunk_id", "chunkid", "id"} {
+		if ref := refsByChunkID[strings.TrimSpace(attrs[key])]; ref != nil {
+			return ref
+		}
+	}
+
+	knowledgeID := strings.TrimSpace(firstNonEmptyIMString(attrs["knowledge_id"], attrs["knowledgeid"]))
+	if knowledgeID != "" {
+		matches := refsByKnowledgeID[knowledgeID]
+		if len(matches) == 1 {
+			return matches[0]
+		}
+	}
+
+	doc := strings.TrimSpace(attrs["doc"])
+	if doc == "" {
+		return nil
+	}
+	var match *types.SearchResult
+	for _, ref := range refsByChunkID {
+		if !sameIMCitationTitle(doc, ref.KnowledgeTitle) && !sameIMCitationTitle(doc, ref.KnowledgeFilename) {
+			continue
+		}
+		if match != nil {
+			return nil
+		}
+		match = ref
+	}
+	return match
+}
+
+func sameIMCitationTitle(left, right string) bool {
+	return strings.EqualFold(strings.TrimSpace(html.UnescapeString(left)), strings.TrimSpace(html.UnescapeString(right)))
+}
+
+func normalizeIMCitationURL(raw string) string {
+	raw = strings.TrimSpace(html.UnescapeString(raw))
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return ""
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "http", "https":
+		return raw
+	default:
+		return ""
+	}
+}
+
+// FormatReplyCitations returns a Markdown source section for adapters that
+// render Markdown (Feishu/Lark cards, for example). It is intentionally a
+// separate operation from BuildReplyCitations so non-Markdown adapters can
+// choose their own structured representation.
+func FormatReplyCitations(platform Platform, citations []ReplyCitation) string {
+	if len(citations) == 0 {
+		return ""
+	}
+
+	heading := "引用来源"
+	if platform == PlatformLark {
+		heading = "Sources"
+	}
+	var b strings.Builder
+	written := 0
+	for _, citation := range citations {
+		url := normalizeIMCitationURL(citation.URL)
+		if url == "" {
+			continue
+		}
+		title := strings.TrimSpace(citation.Title)
+		if title == "" {
+			title = url
+		}
+		label := strings.TrimSpace(citation.Label)
+		if label == "" {
+			label = fmt.Sprintf("S%d", written+1)
+		}
+		if written == 0 {
+			b.WriteString("\n\n")
+			b.WriteString(heading)
+			b.WriteString(":\n")
+		}
+		written++
+		b.WriteString("[")
+		b.WriteString(escapeIMMarkdownText(label))
+		b.WriteString("] [")
+		b.WriteString(escapeIMMarkdownText(title))
+		b.WriteString("](")
+		b.WriteString(strings.ReplaceAll(url, ")", "%29"))
+		b.WriteString(")\n")
+	}
+	if written == 0 {
+		return ""
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func escapeIMMarkdownText(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, "[", `\[`)
+	return strings.ReplaceAll(value, "]", `\]`)
+}
+
+func firstNonEmptyIMString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/im/citations_test.go
+++ b/internal/im/citations_test.go
@@ -1,0 +1,60 @@
+package im
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestBuildReplyCitationsUsesOnlyCitedSources(t *testing.T) {
+	refs := []*types.SearchResult{
+		{
+			ID:             "chunk-1",
+			KnowledgeID:    "doc-1",
+			KnowledgeTitle: "Product Guide",
+			Metadata:       map[string]string{types.MetadataKeySourceURL: "https://feishu.cn/wiki/doc-1"},
+		},
+		{
+			ID:             "chunk-2",
+			KnowledgeID:    "doc-2",
+			KnowledgeTitle: "Uncited Guide",
+			Metadata:       map[string]string{types.MetadataKeySourceURL: "https://feishu.cn/wiki/doc-2"},
+		},
+	}
+
+	answer := `Answer <kb doc="Product Guide" chunk_id="chunk-1" kb_id="kb-1" /> and <kb doc="Product Guide" chunk_id="chunk-1" kb_id="kb-1" />.`
+	got := BuildReplyCitations(answer, refs)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d citations, want one: %#v", len(got), got)
+	}
+	if got[0].Label != "S1" || got[0].Title != "Product Guide" || got[0].URL != "https://feishu.cn/wiki/doc-1" {
+		t.Fatalf("citation = %#v, want S1/Product Guide/source URL", got[0])
+	}
+}
+
+func TestBuildReplyCitationsSupportsWebLinksAndRejectsUnsafeURLs(t *testing.T) {
+	answer := `<web title="Official docs" url="https://example.com/docs" /> <web title="Local" url="javascript:alert(1)" />`
+	got := BuildReplyCitations(answer, nil)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d citations, want one safe citation: %#v", len(got), got)
+	}
+	if got[0].Label != "S1" || got[0].Title != "Official docs" || got[0].URL != "https://example.com/docs" {
+		t.Fatalf("citation = %#v, want safe web citation", got[0])
+	}
+}
+
+func TestFormatReplyCitationsUsesPlatformHeading(t *testing.T) {
+	citations := []ReplyCitation{{Label: "S1", Title: "Product [Guide]", URL: "https://example.com/docs?a=1)"}}
+
+	feishu := FormatReplyCitations(PlatformFeishu, citations)
+	if feishu != "\n\n引用来源:\n[S1] [Product \\[Guide\\]](https://example.com/docs?a=1%29)" {
+		t.Fatalf("Feishu citations = %q", feishu)
+	}
+
+	lark := FormatReplyCitations(PlatformLark, citations)
+	if lark != "\n\nSources:\n[S1] [Product \\[Guide\\]](https://example.com/docs?a=1%29)" {
+		t.Fatalf("Lark citations = %q", lark)
+	}
+}

--- a/internal/im/feishu/adapter.go
+++ b/internal/im/feishu/adapter.go
@@ -503,12 +503,11 @@ func (a *Adapter) SendReply(ctx context.Context, incoming *im.IncomingMessage, r
 		return fmt.Errorf("get access token: %w", err)
 	}
 
-	// Build text message content
-	content, _ := json.Marshal(map[string]string{"text": reply.Content})
+	msgType, content := buildReplyMessageContent(a.region.Platform, reply)
 
 	// Reply payload (no receive_id — the path message_id locates the chat)
 	replyPayload := map[string]interface{}{
-		"msg_type": "text",
+		"msg_type": msgType,
 		"content":  string(content),
 	}
 
@@ -516,11 +515,48 @@ func (a *Adapter) SendReply(ctx context.Context, incoming *im.IncomingMessage, r
 	receiveIDType, receiveID := a.resolveReceiveID(incoming)
 	fallbackPayload := map[string]interface{}{
 		"receive_id": receiveID,
-		"msg_type":   "text",
+		"msg_type":   msgType,
 		"content":    string(content),
 	}
 
 	return a.sendWithFallback(ctx, accessToken, incoming, replyPayload, fallbackPayload, receiveIDType)
+}
+
+// buildReplyMessageContent keeps ordinary replies as text messages. When the
+// service attaches citations, use a static CardKit markdown card so the answer
+// keeps its Markdown formatting and the source links remain clickable in
+// Feishu/Lark clients.
+func buildReplyMessageContent(platform im.Platform, reply *im.ReplyMessage) (msgType string, content []byte) {
+	if reply == nil {
+		reply = &im.ReplyMessage{}
+	}
+	if len(reply.Citations) == 0 {
+		content, _ = json.Marshal(map[string]string{"text": reply.Content})
+		return "text", content
+	}
+
+	citationText := im.FormatReplyCitations(platform, reply.Citations)
+	if citationText == "" {
+		content, _ = json.Marshal(map[string]string{"text": reply.Content})
+		return "text", content
+	}
+
+	card := map[string]interface{}{
+		"schema": "2.0",
+		"config": map[string]interface{}{
+			"wide_screen_mode": true,
+		},
+		"body": map[string]interface{}{
+			"elements": []map[string]interface{}{
+				{
+					"tag":     "markdown",
+					"content": reply.Content + citationText,
+				},
+			},
+		},
+	}
+	content, _ = json.Marshal(card)
+	return "interactive", content
 }
 
 // resolveReceiveID computes the (receive_id_type, receive_id) pair used by the

--- a/internal/im/feishu/send_e2e_test.go
+++ b/internal/im/feishu/send_e2e_test.go
@@ -136,6 +136,62 @@ func TestSendReply_EndToEnd_UsesRegionCloud(t *testing.T) {
 	}
 }
 
+func TestSendReply_EndToEnd_UsesMarkdownCardForCitations(t *testing.T) {
+	useTestHTTPClient(t)
+	fake := &fakeOpenPlatform{}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	a, _ := NewAdapter(testRegion(srv.URL), "cli_app", "secret", "", "", "")
+	incoming := &im.IncomingMessage{
+		Platform:  im.PlatformLark,
+		UserID:    "ou_user1",
+		ChatType:  im.ChatTypeDirect,
+		MessageID: "om_msg1",
+	}
+
+	err := a.SendReply(context.Background(), incoming, &im.ReplyMessage{
+		Content: "answer **with formatting**",
+		Citations: []im.ReplyCitation{{
+			Label: "S1",
+			Title: "Product Guide",
+			URL:   "https://larksuite.com/wiki/doc-1",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("SendReply: %v", err)
+	}
+
+	if got := fake.replyBody["msg_type"]; got != "interactive" {
+		t.Fatalf("msg_type = %v, want interactive", got)
+	}
+	content, ok := fake.replyBody["content"].(string)
+	if !ok {
+		t.Fatalf("content = %T, want JSON string", fake.replyBody["content"])
+	}
+	var card struct {
+		Schema string `json:"schema"`
+		Body   struct {
+			Elements []struct {
+				Tag     string `json:"tag"`
+				Content string `json:"content"`
+			} `json:"elements"`
+		} `json:"body"`
+	}
+	if err := json.Unmarshal([]byte(content), &card); err != nil {
+		t.Fatalf("interactive content is not a card: %v", err)
+	}
+	if card.Schema != "2.0" || len(card.Body.Elements) != 1 {
+		t.Fatalf("card = %#v, want schema 2.0 with one element", card)
+	}
+	if card.Body.Elements[0].Tag != "markdown" {
+		t.Fatalf("card element tag = %q, want markdown", card.Body.Elements[0].Tag)
+	}
+	if !strings.Contains(card.Body.Elements[0].Content, "[S1] [Product Guide](https://larksuite.com/wiki/doc-1)") {
+		t.Fatalf("card markdown does not contain clickable citation: %q", card.Body.Elements[0].Content)
+	}
+}
+
 // A group that rejects reply-in-thread (230071) must still receive the answer
 // via the plain send-message API, addressed to the chat.
 func TestSendReply_EndToEnd_FallsBackToSendAPI(t *testing.T) {

--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -1933,15 +1933,19 @@ func (s *Service) executeQARequest(req *qaRequest) {
 	}
 
 	// Non-streaming fallback: collect full answer then send.
-	answer, err := s.runQA(ctx, req.session, req.msg.Content, req.agent, kbIDs, attachments, imageURLs, req.userKey, req.msg.Quote)
+	answer, references, err := s.runQA(ctx, req.session, req.msg.Content, req.agent, kbIDs, attachments, imageURLs, req.userKey, req.msg.Quote)
 	if err != nil {
 		logger.Errorf(ctx, "[IM] QA failed: %v, sending fallback reply", err)
 		answer = "抱歉，处理您的问题时出现了异常，请稍后再试。"
+		references = nil
 	}
 
 	reply := &ReplyMessage{
 		Content: formatIMOutboundAnswer(ctx, answer, req.tenant, s.defaultFileSvc, s.storageResolver),
 		IsFinal: true,
+	}
+	if req.msg.Platform == PlatformFeishu || req.msg.Platform == PlatformLark {
+		reply.Citations = BuildReplyCitations(answer, references)
 	}
 	if err := req.adapter.SendReply(ctx, req.msg, reply); err != nil {
 		logger.Errorf(ctx, "[IM] Send reply failed: %v", err)
@@ -2730,6 +2734,7 @@ loop:
 		parts.Answer = resolvedAnswer
 	}
 	answer := resolvedAnswer
+	references := append([]*types.SearchResult(nil), assistantMsg.KnowledgeReferences...)
 	finalErr := qaErr
 	noVisibleContent := !streamedAny && strings.TrimSpace(resolvedAnswer) == ""
 	authServices := append([]imMCPAuthService(nil), mcpAuthServices...)
@@ -2744,6 +2749,11 @@ loop:
 		finalDisplay = fallback
 		if answer == "" {
 			answer = fallback
+		}
+	}
+	if msg.Platform == PlatformFeishu || msg.Platform == PlatformLark {
+		if citationText := FormatReplyCitations(msg.Platform, BuildReplyCitations(answer, references)); citationText != "" {
+			finalDisplay += citationText
 		}
 	}
 	if notice := s.buildIMMCPAuthNotice(ctx, authServices); notice != "" {
@@ -2776,17 +2786,22 @@ loop:
 
 // fallbackNonStream is used when streaming initialization fails.
 func (s *Service) fallbackNonStream(ctx context.Context, msg *IncomingMessage, session *types.Session, customAgent *types.CustomAgent, kbIDs []string, attachments types.MessageAttachments, imageURLs []string, adapter Adapter, userKey string, tenant *types.Tenant) error {
-	answer, err := s.runQA(ctx, session, msg.Content, customAgent, kbIDs, attachments, imageURLs, userKey, msg.Quote)
+	answer, references, err := s.runQA(ctx, session, msg.Content, customAgent, kbIDs, attachments, imageURLs, userKey, msg.Quote)
 	if err != nil {
 		logger.Errorf(ctx, "[IM] QA fallback failed: %v", err)
 		answer = "抱歉，处理您的问题时出现了异常，请稍后再试。"
+		references = nil
 	}
 
-	return adapter.SendReply(ctx, msg, &ReplyMessage{Content: formatIMOutboundAnswer(ctx, answer, tenant, s.defaultFileSvc, s.storageResolver), IsFinal: true})
+	reply := &ReplyMessage{Content: formatIMOutboundAnswer(ctx, answer, tenant, s.defaultFileSvc, s.storageResolver), IsFinal: true}
+	if msg.Platform == PlatformFeishu || msg.Platform == PlatformLark {
+		reply.Citations = BuildReplyCitations(answer, references)
+	}
+	return adapter.SendReply(ctx, msg, reply)
 }
 
 // runQA executes the WeKnora QA pipeline and returns the full answer text.
-func (s *Service) runQA(ctx context.Context, session *types.Session, query string, customAgent *types.CustomAgent, kbIDs []string, attachments types.MessageAttachments, imageURLs []string, userKey string, quote *QuotedMessage) (string, error) {
+func (s *Service) runQA(ctx context.Context, session *types.Session, query string, customAgent *types.CustomAgent, kbIDs []string, attachments types.MessageAttachments, imageURLs []string, userKey string, quote *QuotedMessage) (string, []*types.SearchResult, error) {
 	// Cancellable context (no hard deadline): each agent round has its own
 	// LLMCallTimeout. The context can still be cancelled by /stop.
 	ctx, cancel := context.WithCancel(ctx)
@@ -2860,13 +2875,13 @@ func (s *Service) runQA(ctx context.Context, session *types.Session, query strin
 	// Create user message so it appears in conversation history
 	userMsg, err := s.messageService.CreateMessage(ctx, createIMUserMessagePayload(session.ID, query, requestID, attachments))
 	if err != nil {
-		return "", fmt.Errorf("create user message: %w", err)
+		return "", nil, fmt.Errorf("create user message: %w", err)
 	}
 
 	// Create a placeholder assistant message
 	assistantMsg, err := s.messageService.CreateMessage(ctx, createIMAssistantMessagePayload(session.ID, requestID))
 	if err != nil {
-		return "", fmt.Errorf("create assistant message: %w", err)
+		return "", nil, fmt.Errorf("create assistant message: %w", err)
 	}
 
 	eventBus.On(event.EventAgentReferences, func(ctx context.Context, evt event.Event) error {
@@ -2946,17 +2961,18 @@ func (s *Service) runQA(ctx context.Context, session *types.Session, query strin
 		if updateErr := s.messageService.UpdateMessage(context.WithoutCancel(ctx), assistantMsg); updateErr != nil {
 			logger.Warnf(ctx, "[IM] Failed to update cancelled assistant message: %v", updateErr)
 		}
-		return "", fmt.Errorf("QA cancelled: %w", ctx.Err())
+		return "", nil, fmt.Errorf("QA cancelled: %w", ctx.Err())
 	}
 
 	answerMu.Lock()
 	answer := answerBuilder.String()
 	qaError := qaErr
+	references := append([]*types.SearchResult(nil), assistantMsg.KnowledgeReferences...)
 	authServices := append([]imMCPAuthService(nil), mcpAuthServices...)
 	answerMu.Unlock()
 
 	if answer == "" && qaError != nil {
-		return "", qaError
+		return "", references, qaError
 	}
 	if answer == "" {
 		answer = "抱歉，我暂时无法回答这个问题。"
@@ -2973,7 +2989,7 @@ func (s *Service) runQA(ctx context.Context, session *types.Session, query strin
 	}
 
 	// Return raw answer — callers apply cleanIMContent with the appropriate FileService.
-	return answer, nil
+	return answer, references, nil
 }
 
 // ── CRUD operations for IM channels ──

--- a/internal/types/datasource.go
+++ b/internal/types/datasource.go
@@ -309,6 +309,10 @@ type Resource struct {
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
+// MetadataKeySourceURL is the metadata key carrying the original source URL
+// into search results and persisted message references.
+const MetadataKeySourceURL = "source_url"
+
 // FetchedItem represents a single document/content item fetched from external source
 type FetchedItem struct {
 	// Unique ID in the external system


### PR DESCRIPTION
## Description

为飞书和 Lark IM 回复保留知识库原始来源 URL，并将回答中实际引用的知识库或 Web 来源渲染为可点击链接。普通回复保持 text 消息格式；带引用的回复使用 Markdown CardKit 卡片，同时过滤非 HTTP(S) 链接并去重。

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2170

## Testing

- 新增引用提取和 Markdown 格式化测试。
- 新增 Feishu/Lark interactive card payload 测试。
- gofmt、git diff --check 通过。
- 已尝试 go test ./internal/im -run Test(BuildReplyCitations|FormatReplyCitations) -count=1。
- Go 测试被仓库现有 internal/utils/inject.go 对 pg_query.Parse 和 pg_query.Deparse 的 CGo 绑定错误阻塞；当前 Windows 环境也没有可用 C 编译器。
- 未使用真实飞书/Lark 应用做端到端发送验证。

## Checklist

- [x] git diff --check origin/main...HEAD passes
- [x] Changed source files are formatted
- [ ] Targeted Go tests are blocked by the documented environment issue
- [ ] Diff-scoped lint was not run locally
- [ ] Full-repository checks were not run; environment limitation is documented above
- [x] Self-reviewed the code
- [x] Added tests covering the change
- [x] No breaking changes

## Screenshots / Recordings

未附截图；需要真实飞书/Lark 应用和消息流才能完成端到端展示验证。