### PR TITLE
feat(wiki): add manual ingest mode

### DIFF
--- a/docs/api/knowledge-base.md
+++ b/docs/api/knowledge-base.md
@@ -47,6 +47,7 @@
 | faq_config                    | object  | 否   | FAQ 配置（仅 FAQ 类型知识库需要）                               |
 | question_generation_config    | object  | 否   | 问题生成配置                                                    |
 | auto_tag_config               | object  | 否   | 文档自动标签配置，默认关闭；仅适用于 `document` 类型知识库      |
+| wiki_config                   | object  | 否   | Wiki 配置；`ingest_mode` 可设为 `auto`（默认）或 `manual`。手动模式保留 Wiki REST/API 读写，但上传文档不会触发内置 Wiki 自动生成 |
 | vector_store_id               | string  | 否   | 绑定的向量存储 ID。不传或为空字符串等同于 `null`（使用环境变量默认存储）。指定时必须是调用者所在空间拥有的向量存储 UUID；创建后不可修改。无效 UUID / 跨空间 / 未注册到引擎的 ID 会返回 `400` |
 
 **请求**:
@@ -298,6 +299,9 @@ curl --location 'http://localhost:8080/api/v1/knowledge-bases/kb-00000001' \
 | name        | string | 是   | 知识库名称                                                    |
 | description | string | 否   | 知识库描述                                                    |
 | config      | object | 否   | 更新配置；包含 `chunking_config` / `image_processing_config` / `faq_config` / `wiki_config` / `indexing_strategy` |
+
+其中 `config.wiki_config.ingest_mode` 支持 `auto`（默认，上传文档后自动生成 Wiki）和
+`manual`（允许通过 Wiki REST/API 读写页面，但不触发内置文档自动入库）。省略该字段或传入未知值时按 `auto` 处理。
 
 **请求**:
 

