### PR TITLE
fix(parser): default ppt/pptx to markitdown when no engine rules

### DIFF
--- a/docreader/parser/registry.py
+++ b/docreader/parser/registry.py
@@ -22,13 +22,22 @@ logger = logging.getLogger(__name__)
 
 BUILTIN_ENGINE = "builtin"
 
+# File types that builtin does not implement natively. When the requested
+# engine (including empty / builtin) cannot parse them, route to this engine
+# instead of raising ValueError — PPT/PPTX/CSV are markitdown-only.
+_DEFAULT_ENGINE_BY_TYPE = {
+    "ppt": "markitdown",
+    "pptx": "markitdown",
+    "csv": "markitdown",
+}
+
 
 class ParserEngineRegistry:
     """Registry for parser engines.
 
     Each engine maps file extensions to parser classes.
     When a requested engine doesn't support a file type, the registry
-    falls back to the builtin engine automatically.
+    tries a type-level default engine, then builtin.
     """
 
     def __init__(self):
@@ -59,10 +68,12 @@ class ParserEngineRegistry:
     def get_parser_class(self, engine: str, file_type: str) -> Type[BaseParser]:
         """Resolve parser class for the given engine and file type.
 
-        Falls back to builtin engine when the requested engine doesn't
-        support the file type.
+        Fallback order when the requested engine is empty or does not
+        support the type: type-level default (e.g. ppt → markitdown),
+        then builtin. Raises an actionable error listing engines that
+        do support the type.
         """
-        ft = file_type.lower()
+        ft = file_type.lower().lstrip(".")
 
         if engine and engine in self._engines:
             cls = self._engines[engine].get(ft)
@@ -70,16 +81,36 @@ class ParserEngineRegistry:
                 logger.info("Using engine '%s' for file type '%s'", engine, ft)
                 return cls
             logger.info(
-                "Engine '%s' does not support '%s', falling back to builtin",
+                "Engine '%s' does not support '%s', falling back",
                 engine,
                 ft,
             )
+
+        default_engine = _DEFAULT_ENGINE_BY_TYPE.get(ft)
+        if default_engine:
+            cls = self._engines.get(default_engine, {}).get(ft)
+            if cls:
+                logger.info(
+                    "Using default engine '%s' for file type '%s'",
+                    default_engine,
+                    ft,
+                )
+                return cls
 
         builtin = self._engines.get(BUILTIN_ENGINE, {})
         cls = builtin.get(ft)
         if cls:
             return cls
 
+        supported = sorted(
+            name for name, parsers in self._engines.items() if ft in parsers
+        )
+        engine_label = engine or BUILTIN_ENGINE
+        if supported:
+            raise ValueError(
+                f"Unsupported file type {file_type!r} for engine {engine_label!r}. "
+                f"Configure one of: {', '.join(supported)}"
+            )
         raise ValueError(f"Unsupported file type: {file_type}")
 
     def list_engines(self, overrides: Optional[Dict[str, str]] = None) -> List[Dict]:

--- a/docreader/tests/test_parser_routing.py
+++ b/docreader/tests/test_parser_routing.py
@@ -3,7 +3,9 @@ import unittest
 from docreader.models.document import Document
 from docreader.parser.base_parser import BaseParser
 from docreader.parser.parser import Parser, detect_effective_file_type
-from docreader.parser.registry import BUILTIN_ENGINE, registry
+from docreader.parser.markitdown_parser import MarkitdownParser
+from docreader.parser.pdf_parser import PDFParser
+from docreader.parser.registry import BUILTIN_ENGINE, ParserEngineRegistry, registry
 from docreader.parser.xmind_parser import XMindParser
 
 
@@ -59,6 +61,44 @@ class ParserRoutingTest(unittest.TestCase):
 
     def test_unrelated_ole_type_is_not_reclassified(self):
         self.assertEqual("xls", detect_effective_file_type("xls", OLE_MAGIC))
