### PR TITLE
fix(skills): resolve sibling-package imports through ancestor script …

### DIFF
--- a/internal/application/service/tenant_skill_verify.py
+++ b/internal/application/service/tenant_skill_verify.py
@@ -85,11 +85,27 @@ def is_importable(name, script_dir):
     is reported without the side effects of loading a present one. script_dir
     leads the path because that is where the interpreter puts the directory of
     the script it was handed, which is how sibling modules resolve at runtime.
+
+    A file is rarely the entry point, though. Python puts the executed
+    script's directory on sys.path, and every module reached through the
+    import graph from there resolves against that same entry — so a module
+    several levels down can legitimately import a package that sits beside
+    its own directory, whenever some entry script above it runs first. The
+    module's own directory cannot see that neighbour, so each ancestor of
+    the checked file up to the skill root gets the same chance to resolve
+    a name that the script's own directory gets; a name that none of them
+    can resolve is still reported as missing.
     """
     if name in own_modules:
         return True
+    candidates = [script_dir]
+    parent = os.path.dirname(script_dir)
+    while under_root(parent) and parent not in candidates:
+        candidates.append(parent)
+        parent = os.path.dirname(parent)
     saved = sys.path[:]
-    sys.path.insert(0, script_dir)
+    for candidate in reversed(candidates):
+        sys.path.insert(0, candidate)
     try:
         return importlib.util.find_spec(name) is not None
     except Exception:

--- a/internal/application/service/tenant_skill_verify_python_test.go
+++ b/internal/application/service/tenant_skill_verify_python_test.go
@@ -52,6 +52,32 @@ func TestSkillPythonVerifier(t *testing.T) {
 			"scripts/README.txt": "not python\n",
 		},
 	}, {
+		// The shape that failed a real install of Anthropic's xlsx skill:
+		// the entry point lives in scripts/ecmadoc/, so when it runs, its
+		// directory is on sys.path for the whole import graph. The auditors
+		// subpackage it imports reaches for the sibling partkit package
+		// through exactly that path entry. A check that only sees the
+		// auditors directory cannot resolve it and rejected a working skill.
+		name: "a subpackage module importing a sibling package of an ancestor directory",
+		files: map[string]string{
+			"scripts/ecmadoc/partkit/__init__.py":  "def helper():\n    return 1\n",
+			"scripts/ecmadoc/auditors/__init__.py": "from .deck_auditor import audit\n",
+			"scripts/ecmadoc/auditors/deck_auditor.py": "from partkit import helper\n\n" +
+				"def audit():\n    return helper()\n",
+			"scripts/ecmadoc/doc_audit.py": "from auditors import audit\n",
+		},
+	}, {
+		// The ancestor walk must not reach sideways: a module vendored under
+		// a child directory of an ancestor is not on any entry point's path,
+		// so it is still a dependency the installer has to provide.
+		name: "a nested vendored module is still a missing dependency",
+		files: map[string]string{
+			"scripts/run.py":                        "import vendored_absent_pkg\n",
+			"scripts/vendor/vendored_absent_pkg.py": "x = 1\n",
+		},
+		wantProblem: "scripts/run.py imports vendored_absent_pkg, " +
+			"which is not available in this image",
+	}, {
 		name: "an optional dependency behind try/except",
 		files: map[string]string{
 			"scripts/run.py": "try:\n    import matplotlib\nexcept ImportError:\n" +


### PR DESCRIPTION
…dirs

The python verifier judges each file with only its own directory on sys.path, which is right for entry scripts but wrong for modules that are only ever imported by one: a real install of the xlsx skill was rejected because scripts/ecmadoc/auditors/*.py import the partkit package that sits beside auditors/ under scripts/ecmadoc/, the directory the entry script doc_audit.py puts on sys.path when it runs. The import graph inherits that path entry at runtime, so the install was sound and the check a false positive.

Give every ancestor of the checked file up to the skill root the same chance to resolve a name that the file's own directory gets. The walk only follows the file's lineage, so a module vendored under a child of an ancestor (scripts/vendor/requests.py) is still reported missing.

<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

## Type of Change
<!-- Check applicable items -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->

## Checklist
- [ ] `git diff --check origin/main...HEAD` passes
- [ ] Changed source files are formatted
- [ ] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [ ] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