--- a/frontend/src/api/knowledge-base/index.ts
+++ b/frontend/src/api/knowledge-base/index.ts
@@ -112,6 +112,7 @@ export function createKnowledgeBase(data: {
   extract_config?: any;
   faq_config?: { index_mode: string; question_index_mode?: string };
   wiki_config?: {
+    ingest_mode?: 'auto' | 'manual';
     synthesis_model_id?: string;
     max_pages_per_ingest?: number;
     extraction_granularity?: 'focused' | 'standard' | 'exhaustive';
@@ -144,6 +145,7 @@ export function updateKnowledgeBase(id: string, data: {
     image_processing_config?: any;
     faq_config?: any;
     wiki_config?: {
+      ingest_mode?: 'auto' | 'manual';
       synthesis_model_id?: string;
       max_pages_per_ingest?: number;
       extraction_granularity?: 'focused' | 'standard' | 'exhaustive';

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2762,6 +2762,10 @@ export default {
     },
     wiki: {
       title: 'Wiki Settings',
+      ingestModeLabel: 'Wiki Ingest Mode',
+      ingestModeTip: 'Manual mode keeps Wiki REST/API read and write operations available but does not generate pages when documents are uploaded.',
+      ingestModeAuto: 'Automatic',
+      ingestModeManual: 'Manual',
       synthesisModelLabel: 'Wiki Synthesis Model',
       synthesisModelPlaceholder: 'Select the LLM model for Wiki generation',
       synthesisModelTip: 'Falls back to the summary model if not set',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -3878,6 +3878,10 @@ export default {
     },
     wiki: {
       title: 'Wiki 설정',
+      ingestModeLabel: 'Wiki 수집 모드',
+      ingestModeTip: '수동 모드는 Wiki REST/API 읽기 및 쓰기를 유지하지만 문서 업로드 시 페이지를 자동 생성하지 않습니다.',
+      ingestModeAuto: '자동',
+      ingestModeManual: '수동',
       synthesisModelLabel: '합성 모델',
       synthesisModelPlaceholder: 'Wiki 생성에 사용할 LLM 모델을 선택하세요',
       synthesisModelTip: '설정하지 않으면 요약 모델로 대체됩니다',

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -3878,6 +3878,10 @@ export default {
     },
     wiki: {
       title: 'Wiki настройки',
+      ingestModeLabel: 'Режим загрузки Wiki',
+      ingestModeTip: 'Ручной режим сохраняет операции чтения и записи через REST/API Wiki, но не создаёт страницы автоматически при загрузке документов.',
+      ingestModeAuto: 'Автоматический',
+      ingestModeManual: 'Ручной',
       synthesisModelLabel: 'Модель синтеза',
       synthesisModelPlaceholder: 'Выберите LLM модель для генерации Wiki',
       synthesisModelTip: 'Если не указано, используется модель суммаризации',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -3880,6 +3880,10 @@ export default {
     },
     wiki: {
       title: 'Wiki 设置',
+      ingestModeLabel: 'Wiki 入库模式',
+      ingestModeTip: '手动模式保留 Wiki REST/API 的读写能力，但上传文档时不会自动生成 Wiki 页面。',
+      ingestModeAuto: '自动',
+      ingestModeManual: '手动',
       synthesisModelLabel: 'Wiki 合成模型',
       synthesisModelPlaceholder: '选择用于 Wiki 生成的 LLM 模型',
       synthesisModelTip: '不设置时将回退使用摘要模型',

--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.test.mjs
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.test.mjs
@@ -30,3 +30,9 @@ test('shows a post-create hint after the first successful save', () => {
   assert.match(source, /settings-footer-note/)
   assert.match(source, /knowledgeEditor\.postCreateHint\.followUpDesc/)
 })
+
+test('persists Wiki manual ingest mode without disabling the Wiki API', () => {
+  assert.match(source, /v-model="formData\.wikiConfig\.ingestMode"/)
+  assert.match(source, /value="manual"/)
+  assert.match(source, /ingest_mode: formData\.value\.wikiConfig(?:\?\.|\.)ingestMode === 'manual' \? 'manual' : 'auto'/)
+})

--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
@@ -113,6 +113,22 @@
                         </p>
                       </div>
 
+                      <div v-if="!isFAQ && formData.indexingStrategy.wikiEnabled" class="form-item">
+                        <label class="form-label">{{ $t('knowledgeEditor.wiki.ingestModeLabel') }}</label>
+                        <p class="form-tip">{{ $t('knowledgeEditor.wiki.ingestModeTip') }}</p>
+                        <t-radio-group
+                          v-model="formData.wikiConfig.ingestMode"
+                          class="granularity-radio-group"
+                        >
+                          <t-radio-button value="auto">
+                            {{ $t('knowledgeEditor.wiki.ingestModeAuto') }}
+                          </t-radio-button>
+                          <t-radio-button value="manual">
+                            {{ $t('knowledgeEditor.wiki.ingestModeManual') }}
+                          </t-radio-button>
+                        </t-radio-group>
+                      </div>
+
                       <!-- Wiki 提取粒度 (仅当 Wiki 启用时显示) -->
                       <div v-if="!isFAQ && formData.indexingStrategy.wikiEnabled" class="form-item">
                         <label class="form-label">{{ $t('knowledgeEditor.wiki.extractionGranularityLabel') }}</label>
@@ -778,6 +794,7 @@ const initFormData = (type: 'document' | 'faq' = 'document') => {
       skipIfTagged: true
     },
     wikiConfig: {
+      ingestMode: 'auto' as 'auto' | 'manual',
       synthesisModelId: '',
       maxPagesPerIngest: 0,
       extractionGranularity: 'standard' as 'focused' | 'standard' | 'exhaustive',
@@ -906,6 +923,7 @@ const loadKBData = async (kbIdOverride?: string) => {
         skipIfTagged: kb.auto_tag_config?.skip_if_tagged ?? true
       },
       wikiConfig: {
+        ingestMode: kb.wiki_config?.ingest_mode === 'manual' ? 'manual' : 'auto',
         synthesisModelId: kb.wiki_config?.synthesis_model_id || '',
         maxPagesPerIngest: kb.wiki_config?.max_pages_per_ingest || 0,
         extractionGranularity: (
@@ -1277,6 +1295,7 @@ const buildSubmitData = () => {
   // wiki_config only holds wiki-specific tunables.
   if (formData.value.type !== 'faq') {
     data.wiki_config = {
+      ingest_mode: formData.value.wikiConfig?.ingestMode === 'manual' ? 'manual' : 'auto',
       synthesis_model_id: formData.value.modelConfig?.wikiSynthesisModelId || '',
       max_pages_per_ingest: formData.value.wikiConfig?.maxPagesPerIngest || 0,
       extraction_granularity: formData.value.wikiConfig?.extractionGranularity || 'standard',
@@ -1382,6 +1401,7 @@ const doSubmit = async () => {
       }
       if (formData.value.wikiConfig && formData.value.type !== 'faq') {
         updateConfig.wiki_config = {
+          ingest_mode: formData.value.wikiConfig.ingestMode === 'manual' ? 'manual' : 'auto',
           synthesis_model_id: formData.value.modelConfig?.wikiSynthesisModelId || '',
           max_pages_per_ingest: formData.value.wikiConfig.maxPagesPerIngest || 0,
           extraction_granularity: formData.value.wikiConfig.extractionGranularity || 'standard',

--- a/internal/application/service/knowledge_clone_move.go
+++ b/internal/application/service/knowledge_clone_move.go
@@ -1217,7 +1217,7 @@ func (s *knowledgeService) moveOneKnowledge(
 		// reparse re-ingests through KnowledgePostProcess once the new chunks
 		// land; reuse_vectors keeps the existing chunks and never re-enters that
 		// pipeline, so the target KB has to be told about the document here.
-		if targetKB.IsWikiEnabled() {
+		if targetKB.IsWikiAutoIngestEnabled() {
 			EnqueueWikiIngest(ctx, s.task, s.taskPendingRepo, tenantID, targetKB.ID, knowledge.ID)
 		}
 		return nil

--- a/internal/application/service/knowledge_post_process.go
+++ b/internal/application/service/knowledge_post_process.go
@@ -164,7 +164,7 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 	//    on its terminal exit; the row promotes itself to "completed" when
 	//    the counter hits zero (see knowledgeRepository.FinalizeSubtask).
 	//
-	//    Wiki ingest IS counted (as a single subtask): although it's a
+	//    Automatic Wiki ingest IS counted (as a single subtask): although it's a
 	//    KB-scoped debounced batch, each upload enqueues exactly one
 	//    per-knowledge op, and the batch worker calls FinalizeSubtask once
 	//    when that op reaches a terminal state (mapped successfully or
@@ -176,7 +176,7 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 	willSpawnSummary := len(textChunks) > 0
 	willSpawnQuestion := willSpawnSummary && kb.NeedsEmbeddingModel() &&
 		eff.QuestionGenerationConfig.Enabled
-	willSpawnWiki := kb.IndexingStrategy.WikiEnabled && len(textChunks) > 0
+	willSpawnWiki := kb.IsWikiAutoIngestEnabled() && len(textChunks) > 0
 	willSpawnAutoTag := kb.Type == types.KnowledgeBaseTypeDocument &&
 		kb.AutoTagConfig != nil && kb.AutoTagConfig.Enabled && len(textChunks) > 0
 	enqueuedAutoTag := false
@@ -221,13 +221,14 @@ func (s *KnowledgePostProcessService) Handle(ctx context.Context, task *asynq.Ta
 	expectedSubtasks += graphChunkCount
 
 	// enteredFinalizing is set only when the processing-to-finalizing handoff
-	// actually seeded the counter. For Wiki-enabled knowledge, that handoff
+	// actually seeded the counter. For knowledge with automatic Wiki ingest
+	// enabled, that handoff
 	// also persists the pending Wiki op in the same transaction.
 	enteredFinalizing := false
 	wikiSlotOwned := false
 
 	switch {
-	case knowledge.ParseStatus == types.ParseStatusFinalizing && kb.IndexingStrategy.WikiEnabled:
+	case knowledge.ParseStatus == types.ParseStatusFinalizing && kb.IsWikiAutoIngestEnabled():
 		// A previous delivery may have persisted the Wiki op but failed to
 		// enqueue its KB-scoped trigger. Retry only the trigger: appending a
 		// second pending op would duplicate durable work and its finalizer.

--- a/internal/application/service/knowledge_post_process_wiki_enqueue_test.go
+++ b/internal/application/service/knowledge_post_process_wiki_enqueue_test.go
@@ -194,6 +194,24 @@ func TestKnowledgePostProcessAtomicallySeedsWikiSlot(t *testing.T) {
 	}
 }
 
+func TestKnowledgePostProcessManualWikiModeSkipsBuiltInIngest(t *testing.T) {
+	const knowledgeID = "knowledge-wiki-manual"
+	pendingRepo := &wikiEnqueueFailurePendingRepo{}
+	queue := &wikiEnqueueFailureTaskQueue{}
+	service, repo := newWikiEnqueueTestService(knowledgeID, pendingRepo, queue)
+	kbService := service.kbService.(*wikiEnqueueFailureKBService)
+	kbService.kb.WikiConfig = &types.WikiConfig{IngestMode: types.WikiIngestModeManual}
+
+	err := service.Handle(context.Background(), newWikiEnqueuePostProcessTask(t, knowledgeID))
+
+	require.NoError(t, err)
+	assert.Equal(t, types.ParseStatusFinalizing, repo.knowledge.ParseStatus)
+	assert.Equal(t, 1, repo.expectedSubtasks, "only the summary task should be counted")
+	assert.Equal(t, []string{types.TypeSummaryGeneration}, queue.taskTypes)
+	assert.Equal(t, 0, pendingRepo.seedCalls, "manual mode must not persist a wiki pending op")
+	assert.Nil(t, pendingRepo.seededOp)
+}
+
 func TestKnowledgePostProcessRetriesWikiTriggerWithoutDoubleAccounting(t *testing.T) {
 	const knowledgeID = "knowledge-wiki-trigger-retry"
 	wikiErr := errors.New("redis unavailable")

--- a/internal/types/knowledgebase.go
+++ b/internal/types/knowledgebase.go
@@ -788,6 +788,13 @@ func (kb *KnowledgeBase) IsWikiEnabled() bool {
 	return kb.IndexingStrategy.WikiEnabled
 }
 
+// IsWikiAutoIngestEnabled reports whether the built-in document-to-wiki
+// pipeline should run for this knowledge base. WikiEnabled remains the
+// feature/API gate; WikiConfig.IngestMode only controls automatic generation.
+func (kb *KnowledgeBase) IsWikiAutoIngestEnabled() bool {
+	return kb != nil && kb.IsWikiEnabled() && kb.WikiConfig.IsAutoIngestEnabled()
+}
+
 // IsVectorEnabled checks if vector (semantic) search is enabled.
 func (kb *KnowledgeBase) IsVectorEnabled() bool {
 	return kb != nil && kb.IndexingStrategy.VectorEnabled

--- a/internal/types/wiki_page.go
+++ b/internal/types/wiki_page.go
@@ -493,11 +493,37 @@ func (g WikiExtractionGranularity) Normalize() WikiExtractionGranularity {
 	return WikiExtractionStandard
 }
 
+// WikiIngestMode controls whether uploaded documents are automatically turned
+// into wiki pages. Manual mode keeps the wiki REST/API surface available while
+// leaving page creation to an external publisher.
+type WikiIngestMode string
+
+const (
+	// WikiIngestModeAuto preserves the legacy behavior: completed documents
+	// enqueue the built-in wiki generation pipeline.
+	WikiIngestModeAuto WikiIngestMode = "auto"
+	// WikiIngestModeManual disables only the built-in document-to-wiki enqueue.
+	WikiIngestModeManual WikiIngestMode = "manual"
+)
+
+// Normalize returns a supported mode. Empty and unknown values intentionally
+// fall back to auto so old rows and forward-incompatible configurations remain
+// backwards compatible.
+func (m WikiIngestMode) Normalize() WikiIngestMode {
+	if m == WikiIngestModeManual {
+		return WikiIngestModeManual
+	}
+	return WikiIngestModeAuto
+}
+
 // WikiConfig stores wiki-specific configuration for a knowledge base.
 // Applicable to document-type knowledge bases with wiki feature enabled.
 // Whether the wiki feature is turned on is controlled by IndexingStrategy.WikiEnabled;
-// this struct only carries wiki-specific tunables.
+// this struct carries wiki-specific tunables and the automatic ingest mode.
 type WikiConfig struct {
+	// IngestMode controls whether document processing automatically enqueues
+	// built-in wiki generation. Empty values retain the legacy auto behavior.
+	IngestMode WikiIngestMode `yaml:"ingest_mode,omitempty" json:"ingest_mode,omitempty"`
 	// SynthesisModelID is the LLM model ID used for wiki page generation and updates
 	SynthesisModelID string `yaml:"synthesis_model_id" json:"synthesis_model_id"`
 	// MaxPagesPerIngest limits pages created/updated per ingest operation (0 = no limit)
@@ -549,6 +575,13 @@ type WikiConfig struct {
 	// this knob trades a single KB's peak throughput for cross-KB fairness.
 	// Set it >= the wiki pool size to effectively disable the cap.
 	IngestMaxInflight int `yaml:"ingest_max_inflight" json:"ingest_max_inflight,omitempty"`
+}
+
+// IsAutoIngestEnabled reports whether the built-in document-to-wiki pipeline
+// may be scheduled. A nil config and an empty mode both preserve legacy auto
+// ingest behavior.
+func (c *WikiConfig) IsAutoIngestEnabled() bool {
+	return c == nil || c.IngestMode.Normalize() == WikiIngestModeAuto
 }
 
 // IngestBatchSizeOrDefault returns IngestBatchSize when set (> 0),

--- a/internal/types/wiki_page_test.go
+++ b/internal/types/wiki_page_test.go
@@ -65,6 +65,63 @@ func TestWikiConfigScanNil(t *testing.T) {
 	}
 }
 
+func TestWikiIngestModeDefaultsToAuto(t *testing.T) {
+	cases := []struct {
+		name string
+		mode WikiIngestMode
+		want WikiIngestMode
+	}{
+		{name: "empty", mode: "", want: WikiIngestModeAuto},
+		{name: "auto", mode: WikiIngestModeAuto, want: WikiIngestModeAuto},
+		{name: "manual", mode: WikiIngestModeManual, want: WikiIngestModeManual},
+		{name: "unknown", mode: "future", want: WikiIngestModeAuto},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.mode.Normalize(); got != tc.want {
+				t.Fatalf("WikiIngestMode(%q).Normalize() = %q, want %q", tc.mode, got, tc.want)
+			}
+		})
+	}
+
+	if !(*WikiConfig)(nil).IsAutoIngestEnabled() {
+		t.Fatal("nil WikiConfig must preserve automatic ingest")
+	}
+	if !(&WikiConfig{}).IsAutoIngestEnabled() {
+		t.Fatal("empty WikiConfig must preserve automatic ingest")
+	}
+	if (&WikiConfig{IngestMode: WikiIngestModeManual}).IsAutoIngestEnabled() {
+		t.Fatal("manual WikiConfig must disable automatic ingest")
+	}
+}
+
+func TestKnowledgeBaseWikiAutoIngestGate(t *testing.T) {
+	cases := []struct {
+		name   string
+		wiki   bool
+		config *WikiConfig
+		want   bool
+	}{
+		{name: "wiki disabled", wiki: false, config: &WikiConfig{}, want: false},
+		{name: "legacy config", wiki: true, config: nil, want: true},
+		{name: "default mode", wiki: true, config: &WikiConfig{}, want: true},
+		{name: "manual mode", wiki: true, config: &WikiConfig{IngestMode: WikiIngestModeManual}, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kb := &KnowledgeBase{
+				IndexingStrategy: IndexingStrategy{WikiEnabled: tc.wiki},
+				WikiConfig:       tc.config,
+			}
+			if got := kb.IsWikiAutoIngestEnabled(); got != tc.want {
+				t.Fatalf("IsWikiAutoIngestEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestStringArrayValueScan(t *testing.T) {
 	arr := StringArray{"a", "b", "c"}
 
@@ -278,6 +335,7 @@ func TestWikiExtractionGranularity_Normalize(t *testing.T) {
 
 func TestWikiConfig_JSONRoundTrip_WithGranularity(t *testing.T) {
 	original := WikiConfig{
+		IngestMode:            WikiIngestModeManual,
 		SynthesisModelID:      "m-1",
 		MaxPagesPerIngest:     20,
 		ExtractionGranularity: WikiExtractionFocused,
@@ -292,6 +350,9 @@ func TestWikiConfig_JSONRoundTrip_WithGranularity(t *testing.T) {
 	}
 	if restored.ExtractionGranularity != WikiExtractionFocused {
 		t.Errorf("granularity round-trip failed: got %q", restored.ExtractionGranularity)
+	}
+	if restored.IngestMode != WikiIngestModeManual {
+		t.Errorf("ingest mode round-trip failed: got %q", restored.IngestMode)
 	}
 
 	// Legacy row without the granularity field. We also include the removed


### PR DESCRIPTION
## Description

为 Wiki 配置新增 ingest_mode：auto（默认）和 manual。manual 模式保留 Wiki REST/API 的读写、搜索和服务能力，只跳过文档处理完成后的内置自动入库，方便外部系统通过 API 管理 Wiki 内容；旧配置继续保持 auto 行为。

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2327

## Testing

- Node 回归测试：Wiki manual ingest mode 5/5 通过。
- vue-tsc --noEmit --pretty false 通过。
- 新增 Wiki 配置默认值、JSON round-trip 和手动模式服务行为测试。
- gofmt、git diff --check 通过。
- 已尝试 go test ./internal/types -run Test(WikiIngestMode|KnowledgeBaseWikiAutoIngest|WikiConfig_JSONRoundTrip) -count=1。
- Go 测试被仓库现有 internal/utils/inject.go 对 pg_query.Parse 和 pg_query.Deparse 的 CGo 绑定错误阻塞；当前 Windows 环境也没有可用 C 编译器。

## Checklist

- [x] git diff --check origin/main...HEAD passes
- [x] Changed source files are formatted
- [ ] Targeted Go tests are blocked by the documented environment issue
- [ ] Diff-scoped lint was not run locally
- [ ] Full-repository checks were not run; environment limitation is documented above
- [x] Self-reviewed the code
- [x] Added tests covering the change
- [x] Updated related documentation and i18n
- [x] No breaking changes

## Screenshots / Recordings

未附截图；当前环境未启动完整前后端，配置界面由类型检查和静态回归测试覆盖。