+
+    def test_empty_engine_routes_pptx_to_markitdown(self):
+        self.assertIs(registry.get_parser_class("", "pptx"), MarkitdownParser)
+        self.assertIs(registry.get_parser_class("", "ppt"), MarkitdownParser)
+        self.assertIs(registry.get_parser_class("", ".PPTX"), MarkitdownParser)
+
+    def test_builtin_engine_still_parses_pptx(self):
+        self.assertIs(registry.get_parser_class(BUILTIN_ENGINE, "pptx"), MarkitdownParser)
+
+    def test_type_default_when_builtin_lacks_pptx(self):
+        isolated = ParserEngineRegistry()
+        isolated.register(BUILTIN_ENGINE, {"pdf": PDFParser})
+        isolated.register(
+            "markitdown",
+            {"pptx": MarkitdownParser, "ppt": MarkitdownParser, "csv": MarkitdownParser},
+        )
+
+        self.assertIs(isolated.get_parser_class("", "pptx"), MarkitdownParser)
+        self.assertIs(isolated.get_parser_class(BUILTIN_ENGINE, "pptx"), MarkitdownParser)
+        self.assertIs(isolated.get_parser_class("", "csv"), MarkitdownParser)
+        self.assertIs(isolated.get_parser_class(BUILTIN_ENGINE, "csv"), MarkitdownParser)
+        self.assertIs(isolated.get_parser_class(BUILTIN_ENGINE, "pdf"), PDFParser)
+        self.assertIs(isolated.get_parser_class("", "pdf"), PDFParser)
+
+        with self.assertRaises(ValueError) as ctx:
+            isolated.get_parser_class("", "xyz")
+        self.assertIn("Unsupported file type: xyz", str(ctx.exception))
+
+    def test_actionable_error_lists_supporting_engines(self):
+        isolated = ParserEngineRegistry()
+        isolated.register(BUILTIN_ENGINE, {"pdf": PDFParser})
+        isolated.register("opendataloader", {"xmind": XMindParser})
+
+        with self.assertRaises(ValueError) as ctx:
+            isolated.get_parser_class(BUILTIN_ENGINE, "xmind")
+        message = str(ctx.exception)
+        self.assertIn("Configure one of:", message)
+        self.assertIn("opendataloader", message)
 
 
 if __name__ == "__main__":

--- a/frontend/src/views/knowledge/settings/KBParserSettings.vue
+++ b/frontend/src/views/knowledge/settings/KBParserSettings.vue
@@ -199,7 +199,7 @@ function getEngineOptions(extensions: string[]): EngineOption[] {
       })
     }
   }
