### PR TITLE
fix: align chunking config database defaults

### DIFF
--- a/internal/database/migration_sqlite_versioned_schema_test.go
+++ b/internal/database/migration_sqlite_versioned_schema_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/Tencent/WeKnora/internal/infrastructure/chunker"
 	"github.com/stretchr/testify/require"
 )
 
@@ -106,6 +108,44 @@ func TestSQLiteMigrationsUpgradeV12NormalizesChunkingConfig(t *testing.T) {
 
 	assertSQLiteChunkingConfig(t, db, "legacy-kb-1", 700, 50, []string{"\n", "。"})
 	assertSQLiteChunkingConfig(t, db, "legacy-kb-2", 900, 25, []string{"new"})
+}
+
+func TestChunkingConfigDatabaseDefaultsMatchRuntime(t *testing.T) {
+	repoRoot := sqliteRepoRoot(t)
+	runtimeConfig := chunker.DefaultConfig()
+	defaultPattern := regexp.MustCompile(
+		`(?m)^\s*chunking_config\s+\w+\s+NOT NULL DEFAULT '([^']+)'`,
+	)
+
+	files := []string{
+		"migrations/versioned/000000_init.up.sql",
+		"migrations/paradedb/00-init-db.sql",
+		"migrations/sqlite/000000_init.up.sql",
+	}
+	for _, file := range files {
+		t.Run(file, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(repoRoot, file))
+			require.NoError(t, err)
+
+			matches := defaultPattern.FindStringSubmatch(string(data))
+			require.Len(t, matches, 2, "expected one chunking_config default in %s", file)
+
+			var config struct {
+				ChunkSize    int      `json:"chunk_size"`
+				ChunkOverlap int      `json:"chunk_overlap"`
+				Separators   []string `json:"separators"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(matches[1]), &config))
+			require.Equal(t, runtimeConfig.ChunkSize, config.ChunkSize)
+			require.Equal(t, runtimeConfig.ChunkOverlap, config.ChunkOverlap)
+			require.Equal(t, runtimeConfig.Separators, config.Separators)
+
+			var keys map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal([]byte(matches[1]), &keys))
+			require.NotContains(t, keys, "split_markers")
+			require.NotContains(t, keys, "keep_separator")
+		})
+	}
 }
 
 func TestSQLiteMigrationsUpgradeV4PreservesData(t *testing.T) {

--- a/internal/database/migration_sqlite_versioned_schema_test.go
+++ b/internal/database/migration_sqlite_versioned_schema_test.go
@@ -2,8 +2,11 @@ package database
 
 import (
 	"database/sql"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,7 +36,7 @@ var versionedSQLiteColumns = map[string][]string{
 	"mcp_oauth_tokens":   {"principal_type", "principal_id"}, // 000064
 }
 
-const expectedSQLiteMigrationVersion = 12
+const expectedSQLiteMigrationVersion = 13
 
 func TestSQLiteMigrationsCreateVersionedSchema(t *testing.T) {
 	repoRoot := sqliteRepoRoot(t)
@@ -66,6 +69,43 @@ func TestSQLiteMigrationsCreateVersionedSchema(t *testing.T) {
 	assertSQLiteMCPOAuthPrincipalUpsertWorks(t, db)
 	require.False(t, sqliteColumnExists(t, db, "knowledges", "tag_id"),
 		"SQLite migrations must drop legacy knowledges.tag_id after multi-tag migration")
+
+	insertSQLiteKnowledgeBaseWithDefault(t, db, "fresh-kb-1", "fresh")
+	assertSQLiteChunkingConfig(t, db, "fresh-kb-1", 512, 80, []string{"\n\n", "\n", "。"})
+}
+
+func TestSQLiteMigrationsUpgradeV12NormalizesChunkingConfig(t *testing.T) {
+	repoRoot := sqliteRepoRoot(t)
+
+	legacyRoot := copySQLiteMigrationsThrough(t, repoRoot, 12)
+	chdirAndRestore(t, legacyRoot)
+
+	dbPath := filepath.Join(t.TempDir(), "chunking-config-upgrade.db")
+	require.NoError(t, RunMigrationsWithOptions("sqlite3://unused", MigrationOptions{SQLiteDBPath: dbPath}))
+
+	db := openSQLiteDB(t, dbPath)
+	versionBefore, dirtyBefore := sqliteMigrationState(t, db)
+	require.Equal(t, 12, versionBefore)
+	require.False(t, dirtyBefore)
+
+	legacyChunkingConfig := `{"chunk_size": 700, "chunk_overlap": 50,
+"split_markers": ["\n", "。"], "keep_separator": true}`
+	insertSQLiteKnowledgeBase(t, db, "legacy-kb-1", "legacy-1", legacyChunkingConfig)
+
+	mixedChunkingConfig := `{"chunk_size": 900, "chunk_overlap": 25,
+"split_markers": ["old"], "separators": ["new"], "keep_separator": true}`
+	insertSQLiteKnowledgeBase(t, db, "legacy-kb-2", "legacy-2", mixedChunkingConfig)
+
+	chdirAndRestore(t, repoRoot)
+	require.NoError(t, RunMigrationsWithOptions("sqlite3://unused", MigrationOptions{SQLiteDBPath: dbPath}))
+
+	db = openSQLiteDB(t, dbPath)
+	versionAfter, dirtyAfter := sqliteMigrationState(t, db)
+	require.Equal(t, expectedSQLiteMigrationVersion, versionAfter)
+	require.False(t, dirtyAfter)
+
+	assertSQLiteChunkingConfig(t, db, "legacy-kb-1", 700, 50, []string{"\n", "。"})
+	assertSQLiteChunkingConfig(t, db, "legacy-kb-2", 900, 25, []string{"new"})
 }
 
 func TestSQLiteMigrationsUpgradeV4PreservesData(t *testing.T) {
@@ -180,6 +220,55 @@ func sqliteColumnExists(t *testing.T, db *sql.DB, table, column string) bool {
 	return n == 1
 }
 
+func insertSQLiteKnowledgeBase(t *testing.T, db *sql.DB, id, name, chunkingConfig string) {
+	t.Helper()
+	_, err := db.Exec(
+		"INSERT INTO knowledge_bases (id, name, tenant_id, chunking_config, embedding_model_id, summary_model_id) "+
+			"VALUES (?, ?, 1, ?, 'embedding-model', 'summary-model')",
+		id, name, chunkingConfig,
+	)
+	require.NoError(t, err)
+}
+
+func insertSQLiteKnowledgeBaseWithDefault(t *testing.T, db *sql.DB, id, name string) {
+	t.Helper()
+	_, err := db.Exec(
+		"INSERT INTO knowledge_bases (id, name, tenant_id, embedding_model_id, summary_model_id) "+
+			"VALUES (?, ?, 1, 'embedding-model', 'summary-model')",
+		id, name,
+	)
+	require.NoError(t, err)
+}
+
+func assertSQLiteChunkingConfig(
+	t *testing.T,
+	db *sql.DB,
+	id string,
+	expectedSize, expectedOverlap int,
+	expectedSeparators []string,
+) {
+	t.Helper()
+	var raw string
+	require.NoError(t, db.QueryRow(
+		"SELECT chunking_config FROM knowledge_bases WHERE id = ?", id,
+	).Scan(&raw))
+
+	var config struct {
+		ChunkSize    int      `json:"chunk_size"`
+		ChunkOverlap int      `json:"chunk_overlap"`
+		Separators   []string `json:"separators"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(raw), &config))
+	require.Equal(t, expectedSize, config.ChunkSize)
+	require.Equal(t, expectedOverlap, config.ChunkOverlap)
+	require.Equal(t, expectedSeparators, config.Separators)
+
+	var keys map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(raw), &keys))
+	require.NotContains(t, keys, "split_markers")
+	require.NotContains(t, keys, "keep_separator")
+}
+
 func assertSQLiteShareLinkInvitationsWork(t *testing.T, db *sql.DB) {
 	t.Helper()
 	_, err := db.Exec("INSERT INTO tenants (name, business) VALUES (?, ?)", "share-link-tenant", "share-link-test")
@@ -241,20 +330,28 @@ func assertSQLiteMCPOAuthPrincipalUpsertWorks(t *testing.T, db *sql.DB) {
 }
 
 func copySQLiteMigrationsV4(t *testing.T, repoRoot string) string {
+	return copySQLiteMigrationsThrough(t, repoRoot, 4)
+}
+
+func copySQLiteMigrationsThrough(t *testing.T, repoRoot string, maxVersion int) string {
 	t.Helper()
 	dest := t.TempDir()
 	srcDir := filepath.Join(repoRoot, "migrations", "sqlite")
 	destDir := filepath.Join(dest, "migrations", "sqlite")
 	require.NoError(t, os.MkdirAll(destDir, 0o755))
 
-	legacy := []string{
-		"000000_init.up.sql",
-		"000001_remove_wiki_log.up.sql",
-		"000002_knowledge_folder_path.up.sql",
-		"000003_knowledge_base_auto_tag_config.up.sql",
-		"000004_memory.up.sql",
-	}
-	for _, name := range legacy {
+	entries, err := os.ReadDir(srcDir)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".up.sql") || len(name) < 6 {
+			continue
+		}
+		version, err := strconv.Atoi(name[:6])
+		require.NoError(t, err)
+		if version > maxVersion {
+			continue
+		}
 		data, err := os.ReadFile(filepath.Join(srcDir, name))
 		require.NoError(t, err)
 		require.NoError(t, os.WriteFile(filepath.Join(destDir, name), data, 0o600))

--- a/migrations/paradedb/00-init-db.sql
+++ b/migrations/paradedb/00-init-db.sql
@@ -56,7 +56,7 @@ CREATE TABLE IF NOT EXISTS knowledge_bases (
     name VARCHAR(255) NOT NULL,
     description TEXT,
     tenant_id INTEGER NOT NULL,
-    chunking_config JSONB NOT NULL DEFAULT '{"chunk_size": 512, "chunk_overlap": 50, "split_markers": ["\n\n", "\n", "。"], "keep_separator": true}',
+    chunking_config JSONB NOT NULL DEFAULT '{"chunk_size": 512, "chunk_overlap": 80, "separators": ["\n\n", "\n", "。"]}',
     image_processing_config JSONB NOT NULL DEFAULT '{"enable_multimodal": false, "model_id": ""}',
     embedding_model_id VARCHAR(64) NOT NULL,
     summary_model_id VARCHAR(64) NOT NULL,

--- a/migrations/sqlite/000000_init.up.sql
+++ b/migrations/sqlite/000000_init.up.sql
@@ -55,7 +55,7 @@ CREATE TABLE IF NOT EXISTS knowledge_bases (
     description TEXT,
     tenant_id INTEGER NOT NULL,
     type VARCHAR(32) NOT NULL DEFAULT 'document',
-    chunking_config TEXT NOT NULL DEFAULT '{"chunk_size": 512, "chunk_overlap": 50, "split_markers": ["\n\n", "\n", "。"], "keep_separator": true}',
+    chunking_config TEXT NOT NULL DEFAULT '{"chunk_size": 512, "chunk_overlap": 80, "separators": ["\n\n", "\n", "。"]}',
     image_processing_config TEXT NOT NULL DEFAULT '{"enable_multimodal": false, "model_id": ""}',
     embedding_model_id VARCHAR(64) NOT NULL,
     summary_model_id VARCHAR(64) NOT NULL,

--- a/migrations/sqlite/000013_fix_chunking_config_default.down.sql
+++ b/migrations/sqlite/000013_fix_chunking_config_default.down.sql
@@ -1,0 +1,105 @@
+-- Restore the previous schema default. Existing rows intentionally remain
+-- normalized because the data migration is not safely reversible.
+
+CREATE TABLE knowledge_bases_new (
+    id VARCHAR(36) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    tenant_id INTEGER NOT NULL,
+    type VARCHAR(32) NOT NULL DEFAULT 'document',
+    chunking_config TEXT NOT NULL DEFAULT '{"chunk_size": 512, "chunk_overlap": 50, "split_markers": ["\n\n", "\n", "。"], "keep_separator": true}',
+    image_processing_config TEXT NOT NULL DEFAULT '{"enable_multimodal": false, "model_id": ""}',
+    embedding_model_id VARCHAR(64) NOT NULL,
+    summary_model_id VARCHAR(64) NOT NULL,
+    cos_config TEXT NOT NULL DEFAULT '{}',
+    storage_provider_config TEXT DEFAULT NULL,
+    vlm_config TEXT NOT NULL DEFAULT '{}',
+    extract_config TEXT NULL DEFAULT NULL,
+    faq_config TEXT,
+    question_generation_config TEXT NULL,
+    is_temporary BOOLEAN NOT NULL DEFAULT 0,
+    is_pinned INTEGER NOT NULL DEFAULT 0,
+    pinned_at DATETIME NULL,
+    asr_config TEXT,
+    vector_store_id VARCHAR(36),
+    storage_backend_id VARCHAR(36),
+    creator_id VARCHAR(36),
+    wiki_config TEXT,
+    indexing_strategy TEXT DEFAULT '{"vector_enabled":true,"keyword_enabled":true,"wiki_enabled":false,"graph_enabled":false}',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    deleted_at DATETIME,
+    auto_tag_config TEXT
+);
+
+INSERT INTO knowledge_bases_new (
+    id,
+    name,
+    description,
+    tenant_id,
+    type,
+    chunking_config,
+    image_processing_config,
+    embedding_model_id,
+    summary_model_id,
+    cos_config,
+    storage_provider_config,
+    vlm_config,
+    extract_config,
+    faq_config,
+    question_generation_config,
+    is_temporary,
+    is_pinned,
+    pinned_at,
+    asr_config,
+    vector_store_id,
+    storage_backend_id,
+    creator_id,
+    wiki_config,
+    indexing_strategy,
+    created_at,
+    updated_at,
+    deleted_at,
+    auto_tag_config
+)
+SELECT
+    id,
+    name,
+    description,
+    tenant_id,
+    type,
+    chunking_config,
+    image_processing_config,
+    embedding_model_id,
+    summary_model_id,
+    cos_config,
+    storage_provider_config,
+    vlm_config,
+    extract_config,
+    faq_config,
+    question_generation_config,
+    is_temporary,
+    is_pinned,
+    pinned_at,
+    asr_config,
+    vector_store_id,
+    storage_backend_id,
+    creator_id,
+    wiki_config,
+    indexing_strategy,
+    created_at,
+    updated_at,
+    deleted_at,
+    auto_tag_config
+FROM knowledge_bases;
+
+DROP TABLE knowledge_bases;
+ALTER TABLE knowledge_bases_new RENAME TO knowledge_bases;
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_bases_tenant_id ON knowledge_bases(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_knowledge_bases_tenant_vector_store
+    ON knowledge_bases(tenant_id, vector_store_id);
+CREATE INDEX IF NOT EXISTS idx_knowledge_bases_storage_backend
+    ON knowledge_bases(tenant_id, storage_backend_id);
+CREATE INDEX IF NOT EXISTS idx_knowledge_bases_tenant_creator
+    ON knowledge_bases(tenant_id, creator_id);

--- a/migrations/sqlite/000013_fix_chunking_config_default.up.sql
+++ b/migrations/sqlite/000013_fix_chunking_config_default.up.sql
@@ -1,0 +1,123 @@
+-- Migration 000013: align persisted chunking configuration with the runtime defaults.
+-- SQLite has no portable ALTER COLUMN ... SET DEFAULT, so rebuild the table
+-- while preserving all existing columns and data.
+
+CREATE TABLE knowledge_bases_new (
+    id VARCHAR(36) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    tenant_id INTEGER NOT NULL,
+    type VARCHAR(32) NOT NULL DEFAULT 'document',
+    chunking_config TEXT NOT NULL DEFAULT '{"chunk_size": 512, "chunk_overlap": 80, "separators": ["\n\n", "\n", "。"]}',
+    image_processing_config TEXT NOT NULL DEFAULT '{"enable_multimodal": false, "model_id": ""}',
+    embedding_model_id VARCHAR(64) NOT NULL,
+    summary_model_id VARCHAR(64) NOT NULL,
+    cos_config TEXT NOT NULL DEFAULT '{}',
+    storage_provider_config TEXT DEFAULT NULL,
+    vlm_config TEXT NOT NULL DEFAULT '{}',
+    extract_config TEXT NULL DEFAULT NULL,
+    faq_config TEXT,
+    question_generation_config TEXT NULL,
+    is_temporary BOOLEAN NOT NULL DEFAULT 0,
+    is_pinned INTEGER NOT NULL DEFAULT 0,
+    pinned_at DATETIME NULL,
+    asr_config TEXT,
+    vector_store_id VARCHAR(36),
+    storage_backend_id VARCHAR(36),
+    creator_id VARCHAR(36),
+    wiki_config TEXT,
+    indexing_strategy TEXT DEFAULT '{"vector_enabled":true,"keyword_enabled":true,"wiki_enabled":false,"graph_enabled":false}',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    deleted_at DATETIME,
+    auto_tag_config TEXT
+);
+
+INSERT INTO knowledge_bases_new (
+    id,
+    name,
+    description,
+    tenant_id,
+    type,
+    chunking_config,
+    image_processing_config,
+    embedding_model_id,
+    summary_model_id,
+    cos_config,
+    storage_provider_config,
+    vlm_config,
+    extract_config,
+    faq_config,
+    question_generation_config,
+    is_temporary,
+    is_pinned,
+    pinned_at,
+    asr_config,
+    vector_store_id,
+    storage_backend_id,
+    creator_id,
+    wiki_config,
+    indexing_strategy,
+    created_at,
+    updated_at,
+    deleted_at,
+    auto_tag_config
+)
+SELECT
+    id,
+    name,
+    description,
+    tenant_id,
+    type,
+    CASE
+        WHEN json_valid(chunking_config) THEN
+            json_remove(
+                CASE
+                    WHEN json_type(chunking_config, '$.split_markers') IS NOT NULL
+                         AND json_type(chunking_config, '$.separators') IS NULL
+                    THEN json_set(
+                        chunking_config,
+                        '$.separators',
+                        json_extract(chunking_config, '$.split_markers')
+                    )
+                    ELSE chunking_config
+                END,
+                '$.split_markers',
+                '$.keep_separator'
+            )
+        ELSE chunking_config
+    END,
+    image_processing_config,
+    embedding_model_id,
+    summary_model_id,
+    cos_config,
+    storage_provider_config,
+    vlm_config,
+    extract_config,
+    faq_config,
+    question_generation_config,
+    is_temporary,
+    is_pinned,
+    pinned_at,
+    asr_config,
+    vector_store_id,
+    storage_backend_id,
+    creator_id,
+    wiki_config,
+    indexing_strategy,
+    created_at,
+    updated_at,
+    deleted_at,
+    auto_tag_config
+FROM knowledge_bases;
+
+DROP TABLE knowledge_bases;
+ALTER TABLE knowledge_bases_new RENAME TO knowledge_bases;
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_bases_tenant_id ON knowledge_bases(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_knowledge_bases_tenant_vector_store
+    ON knowledge_bases(tenant_id, vector_store_id);
+CREATE INDEX IF NOT EXISTS idx_knowledge_bases_storage_backend
+    ON knowledge_bases(tenant_id, storage_backend_id);
+CREATE INDEX IF NOT EXISTS idx_knowledge_bases_tenant_creator
+    ON knowledge_bases(tenant_id, creator_id);

--- a/migrations/versioned/000000_init.up.sql
+++ b/migrations/versioned/000000_init.up.sql
@@ -75,7 +75,7 @@ CREATE TABLE IF NOT EXISTS knowledge_bases (
     name VARCHAR(255) NOT NULL,
     description TEXT,
     tenant_id INTEGER NOT NULL,
-    chunking_config JSONB NOT NULL DEFAULT '{"chunk_size": 512, "chunk_overlap": 50, "split_markers": ["\n\n", "\n", "。"], "keep_separator": true}',
+    chunking_config JSONB NOT NULL DEFAULT '{"chunk_size": 512, "chunk_overlap": 80, "separators": ["\n\n", "\n", "。"]}',
     image_processing_config JSONB NOT NULL DEFAULT '{"enable_multimodal": false, "model_id": ""}',
     embedding_model_id VARCHAR(64) NOT NULL,
     summary_model_id VARCHAR(64) NOT NULL,

--- a/migrations/versioned/000091_fix_chunking_config_default.down.sql
+++ b/migrations/versioned/000091_fix_chunking_config_default.down.sql
@@ -1,0 +1,5 @@
+-- Restore the previous schema default. Existing rows intentionally remain
+-- normalized because the data migration is not safely reversible.
+
+ALTER TABLE knowledge_bases
+    ALTER COLUMN chunking_config SET DEFAULT '{"chunk_size": 512, "chunk_overlap": 50, "split_markers": ["\n\n", "\n", "。"], "keep_separator": true}'::jsonb;

--- a/migrations/versioned/000091_fix_chunking_config_default.up.sql
+++ b/migrations/versioned/000091_fix_chunking_config_default.up.sql
@@ -1,0 +1,18 @@
+-- Migration 000091: align persisted chunking configuration with the runtime defaults.
+
+DO $$ BEGIN RAISE NOTICE '[Migration 000091] Normalizing knowledge base chunking configuration'; END $$;
+
+UPDATE knowledge_bases
+SET chunking_config =
+    (chunking_config - 'split_markers' - 'keep_separator')
+    || CASE
+        WHEN chunking_config ? 'split_markers'
+             AND NOT (chunking_config ? 'separators')
+        THEN jsonb_build_object('separators', chunking_config -> 'split_markers')
+        ELSE '{}'::jsonb
+    END
+WHERE chunking_config ? 'split_markers'
+   OR chunking_config ? 'keep_separator';
+
+ALTER TABLE knowledge_bases
+    ALTER COLUMN chunking_config SET DEFAULT '{"chunk_size": 512, "chunk_overlap": 80, "separators": ["\n\n", "\n", "。"]}'::jsonb;


### PR DESCRIPTION
## Description

Fix the persisted `chunking_config` defaults so they match the JSON schema used by the current Go runtime.

The previous fresh-install database defaults used the legacy `split_markers` and `keep_separator` keys and an overlap of 50, while the current runtime uses `separators` and an overlap of 80.

This change:

- aligns PostgreSQL, ParadeDB, and SQLite fresh-install defaults with `chunker.DefaultConfig()`
- adds PostgreSQL migration 000091 to normalize legacy JSON without overwriting valid `separators` or user-defined chunking values
- adds SQLite migration 000013 with a data-preserving table rebuild and the same compatibility behavior
- adds regression coverage for fresh defaults, legacy upgrades, mixed legacy/current keys, and future default drift across all three DDL entry points

Existing `chunk_size` and `chunk_overlap` values are intentionally preserved during data migration so existing knowledge bases keep their configured behavior.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test (adds or updates tests)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Related Issue

Fixes #2884

## Testing

- `go test ./internal/database ./internal/infrastructure/chunker -count=1`
- `go vet ./internal/database ./internal/infrastructure/chunker`
- `golangci-lint run --new-from-rev=origin/main ./...`
- `git diff --check origin/main...HEAD`
- The full `make fmt`, `make lint`, and `make test` gate was not run because `make` is unavailable in the Windows environment; the focused checks above passed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have run `git diff --check origin/main...HEAD`
- [x] I have formatted all changed Go code with `gofmt`
- [x] I have added or updated tests for the change
- [x] I have run the targeted tests for changed packages
- [x] I have run the diff-scoped linter
- [x] I have run the full repository gate, or documented why it was not run above
- [x] This change does not introduce breaking changes

## Screenshots

Not applicable.