### PR TITLE
fix(knowledge): align chunking_config DDL default key with Go json tag

### DIFF
--- a/internal/types/chunking_config_test.go
+++ b/internal/types/chunking_config_test.go
@@ -1,0 +1,80 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Regression tests for the chunking_config key mismatch between the
+// migration DDL defaults ("split_markers") and the Go json tag
+// ("separators"): the default must not be silently dropped, and legacy
+// rows written with the old key must still be readable.
+func TestChunkingConfigUnmarshalFromDDLDefault(t *testing.T) {
+	// Exact default JSON now emitted by the migrations
+	// (migrations/{paradedb,sqlite,versioned}/000000_init*).
+	ddlDefault := `{"chunk_size": 512, "chunk_overlap": 50, "separators": ["\n\n", "\n", "。"], "keep_separator": true}`
+	var cfg ChunkingConfig
+	if err := json.Unmarshal([]byte(ddlDefault), &cfg); err != nil {
+		t.Fatalf("unmarshal DDL default: %v", err)
+	}
+	if cfg.ChunkSize != 512 || cfg.ChunkOverlap != 50 {
+		t.Fatalf("chunk size/overlap lost: %#v", cfg)
+	}
+	if len(cfg.Separators) != 3 || cfg.Separators[0] != "\n\n" || cfg.Separators[1] != "\n" || cfg.Separators[2] != "。" {
+		t.Fatalf("separators not parsed from DDL default, got %#v", cfg.Separators)
+	}
+}
+
+func TestChunkingConfigUnmarshalLegacySplitMarkersKey(t *testing.T) {
+	// Rows created before the fix stored the default under "split_markers".
+	legacy := `{"chunk_size": 512, "chunk_overlap": 50, "split_markers": ["\n\n", "\n", "。"], "keep_separator": true}`
+	var cfg ChunkingConfig
+	if err := json.Unmarshal([]byte(legacy), &cfg); err != nil {
+		t.Fatalf("unmarshal legacy default: %v", err)
+	}
+	if len(cfg.Separators) != 3 || cfg.Separators[0] != "\n\n" || cfg.Separators[2] != "。" {
+		t.Fatalf("legacy split_markers not honored, got %#v", cfg.Separators)
+	}
+}
+
+func TestChunkingConfigUnmarshalExplicitEmptySeparators(t *testing.T) {
+	// Explicitly empty separators must stay empty even when a legacy
+	// split_markers key is present: the caller asked for no separators.
+	payload := `{"chunk_size": 100, "separators": [], "split_markers": ["\n\n"]}`
+	var cfg ChunkingConfig
+	if err := json.Unmarshal([]byte(payload), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(cfg.Separators) != 0 {
+		t.Fatalf("explicit empty separators overridden by legacy key, got %#v", cfg.Separators)
+	}
+}
+
+func TestChunkingConfigRoundTripUsesCanonicalKey(t *testing.T) {
+	cfg := ChunkingConfig{
+		ChunkSize:    256,
+		ChunkOverlap: 20,
+		Separators:   []string{"\n\n", "。"},
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var probe map[string]interface{}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		t.Fatalf("unmarshal probe: %v", err)
+	}
+	if _, ok := probe["separators"]; !ok {
+		t.Fatalf("marshal did not emit canonical separators key: %s", raw)
+	}
+	if _, ok := probe["split_markers"]; ok {
+		t.Fatalf("marshal must never emit legacy split_markers key: %s", raw)
+	}
+	var back ChunkingConfig
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("round trip unmarshal: %v", err)
+	}
+	if len(back.Separators) != 2 {
+		t.Fatalf("round trip lost separators: %#v", back.Separators)
+	}
+}

--- a/internal/types/knowledgebase.go
+++ b/internal/types/knowledgebase.go
@@ -316,6 +316,36 @@ func DefaultParserEngine(fileType string) string {
 	return defaultParserEngineByType[ft]
 }
 
+// UnmarshalJSON keeps backward compatibility with rows written from the
+// migration DDL defaults, which used the legacy "split_markers" key for the
+// separator list. The canonical key is "separators"; the legacy key is read
+// only when "separators" is absent, so an explicitly empty separator list
+// is never overridden by a stale legacy key.
+func (c *ChunkingConfig) UnmarshalJSON(data []byte) error {
+	type alias ChunkingConfig
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	// Fall back to the legacy "split_markers" key only when the canonical
+	// "separators" key is absent, so an explicitly empty separator list
+	// is never overridden by a stale legacy key.
+	var keys map[string]json.RawMessage
+	if err := json.Unmarshal(data, &keys); err != nil {
+		return err
+	}
+	if _, present := keys["separators"]; !present {
+		var legacy struct {
+			SplitMarkers []string `json:"split_markers"`
+		}
+		if err := json.Unmarshal(data, &legacy); err == nil && len(legacy.SplitMarkers) > 0 {
+			decoded.Separators = legacy.SplitMarkers
+		}
+	}
+	*c = ChunkingConfig(decoded)
+	return nil
+}
+
 // ResolveParserEngine returns the engine name for the given file type
 // based on the configured rules. When no rule matches it returns the
 // type-level default (see DefaultParserEngine).