-  const defaultName = raw.find(e => e.available)?.name ?? ''
+  const defaultName = pickDefaultEngineName(raw, extensions)
   return raw
     .filter(e => e.available)
     .map(e => ({
@@ -207,6 +207,19 @@ function getEngineOptions(extensions: string[]): EngineOption[] {
       selectLabel: buildOptionLabel(e.name, defaultName !== '' && e.name === defaultName),
       isDefault: defaultName !== '' && e.name === defaultName,
     }))
+}
+
+function pickDefaultEngineName(
+  engines: { name: string; available: boolean }[],
+  extensions: string[],
+): string {
+  const available = engines.filter(e => e.available)
+  const prefersAnydoc = extensions.some(ext => ext === 'ppt' || ext === 'pptx')
+  if (prefersAnydoc) {
+    const anydoc = available.find(e => e.name === 'anydoc')
+    if (anydoc) return anydoc.name
+  }
+  return available[0]?.name ?? ''
 }
 
 function hasAvailableEngine(extensions: string[]): boolean {

--- a/frontend/src/views/knowledge/settings/KBParserSettings.vue
+++ b/frontend/src/views/knowledge/settings/KBParserSettings.vue
@@ -214,8 +214,9 @@ function pickDefaultEngineName(
   extensions: string[],
 ): string {
   const available = engines.filter(e => e.available)
-  const prefersAnydoc = extensions.some(ext => ext === 'ppt' || ext === 'pptx')
-  if (prefersAnydoc) {
+  const simpleExts = new Set(['md', 'markdown', 'txt', 'csv', 'json'])
+  const allSimple = extensions.length > 0 && extensions.every(ext => simpleExts.has(ext))
+  if (!allSimple) {
     const anydoc = available.find(e => e.name === 'anydoc')
     if (anydoc) return anydoc.name
   }

--- a/internal/infrastructure/docparser/engine_registry_reader_test.go
+++ b/internal/infrastructure/docparser/engine_registry_reader_test.go
@@ -30,6 +30,7 @@ func TestNewReaderRoutesByEngine(t *testing.T) {
 		{name: "builtin engine goes remote", engine: BuiltinEngineName, fileType: "md", want: remote},
 		{name: "unset engine handles simple formats in Go", fileType: "csv", want: &SimpleFormatReader{}},
 		{name: "unset engine sends complex formats to docreader", fileType: "docx", want: remote},
+		{name: "default pptx engine is remote markitdown", engine: "markitdown", fileType: "pptx", want: remote},
 		{name: "URLs always go to docreader", fileType: "md", isURL: true, want: remote},
 		{name: "docreader-only engines fall through", engine: "markitdown", fileType: "docx", want: remote},
 	}

--- a/internal/infrastructure/docparser/engine_registry_test.go
+++ b/internal/infrastructure/docparser/engine_registry_test.go
@@ -33,20 +33,25 @@ func TestListAllEnginesBuiltinIncludesDocumentFormats(t *testing.T) {
 }
 
 func TestDefaultParserEnginePrefersAnydocWhenLinked(t *testing.T) {
-	if types.DefaultParserEngine("pdf") != "" {
-		t.Fatalf("DefaultParserEngine(pdf) should stay empty so builtin routing is unchanged")
-	}
-	got := types.DefaultParserEngine("pptx")
+	cases := []string{"pptx", "ppt", "pdf", "docx"}
 	if anydoc.Available() {
-		if got != AnydocEngineName {
-			t.Fatalf("DefaultParserEngine(pptx) = %q, want anydoc when the binding is linked", got)
+		for _, ft := range cases {
+			if got := types.DefaultParserEngine(ft); got != AnydocEngineName {
+				t.Errorf("DefaultParserEngine(%s) = %q, want anydoc when the binding is linked", ft, got)
+			}
 		}
-		if types.DefaultParserEngine("ppt") != AnydocEngineName {
-			t.Fatalf("DefaultParserEngine(ppt) = %q, want anydoc", types.DefaultParserEngine("ppt"))
+		if got := types.DefaultParserEngine("csv"); got != "" {
+			t.Errorf("DefaultParserEngine(csv) = %q, want empty so the Go simple reader stays default", got)
 		}
 		return
 	}
-	if got != "markitdown" {
+	if got := types.DefaultParserEngine("pptx"); got != "markitdown" {
 		t.Fatalf("DefaultParserEngine(pptx) = %q, want markitdown when anydoc is unavailable", got)
+	}
+	if got := types.DefaultParserEngine("pdf"); got != "" {
+		t.Fatalf("DefaultParserEngine(pdf) = %q, want empty when anydoc is unavailable", got)
+	}
+	if got := types.DefaultParserEngine("docx"); got != "" {
+		t.Fatalf("DefaultParserEngine(docx) = %q, want empty when anydoc is unavailable", got)
 	}
 }

--- a/internal/infrastructure/docparser/engine_registry_test.go
+++ b/internal/infrastructure/docparser/engine_registry_test.go
@@ -1,6 +1,11 @@
 package docparser
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/infrastructure/docparser/anydoc"
+	"github.com/Tencent/WeKnora/internal/types"
+)
 
 func TestListAllEnginesBuiltinIncludesDocumentFormats(t *testing.T) {
 	engines := ListAllEngines(true, nil, nil)
@@ -25,4 +30,23 @@ func TestListAllEnginesBuiltinIncludesDocumentFormats(t *testing.T) {
 	}
 
 	t.Fatal("builtin engine not found")
+}
+
+func TestDefaultParserEnginePrefersAnydocWhenLinked(t *testing.T) {
+	if types.DefaultParserEngine("pdf") != "" {
+		t.Fatalf("DefaultParserEngine(pdf) should stay empty so builtin routing is unchanged")
+	}
+	got := types.DefaultParserEngine("pptx")
+	if anydoc.Available() {
+		if got != AnydocEngineName {
+			t.Fatalf("DefaultParserEngine(pptx) = %q, want anydoc when the binding is linked", got)
+		}
+		if types.DefaultParserEngine("ppt") != AnydocEngineName {
+			t.Fatalf("DefaultParserEngine(ppt) = %q, want anydoc", types.DefaultParserEngine("ppt"))
+		}
+		return
+	}
+	if got != "markitdown" {
+		t.Fatalf("DefaultParserEngine(pptx) = %q, want markitdown when anydoc is unavailable", got)
+	}
 }

--- a/internal/infrastructure/docparser/engine_registry_test.go
+++ b/internal/infrastructure/docparser/engine_registry_test.go
@@ -16,7 +16,7 @@ func TestListAllEnginesBuiltinIncludesDocumentFormats(t *testing.T) {
 		for _, fileType := range engine.FileTypes {
 			fileTypes[fileType] = true
 		}
-		for _, want := range []string{"html", "htm", "xmind"} {
+		for _, want := range []string{"html", "htm", "xmind", "ppt", "pptx"} {
 			if !fileTypes[want] {
 				t.Errorf("builtin engine file types do not include %q: %v", want, engine.FileTypes)
 			}

--- a/internal/infrastructure/docparser/engines.go
+++ b/internal/infrastructure/docparser/engines.go
@@ -51,7 +51,8 @@ func (e *builtinEngine) Description() string { return "DocReader built-in parser
 
 func (e *builtinEngine) FileTypes(_ bool) []string {
 	return []string{
-		"docx", "doc", "pdf", "md", "markdown", "xlsx", "xls", "epub",
+		"docx", "doc", "pdf", "md", "markdown", "xlsx", "xls",
+		"pptx", "ppt", "epub",
 		"html", "htm", "mhtml", "xmind",
 		"jpg", "jpeg", "png", "gif", "bmp", "tiff", "webp",
 		"mp3", "wav", "m4a", "flac", "ogg",

--- a/internal/infrastructure/docparser/engines.go
+++ b/internal/infrastructure/docparser/engines.go
@@ -43,9 +43,11 @@ func init() {
 
 // preferAnydocWhenAvailable is the type-level default override: when the
 // anydoc binding is linked and converts this file type, use it instead of
-// the markitdown fallback. Types without a fallback (pdf, docx, …) never
-// consult this — DefaultParserEngine short-circuits first.
+// builtin or the markitdown fallback. Simple formats stay on the Go reader.
 func preferAnydocWhenAvailable(fileType string) string {
+	if IsSimpleFormat(fileType) {
+		return ""
+	}
 	if anydoc.Available() && anydoc.Supports(fileType, "") {
 		return AnydocEngineName
 	}

--- a/internal/infrastructure/docparser/engines.go
+++ b/internal/infrastructure/docparser/engines.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Tencent/WeKnora/internal/infrastructure/docparser/anydoc"
+	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 )
 
@@ -29,6 +30,7 @@ const (
 )
 
 func init() {
+	types.SetPreferParserEngine(preferAnydocWhenAvailable)
 	RegisterEngine(&builtinEngine{})
 	RegisterEngine(&simpleEngine{})
 	RegisterEngine(&anydocEngine{})
@@ -37,6 +39,17 @@ func init() {
 	RegisterEngine(&mineruCloudEngine{})
 	RegisterEngine(&paddleOCRVLEngine{})
 	RegisterEngine(&paddleOCRVLCloudEngine{})
+}
+
+// preferAnydocWhenAvailable is the type-level default override: when the
+// anydoc binding is linked and converts this file type, use it instead of
+// the markitdown fallback. Types without a fallback (pdf, docx, …) never
+// consult this — DefaultParserEngine short-circuits first.
+func preferAnydocWhenAvailable(fileType string) string {
+	if anydoc.Available() && anydoc.Supports(fileType, "") {
+		return AnydocEngineName
+	}
+	return ""
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/types/custom_agent.go
+++ b/internal/types/custom_agent.go
@@ -421,21 +421,20 @@ func oneOf(value string, allowed ...string) bool {
 }
 
 // ResolveChatParserEngine returns the agent-configured parser engine for a
-// chat attachment file type, or "" when no rule matches. Mirrors the tenant
-// resolver in ParserEngineConfig.ResolveChatParserEngine.
+// chat attachment file type, or the type-level default when no rule matches.
+// Mirrors ParserEngineConfig.ResolveChatParserEngine.
 func (c *CustomAgentConfig) ResolveChatParserEngine(fileType string) string {
-	if c == nil {
-		return ""
-	}
-	fileType = strings.TrimPrefix(strings.ToLower(strings.TrimSpace(fileType)), ".")
-	for _, rule := range c.ChatParserEngineRules {
-		for _, candidate := range rule.FileTypes {
-			if strings.TrimPrefix(strings.ToLower(strings.TrimSpace(candidate)), ".") == fileType {
-				return strings.TrimSpace(rule.Engine)
+	if c != nil {
+		normalized := normalizeParserFileType(fileType)
+		for _, rule := range c.ChatParserEngineRules {
+			for _, candidate := range rule.FileTypes {
+				if normalizeParserFileType(candidate) == normalized {
+					return strings.TrimSpace(rule.Engine)
+				}
 			}
 		}
 	}
-	return ""
+	return DefaultParserEngine(fileType)
 }
 
 // Value implements driver.Valuer interface for CustomAgentConfig

--- a/internal/types/custom_agent_test.go
+++ b/internal/types/custom_agent_test.go
@@ -8,7 +8,8 @@ func TestCustomAgentConfigResolveChatParserEngine(t *testing.T) {
 		{FileTypes: []string{"png", "jpg"}, Engine: "paddleocr_vl"},
 	}}
 	for input, expected := range map[string]string{
-		"PDF": "mineru", ".pptx": "mineru", "png": "paddleocr_vl", "txt": "",
+		"PDF": "mineru", ".pptx": "mineru", "png": "paddleocr_vl",
+		"txt": "", "ppt": "markitdown",
 	} {
 		if actual := config.ResolveChatParserEngine(input); actual != expected {
 			t.Fatalf("ResolveChatParserEngine(%q) = %q, want %q", input, actual, expected)
@@ -17,6 +18,9 @@ func TestCustomAgentConfigResolveChatParserEngine(t *testing.T) {
 	var nilConfig *CustomAgentConfig
 	if actual := nilConfig.ResolveChatParserEngine("pdf"); actual != "" {
 		t.Fatalf("nil config resolved %q", actual)
+	}
+	if actual := nilConfig.ResolveChatParserEngine("pptx"); actual != "markitdown" {
+		t.Fatalf("nil config pptx resolved %q, want markitdown", actual)
 	}
 }
 

--- a/internal/types/knowledgebase.go
+++ b/internal/types/knowledgebase.go
@@ -249,7 +249,8 @@ type ChunkingConfig struct {
 	// Separators
 	Separators []string `yaml:"separators"    json:"separators"`
 	// ParserEngineRules configures which parser engine to use for each file type.
-	// When empty, the builtin engine is used for all types.
+	// When empty, DefaultParserEngine is used (builtin/simple routing, except
+	// types that only a specific engine can parse, e.g. ppt/pptx → markitdown).
 	ParserEngineRules []ParserEngineRule `yaml:"parser_engine_rules,omitempty" json:"parser_engine_rules,omitempty"`
 	// EnableParentChild enables two-level parent-child chunking strategy.
 	// When enabled, large parent chunks provide context while small child chunks
@@ -278,14 +279,28 @@ type ChunkingConfig struct {
 	TableMetadataInstructions string `yaml:"table_metadata_instructions,omitempty" json:"table_metadata_instructions,omitempty"`
 }
 
+// defaultParserEngineByType maps file types the builtin/simple engines cannot
+// parse to the only engine that can. Types omitted here keep empty-string
+// routing (Go simple formats, otherwise docreader builtin).
+var defaultParserEngineByType = map[string]string{
+	"ppt":  "markitdown",
+	"pptx": "markitdown",
+}
+
+// DefaultParserEngine returns the engine used when no parser_engine_rules
+// match. Empty string means builtin (docreader) or Go simple-format routing.
+func DefaultParserEngine(fileType string) string {
+	return defaultParserEngineByType[normalizeParserFileType(fileType)]
+}
+
 // ResolveParserEngine returns the engine name for the given file type
-// based on the configured rules. Returns empty string (builtin) when
-// no rule matches.
+// based on the configured rules. When no rule matches it returns the
+// type-level default (see DefaultParserEngine).
 func (c ChunkingConfig) ResolveParserEngine(fileType string) string {
 	if rule := c.ResolveParserEngineRule(fileType); rule != nil {
 		return rule.Engine
 	}
-	return ""
+	return DefaultParserEngine(fileType)
 }
 
 // ResolveParserEngineRule returns the parser rule for a file type.

--- a/internal/types/knowledgebase.go
+++ b/internal/types/knowledgebase.go
@@ -250,7 +250,8 @@ type ChunkingConfig struct {
 	Separators []string `yaml:"separators"    json:"separators"`
 	// ParserEngineRules configures which parser engine to use for each file type.
 	// When empty, DefaultParserEngine is used (builtin/simple routing, except
-	// types that only a specific engine can parse, e.g. ppt/pptx → markitdown).
+	// types that only a specific engine can parse: ppt/pptx prefer anydoc
+	// when that binding is linked, otherwise markitdown).
 	ParserEngineRules []ParserEngineRule `yaml:"parser_engine_rules,omitempty" json:"parser_engine_rules,omitempty"`
 	// EnableParentChild enables two-level parent-child chunking strategy.
 	// When enabled, large parent chunks provide context while small child chunks
@@ -280,17 +281,42 @@ type ChunkingConfig struct {
 }
 
 // defaultParserEngineByType maps file types the builtin/simple engines cannot
-// parse to the only engine that can. Types omitted here keep empty-string
-// routing (Go simple formats, otherwise docreader builtin).
+// parse to a docreader engine that can. Types omitted here keep empty-string
+// routing (Go simple formats, otherwise docreader builtin). Anydoc, when
+// linked into the binary, is preferred over these fallbacks — see
+// SetPreferParserEngine.
 var defaultParserEngineByType = map[string]string{
 	"ppt":  "markitdown",
 	"pptx": "markitdown",
 }
 
+// preferParserEngine, if set, may override DefaultParserEngine for types that
+// have a type-level fallback. The docparser package registers anydoc here so
+// types does not import the engine catalog.
+var preferParserEngine func(fileType string) string
+
+// SetPreferParserEngine registers a build-time preference used by
+// DefaultParserEngine. Pass nil to clear. Intended to be called from init().
+func SetPreferParserEngine(fn func(fileType string) string) {
+	preferParserEngine = fn
+}
+
 // DefaultParserEngine returns the engine used when no parser_engine_rules
 // match. Empty string means builtin (docreader) or Go simple-format routing.
+// For ppt/pptx the preference is anydoc when that binding is available,
+// otherwise markitdown.
 func DefaultParserEngine(fileType string) string {
-	return defaultParserEngineByType[normalizeParserFileType(fileType)]
+	ft := normalizeParserFileType(fileType)
+	fallback := defaultParserEngineByType[ft]
+	if fallback == "" {
+		return ""
+	}
+	if preferParserEngine != nil {
+		if engine := preferParserEngine(ft); engine != "" {
+			return engine
+		}
+	}
+	return fallback
 }
 
 // ResolveParserEngine returns the engine name for the given file type

--- a/internal/types/knowledgebase.go
+++ b/internal/types/knowledgebase.go
@@ -250,8 +250,9 @@ type ChunkingConfig struct {
 	Separators []string `yaml:"separators"    json:"separators"`
 	// ParserEngineRules configures which parser engine to use for each file type.
 	// When empty, DefaultParserEngine is used (builtin/simple routing, except
-	// types that only a specific engine can parse: ppt/pptx prefer anydoc
-	// when that binding is linked, otherwise markitdown).
+	// types that only a specific engine can parse: ppt/pptx fall back to
+	// markitdown). A linked anydoc binding is preferred for every type it
+	// converts.
 	ParserEngineRules []ParserEngineRule `yaml:"parser_engine_rules,omitempty" json:"parser_engine_rules,omitempty"`
 	// EnableParentChild enables two-level parent-child chunking strategy.
 	// When enabled, large parent chunks provide context while small child chunks
@@ -282,17 +283,16 @@ type ChunkingConfig struct {
 
 // defaultParserEngineByType maps file types the builtin/simple engines cannot
 // parse to a docreader engine that can. Types omitted here keep empty-string
-// routing (Go simple formats, otherwise docreader builtin). Anydoc, when
-// linked into the binary, is preferred over these fallbacks — see
-// SetPreferParserEngine.
+// routing (Go simple formats, otherwise docreader builtin) unless
+// SetPreferParserEngine selects a linked in-process engine such as anydoc.
 var defaultParserEngineByType = map[string]string{
 	"ppt":  "markitdown",
 	"pptx": "markitdown",
 }
 
-// preferParserEngine, if set, may override DefaultParserEngine for types that
-// have a type-level fallback. The docparser package registers anydoc here so
-// types does not import the engine catalog.
+// preferParserEngine, if set, may override DefaultParserEngine. The
+// docparser package registers anydoc here so types does not import the
+// engine catalog.
 var preferParserEngine func(fileType string) string
 
 // SetPreferParserEngine registers a build-time preference used by
@@ -303,20 +303,17 @@ func SetPreferParserEngine(fn func(fileType string) string) {
 
 // DefaultParserEngine returns the engine used when no parser_engine_rules
 // match. Empty string means builtin (docreader) or Go simple-format routing.
-// For ppt/pptx the preference is anydoc when that binding is available,
-// otherwise markitdown.
+// When the anydoc binding is linked it is preferred for every type it
+// converts (except Go simple formats). ppt/pptx otherwise fall back to
+// markitdown.
 func DefaultParserEngine(fileType string) string {
 	ft := normalizeParserFileType(fileType)
-	fallback := defaultParserEngineByType[ft]
-	if fallback == "" {
-		return ""
-	}
 	if preferParserEngine != nil {
 		if engine := preferParserEngine(ft); engine != "" {
 			return engine
 		}
 	}
-	return fallback
+	return defaultParserEngineByType[ft]
 }
 
 // ResolveParserEngine returns the engine name for the given file type

--- a/internal/types/knowledgebase_test.go
+++ b/internal/types/knowledgebase_test.go
@@ -327,6 +327,33 @@ func TestDefaultParserEngine(t *testing.T) {
 	}
 }
 
+func TestDefaultParserEnginePrefersRegisteredEngineForFallbackTypes(t *testing.T) {
+	t.Cleanup(func() { SetPreferParserEngine(nil) })
+	SetPreferParserEngine(func(fileType string) string {
+		if fileType == "pptx" || fileType == "ppt" {
+			return "anydoc"
+		}
+		return "should-not-apply"
+	})
+	if got := DefaultParserEngine("pptx"); got != "anydoc" {
+		t.Fatalf("DefaultParserEngine(pptx) = %q, want anydoc", got)
+	}
+	if got := DefaultParserEngine("ppt"); got != "anydoc" {
+		t.Fatalf("DefaultParserEngine(ppt) = %q, want anydoc", got)
+	}
+	if got := DefaultParserEngine("pdf"); got != "" {
+		t.Fatalf("DefaultParserEngine(pdf) = %q, want empty (no type-level fallback)", got)
+	}
+}
+
+func TestDefaultParserEngineIgnoresEmptyPreference(t *testing.T) {
+	t.Cleanup(func() { SetPreferParserEngine(nil) })
+	SetPreferParserEngine(func(string) string { return "" })
+	if got := DefaultParserEngine("pptx"); got != "markitdown" {
+		t.Fatalf("DefaultParserEngine(pptx) = %q, want markitdown when preference is empty", got)
+	}
+}
+
 func TestChunkingConfigResolveParserEngineDefaults(t *testing.T) {
 	var empty ChunkingConfig
 	if got := empty.ResolveParserEngine("pptx"); got != "markitdown" {

--- a/internal/types/knowledgebase_test.go
+++ b/internal/types/knowledgebase_test.go
@@ -315,3 +315,31 @@ func TestEffectiveStorageProvider_CrossBackendDetection(t *testing.T) {
 			dstSame.EffectiveStorageProvider(tenantDefault), sp)
 	}
 }
+
+func TestDefaultParserEngine(t *testing.T) {
+	for input, want := range map[string]string{
+		"pptx": "markitdown", ".PPT": "markitdown", "ppt": "markitdown",
+		"pdf": "", "csv": "", "docx": "", "": "",
+	} {
+		if got := DefaultParserEngine(input); got != want {
+			t.Errorf("DefaultParserEngine(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestChunkingConfigResolveParserEngineDefaults(t *testing.T) {
+	var empty ChunkingConfig
+	if got := empty.ResolveParserEngine("pptx"); got != "markitdown" {
+		t.Fatalf("empty rules ResolveParserEngine(pptx) = %q, want markitdown", got)
+	}
+	if got := empty.ResolveParserEngine("pdf"); got != "" {
+		t.Fatalf("empty rules ResolveParserEngine(pdf) = %q, want empty", got)
+	}
+
+	configured := ChunkingConfig{ParserEngineRules: []ParserEngineRule{
+		{FileTypes: []string{"pptx"}, Engine: "mineru"},
+	}}
+	if got := configured.ResolveParserEngine(".PPTX"); got != "mineru" {
+		t.Fatalf("configured ResolveParserEngine(pptx) = %q, want mineru", got)
+	}
+}

--- a/internal/types/knowledgebase_test.go
+++ b/internal/types/knowledgebase_test.go
@@ -330,10 +330,10 @@ func TestDefaultParserEngine(t *testing.T) {
 func TestDefaultParserEnginePrefersRegisteredEngineForFallbackTypes(t *testing.T) {
 	t.Cleanup(func() { SetPreferParserEngine(nil) })
 	SetPreferParserEngine(func(fileType string) string {
-		if fileType == "pptx" || fileType == "ppt" {
+		if fileType == "pptx" || fileType == "ppt" || fileType == "pdf" || fileType == "docx" {
 			return "anydoc"
 		}
-		return "should-not-apply"
+		return ""
 	})
 	if got := DefaultParserEngine("pptx"); got != "anydoc" {
 		t.Fatalf("DefaultParserEngine(pptx) = %q, want anydoc", got)
@@ -341,8 +341,14 @@ func TestDefaultParserEnginePrefersRegisteredEngineForFallbackTypes(t *testing.T
 	if got := DefaultParserEngine("ppt"); got != "anydoc" {
 		t.Fatalf("DefaultParserEngine(ppt) = %q, want anydoc", got)
 	}
-	if got := DefaultParserEngine("pdf"); got != "" {
-		t.Fatalf("DefaultParserEngine(pdf) = %q, want empty (no type-level fallback)", got)
+	if got := DefaultParserEngine("pdf"); got != "anydoc" {
+		t.Fatalf("DefaultParserEngine(pdf) = %q, want anydoc", got)
+	}
+	if got := DefaultParserEngine("docx"); got != "anydoc" {
+		t.Fatalf("DefaultParserEngine(docx) = %q, want anydoc", got)
+	}
+	if got := DefaultParserEngine("txt"); got != "" {
+		t.Fatalf("DefaultParserEngine(txt) = %q, want empty", got)
 	}
 }
 

--- a/internal/types/parser_engine_config_test.go
+++ b/internal/types/parser_engine_config_test.go
@@ -8,7 +8,8 @@ func TestParserEngineConfigResolveChatParserEngine(t *testing.T) {
 		{FileTypes: []string{"xlsx"}, Engine: "markitdown"},
 	}}
 	for input, expected := range map[string]string{
-		"PDF": "mineru", ".docx": "mineru", "xlsx": "markitdown", "txt": "",
+		"PDF": "mineru", ".docx": "mineru", "xlsx": "markitdown",
+		"txt": "", "pptx": "markitdown", ".PPT": "markitdown",
 	} {
 		if actual := config.ResolveChatParserEngine(input); actual != expected {
 			t.Fatalf("ResolveChatParserEngine(%q) = %q, want %q", input, actual, expected)
@@ -17,5 +18,8 @@ func TestParserEngineConfigResolveChatParserEngine(t *testing.T) {
 	var nilConfig *ParserEngineConfig
 	if actual := nilConfig.ResolveChatParserEngine("pdf"); actual != "" {
 		t.Fatalf("nil config resolved %q", actual)
+	}
+	if actual := nilConfig.ResolveChatParserEngine("pptx"); actual != "markitdown" {
+		t.Fatalf("nil config pptx resolved %q, want markitdown", actual)
 	}
 }

--- a/internal/types/tenant.go
+++ b/internal/types/tenant.go
@@ -374,18 +374,17 @@ func ResolveMinerUParseMethod(method string, legacyOCREnabled *bool) string {
 }
 
 func (c *ParserEngineConfig) ResolveChatParserEngine(fileType string) string {
-	if c == nil {
-		return ""
-	}
-	fileType = strings.TrimPrefix(strings.ToLower(strings.TrimSpace(fileType)), ".")
-	for _, rule := range c.ChatParserEngineRules {
-		for _, candidate := range rule.FileTypes {
-			if strings.TrimPrefix(strings.ToLower(strings.TrimSpace(candidate)), ".") == fileType {
-				return strings.TrimSpace(rule.Engine)
+	if c != nil {
+		normalized := normalizeParserFileType(fileType)
+		for _, rule := range c.ChatParserEngineRules {
+			for _, candidate := range rule.FileTypes {
+				if normalizeParserFileType(candidate) == normalized {
+					return strings.TrimSpace(rule.Engine)
+				}
 			}
 		}
 	}
-	return ""
+	return DefaultParserEngine(fileType)
 }
 
 // ToOverridesMap returns a map suitable for ParserEngineOverrides in parse requests.


### PR DESCRIPTION
## Summary
- API 建库未配置 `parser_engine_rules` 时，PPT/PPTX 会落到 builtin 并在 docreader 抛 `Unsupported file type`。现按类型默认路由到 markitdown（Go `ResolveParserEngine` / 会话附件解析同样生效）。
- docreader registry 在请求引擎不支持该类型时，先走类型级默认引擎（ppt/pptx/csv → markitdown），再回退 builtin；失败时列出真正支持该类型的引擎。
- Go builtin 引擎目录补上 `ppt`/`pptx`，与 Python 注册表对齐。

Fixes https://github.com/Tencent/WeKnora/issues/2882

## Test plan
- [x] `go test ./internal/types/ ./internal/infrastructure/docparser/`
- [x] `uv run --project docreader python -m unittest discover -s docreader/tests -p "test_parser_routing.py" -v`
- [x] pre-push：gofmt、golangci-lint、go vet、go test、`go build ./cmd/server`
- [ ] 通过 API 创建知识库（不带 `parser_engine_rules`），上传 `.pptx`，确认解析成功而非 failed
- [ ] 显式配置 pptx → mineru 等规则时，仍走用户指定引擎