### PR TITLE
fix(website-docs): work around vitepress-plugin-mermaid#98 fastdom ESM error

### DIFF
--- a/website-docs/.vitepress/config.mts
+++ b/website-docs/.vitepress/config.mts
@@ -186,5 +186,22 @@ export default withMermaid(
         fontSize: '14px',
       },
     },
+
+    // vitepress-plugin-mermaid loads mermaid chunks via dynamic import, so
+    // Vite's dep scanner misses their `import "fastdom"` references at
+    // startup and serves fastdom@1.0.12's raw UMD file as an ES module —
+    // which has no `default` export (its IIFE only sets `module.exports`
+    // when `typeof module === 'object'`, which is false in browser ESM).
+    // Force pre-bundling so esbuild's CJS→ESM interop wraps the module and
+    // exposes `default`. `fastdom-promised` is the second piece mermaid's
+    // core chunk imports the same way.
+    vite: {
+      optimizeDeps: {
+        include: [
+          'fastdom',
+          'fastdom/extensions/fastdom-promised.js',
+        ],
+      },
+    },
   }),
 )


### PR DESCRIPTION
## Summary

Fix the docs site (`website-docs`) failing in `npm run dev` because Mermaid diagrams throw:

```
Uncaught SyntaxError: The requested module '/docs/node_modules/fastdom/fastdom.js'
does not provide an export named 'default'
```

## Root cause

`vitepress-plugin-mermaid` loads Mermaid's ESM chunks via dynamic `import()`. Mermaid's `chunk-GMAD6QVW.mjs` does:

```js
import fastdomModule from "fastdom";
import fastdomPromised from "fastdom/extensions/fastdom-promised.js";
```

Vite's dep scanner doesn't see those references at startup (dynamic imports are scanned lazily), so `fastdom` and `fastdom-promised` are not added to `optimizeDeps`. They get served raw from `node_modules/` instead of being pre-bundled via esbuild's CJS→ESM interop.

`fastdom@1.0.12` is an old UMD module — its IIFE only assigns `module.exports` when `typeof module === 'object'`. In browser ESM, `module` is `undefined`, so no `default` export is produced and the import fails.

## Fix

Force pre-bundling both fastdom entries via `vite.optimizeDeps.include`. esbuild then wraps them with CJS→ESM interop and the `default` export materialises.

```ts
vite: {
  optimizeDeps: {
    include: [
      'fastdom',
      'fastdom/extensions/fastdom-promised.js',
    ],
  },
},
```

17 lines added, 0 removed. Pure addition, no behaviour change outside the broken case.

## References

- Tencent/WeKnora#2899 — bug report
- emersonbottero/vitepress-plugin-mermaid#98 — same error upstream, Open

When the plugin ships a proper fix upstream, this workaround can be removed.

## Test plan

- [ ] `cd website-docs && npm install && npm run dev`
- [ ] Open http://localhost:5173/docs/01-getting-started/01-introduction (or any page with a Mermaid block — most docs pages have one)
- [ ] Browser console should be clean (no `fastdom does not provide an export named 'default'`)
- [ ] Mermaid diagrams should render as SVG, not broken blocks