--- a/migrations/paradedb/00-init-db.sql
+++ b/migrations/paradedb/00-init-db.sql
@@ -56,7 +56,7 @@ CREATE TABLE IF NOT EXISTS knowledge_bases (
     name VARCHAR(255) NOT NULL,
     description TEXT,
     tenant_id INTEGER NOT NULL,
-    chunking_config JSONB NOT NULL DEFAULT '{"chunk_size": 512, "chunk_overlap": 50, "split_markers": ["\n\n", "\n", "。"], "keep_separator": true}',
+    chunking_config JSONB NOT NULL DEFAULT '{"chunk_size": 512, "chunk_overlap": 50, "separators": ["\n\n", "\n", "。"], "keep_separator": true}',
     image_processing_config JSONB NOT NULL DEFAULT '{"enable_multimodal": false, "model_id": ""}',
     embedding_model_id VARCHAR(64) NOT NULL,
     summary_model_id VARCHAR(64) NOT NULL,

--- a/migrations/sqlite/000000_init.up.sql
+++ b/migrations/sqlite/000000_init.up.sql
@@ -55,7 +55,7 @@ CREATE TABLE IF NOT EXISTS knowledge_bases (
     description TEXT,
     tenant_id INTEGER NOT NULL,
     type VARCHAR(32) NOT NULL DEFAULT 'document',
-    chunking_config TEXT NOT NULL DEFAULT '{"chunk_size": 512, "chunk_overlap": 50, "split_markers": ["\n\n", "\n", "。"], "keep_separator": true}',
+    chunking_config TEXT NOT NULL DEFAULT '{"chunk_size": 512, "chunk_overlap": 50, "separators": ["\n\n", "\n", "。"], "keep_separator": true}',
     image_processing_config TEXT NOT NULL DEFAULT '{"enable_multimodal": false, "model_id": ""}',
     embedding_model_id VARCHAR(64) NOT NULL,
     summary_model_id VARCHAR(64) NOT NULL,

--- a/migrations/versioned/000000_init.up.sql
+++ b/migrations/versioned/000000_init.up.sql
@@ -75,7 +75,7 @@ CREATE TABLE IF NOT EXISTS knowledge_bases (
     name VARCHAR(255) NOT NULL,
     description TEXT,
     tenant_id INTEGER NOT NULL,
-    chunking_config JSONB NOT NULL DEFAULT '{"chunk_size": 512, "chunk_overlap": 50, "split_markers": ["\n\n", "\n", "。"], "keep_separator": true}',
+    chunking_config JSONB NOT NULL DEFAULT '{"chunk_size": 512, "chunk_overlap": 50, "separators": ["\n\n", "\n", "。"], "keep_separator": true}',
     image_processing_config JSONB NOT NULL DEFAULT '{"enable_multimodal": false, "model_id": ""}',
     embedding_model_id VARCHAR(64) NOT NULL,
     summary_model_id VARCHAR(64) NOT NULL,


### PR DESCRIPTION
Fixes #2884

## Problem

The migrations' default `chunking_config` JSON used the key `split_markers` while the Go struct json tag is `separators` (`internal/types/knowledgebase.go`), so the default separator list was **silently dropped** for knowledge bases created without an explicit chunking_config. Reproduced with a unit test: unmarshaling the DDL default JSON yields `Separators = nil`.

## Changes

- `migrations/{paradedb,sqlite,versioned}/000000_init*.sql`: default JSON key `split_markers` -> `separators`
- `internal/types/knowledgebase.go`: `ChunkingConfig.UnmarshalJSON` falls back to the legacy `split_markers` key **only when `separators` is absent**, so rows written before the fix keep parsing and an explicitly empty separator list is never overridden
- `internal/types/chunking_config_test.go`: 4 regression tests (DDL default parse, legacy key fallback, explicit empty wins, round trip uses canonical key)

## Verification

```
go test -run TestChunkingConfig ./internal/types/  # 4/4 PASS
go test ./internal/types/ ./internal/infrastructure/chunker/ ./internal/handler/  # PASS
go vet ./internal/types/  # clean
```