### PR TITLE
fix(observability): nest follow-up and sandbox spans under the chat trace

### DIFF
--- a/internal/application/service/artifact_collector.go
+++ b/internal/application/service/artifact_collector.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/sandbox"
+	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"github.com/google/uuid"
@@ -255,7 +256,7 @@ func (c *ArtifactCollector) collect(
 	tenantID uint64,
 	outputDir string,
 	notify func(pending int),
-) (types.MessageArtifacts, error) {
+) (artifacts types.MessageArtifacts, err error) {
 	if c == nil || c.fileService == nil {
 		logger.Infof(ctx, "[ArtifactCollector] skipped: collector or dependencies nil (session=%s)", sessionID)
 		return nil, nil
@@ -280,6 +281,20 @@ func (c *ArtifactCollector) collect(
 		logger.Infof(ctx, "[ArtifactCollector] skipped: empty outputDir (session=%s)", sessionID)
 		return nil, nil
 	}
+
+	ctx, span := langfuse.GetManager().StartSpan(ctx, langfuse.SpanOptions{
+		Name: "sandbox.collect_artifacts",
+		Input: map[string]interface{}{
+			"session_id": sessionID,
+			"message_id": messageID,
+			"output_dir": outputDir,
+		},
+	})
+	defer func() {
+		span.Finish(map[string]interface{}{
+			"artifact_count": len(artifacts),
+		}, nil, err)
+	}()
 
 	logger.Infof(ctx, "[ArtifactCollector] begin session=%s dir=%s", sessionID, outputDir)
 
@@ -318,7 +333,7 @@ func (c *ArtifactCollector) collect(
 		notify(pending)
 	}
 
-	artifacts := make(types.MessageArtifacts, 0, pending)
+	artifacts = make(types.MessageArtifacts, 0, pending)
 	for _, entry := range entries {
 		art, ok := c.maybePersist(ctx, source, sessionID, messageID, tenantID, entry, known)
 		if !ok {

--- a/internal/application/service/message_suggestion.go
+++ b/internal/application/service/message_suggestion.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/models/chat"
 	"github.com/Tencent/WeKnora/internal/searchutil"
+	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"github.com/google/uuid"
@@ -258,7 +259,30 @@ func (s *messageSuggestionService) generate(
 	message *types.Message,
 	answer string,
 	config types.FollowUpSuggestionConfig,
-) (types.SuggestionItems, types.TokenUsage, error) {
+) (questions types.SuggestionItems, usage types.TokenUsage, err error) {
+	// The LLM call often runs on POST .../suggestions (frontend onTurnComplete)
+	// or after GinMiddleware has already ended the HTTP root. Resume the
+	// originating chat trace so chat.completion nests under that turn instead
+	// of auto-creating an orphan root.
+	ctx = langfuse.AttachTraceparent(ctx, message.ExecutionContext.LangfuseTraceparent)
+	ctx, span := langfuse.GetManager().StartSpan(ctx, langfuse.SpanOptions{
+		Name: "follow_up.suggestions",
+		Input: map[string]interface{}{
+			"session_id":           message.SessionID,
+			"assistant_message_id": message.ID,
+			"mode":                 config.Mode,
+		},
+		Metadata: map[string]interface{}{
+			"count":    config.Count,
+			"model_id": config.ModelID,
+		},
+	})
+	defer func() {
+		span.Finish(map[string]interface{}{
+			"question_count": len(questions),
+		}, nil, err)
+	}()
+
 	count := config.Count
 	if count < 1 {
 		count = 3
@@ -269,7 +293,6 @@ func (s *messageSuggestionService) generate(
 	}
 	var generated types.SuggestionItems
 	var knowledge types.SuggestionItems
-	var usage types.TokenUsage
 	var modelErr error
 	if config.Mode == types.SuggestionModeGenerated || config.Mode == types.SuggestionModeHybrid {
 		generated, usage, modelErr = s.generateWithModel(
@@ -329,6 +352,7 @@ func (s *messageSuggestionService) generateWithModel(
 	if err != nil {
 		return nil, types.TokenUsage{}, err
 	}
+	modelCtx = types.WithLLMCallMetadata(modelCtx, "follow_up.suggestions", "")
 	categories := strings.Join(config.Categories, ", ")
 	if categories == "" {
 		categories = "clarify, deepen, action"

--- a/internal/application/service/tenant_skill_reaper.go
+++ b/internal/application/service/tenant_skill_reaper.go
@@ -422,10 +422,10 @@ func configuredSandboxTTL(cfg *types.TenantSandboxConfig) time.Duration {
 // image is never touched, nor is anything the ledger does not name: extras
 // belong to other environments on a shared provider account.
 //
-// A live sandbox does not need the template it was created from in order to
-// keep running, so the only reason to wait is in-flight creates that resolved
-// the previous pointer. Twenty-four hours is far past every backend's default
-// TTL; a config that sets a longer one extends the wait.
+// Retention is a lower bound, not a guarantee the provider will accept the
+// delete. Session sandboxes pause instead of dying when idle, and a paused
+// sandbox still pins its template; a Conflict is left on the ledger for the
+// next sweep.
 func (s *TenantSkillService) PruneSupersededSnapshots(ctx context.Context) (int, error) {
 	if s == nil || s.skills == nil {
 		return 0, nil
@@ -497,6 +497,12 @@ func (s *TenantSkillService) pruneConfigSnapshots(
 			continue
 		}
 		if err := deleter.DeleteSnapshot(ctx, row.SnapshotID); err != nil && !sandbox.IsRemoteNotFound(err) {
+			if sandbox.IsRemoteConflict(err) {
+				logger.Infof(ctx,
+					"[skill] snapshot %s still in use; leaving it until sandboxes release it: %s",
+					row.SnapshotID, sandbox.RemoteErrorDiagnostics(err))
+				continue
+			}
 			logger.Warnf(ctx, "[skill] delete superseded snapshot %s failed: %v", row.SnapshotID, err)
 			continue
 		}
@@ -568,6 +574,12 @@ func (s *TenantSkillService) reapAbandonedBuilds(
 			continue
 		}
 		if err := deleter.DeleteSnapshot(ctx, found); err != nil && !sandbox.IsRemoteNotFound(err) {
+			if sandbox.IsRemoteConflict(err) {
+				logger.Infof(ctx,
+					"[skill] abandoned build %s of config %s still in use; leaving it until sandboxes release it: %s",
+					found, cfg.ID, sandbox.RemoteErrorDiagnostics(err))
+				continue
+			}
 			logger.Warnf(ctx, "[skill] delete abandoned build %s of config %s failed: %v",
 				found, cfg.ID, err)
 			continue

--- a/internal/application/service/tenant_skill_reaper_test.go
+++ b/internal/application/service/tenant_skill_reaper_test.go
@@ -390,6 +390,28 @@ func TestPruneSupersededSnapshotsLeavesTheRowWhenDeleteFails(t *testing.T) {
 		"a failed provider delete must not be recorded as deleted")
 }
 
+func TestPruneSupersededSnapshotsRetriesWhenSnapshotStillInUse(t *testing.T) {
+	fx := newReaperFixture(t)
+	fx.svc.snapshotRetention = time.Hour
+	old := fx.now.Add(-2 * time.Hour)
+	fx.live("snap-live")
+	fx.superseded("sk-1", "snap-old", "", old)
+	fx.provider.deleteErr = sandbox.NewRemoteError(
+		sandbox.SandboxTypeE2B, "DeleteSnapshot", sandbox.RemoteErrorKindConflict,
+		"cannot delete template because there are paused sandboxes using it", nil,
+	)
+
+	n, err := fx.svc.PruneSupersededSnapshots(context.Background())
+
+	require.NoError(t, err)
+	require.Zero(t, n)
+	require.Empty(t, fx.provider.deleted)
+	rows, err := fx.skills.ListSnapshotsByConfig(context.Background(), 7, "cfg-1")
+	require.NoError(t, err)
+	require.Equal(t, types.SkillSnapshotStateSuperseded, rows[0].State,
+		"an in-use template must stay on the ledger so the next sweep can retry")
+}
+
 func TestPruneSupersededSnapshotsTreatsMissingProviderSnapshotAsDeleted(t *testing.T) {
 	fx := newReaperFixture(t)
 	fx.svc.snapshotRetention = time.Hour

--- a/internal/application/service/tenant_skill_service.go
+++ b/internal/application/service/tenant_skill_service.go
@@ -43,11 +43,10 @@ const (
 	skillInstallInFlightSkip = 3 * time.Minute
 
 	// skillSnapshotRetention is how long a superseded snapshot stays on the
-	// provider after the pointer has moved. Live sandboxes may still have
-	// been created from it (especially SkillRolloutNewSession); once they
-	// expire, the template is only a billed leftover. Twenty-four hours is
-	// well past every backend's default sandbox TTL. A config that sets a
-	// longer sandbox TTL extends this via snapshotRetentionFor.
+	// provider after the pointer has moved before prune even tries. Paused
+	// session sandboxes can pin the template past this window; prune retries
+	// on Conflict. A config that sets a longer sandbox TTL extends this via
+	// snapshotRetentionFor.
 	skillSnapshotRetention = 24 * time.Hour
 
 	// skillSnapshotTTLMargin is added on top of a config's own sandbox TTL

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/event"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/storageurl"
+	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
 	"github.com/gin-gonic/gin"
@@ -437,14 +438,15 @@ func buildMessageExecutionContext(
 	locale := types.LanguageFromContextOrDefault(ctx)
 
 	snapshot := types.MessageExecutionContext{
-		KnowledgeBaseIDs: knowledgeBaseIDs,
-		KnowledgeIDs:     knowledgeIDs,
-		TagIDs:           tagIDs,
-		TagScopes:        cloneTagScopes(tagScopes),
-		MCPServiceIDs:    mcpServiceIDs,
-		SkillNames:       skillNames,
-		WebSearchEnabled: webSearchEnabled,
-		Locale:           locale,
+		KnowledgeBaseIDs:    knowledgeBaseIDs,
+		KnowledgeIDs:        knowledgeIDs,
+		TagIDs:              tagIDs,
+		TagScopes:           cloneTagScopes(tagScopes),
+		MCPServiceIDs:       mcpServiceIDs,
+		SkillNames:          skillNames,
+		WebSearchEnabled:    webSearchEnabled,
+		Locale:              locale,
+		LangfuseTraceparent: langfuse.TraceparentFromContext(ctx),
 	}
 	if agent == nil {
 		return snapshot, "", effectiveTenantID, modelOverride

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -529,3 +529,21 @@ func CloneContext(ctx context.Context) context.Context {
 
 	return newCtx
 }
+
+// CloneContextWithoutTrace copies the same identity keys as CloneContext but
+// drops the Langfuse *Trace handle and the OpenTelemetry span. Use it for
+// background work that must keep tenant/session identity yet must not attach
+// child spans (Docker Engine HTTP, idle sweeps, image pulls kicked off after
+// a tool has returned) onto the originating chat trace.
+func CloneContextWithoutTrace(ctx context.Context) context.Context {
+	newCtx := context.Background()
+	for _, k := range types.ContextKeysClonedAcrossDetach() {
+		if k == types.LangfuseTraceContextKey {
+			continue
+		}
+		if v := ctx.Value(k); v != nil {
+			newCtx = context.WithValue(newCtx, k, v)
+		}
+	}
+	return newCtx
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -279,3 +279,26 @@ func TestCloneContextKeepsTheNonInteractiveOAuthMark(t *testing.T) {
 		t.Fatal("IsMCPOAuthNonInteractive(cloned) = true for an unmarked context, want interactive prompts to stay possible")
 	}
 }
+
+func TestCloneContextWithoutTraceDropsTheChatTrace(t *testing.T) {
+	t.Parallel()
+
+	const tenantID uint64 = 42
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, tenantID)
+	ctx = context.WithValue(ctx, types.LangfuseTraceContextKey, "trace-handle")
+
+	kept := CloneContext(ctx)
+	if kept.Value(types.LangfuseTraceContextKey) != "trace-handle" {
+		t.Fatal("CloneContext must keep the Langfuse trace so same-request work stays nested")
+	}
+
+	detached := CloneContextWithoutTrace(ctx)
+	if detached.Value(types.LangfuseTraceContextKey) != nil {
+		t.Fatal("CloneContextWithoutTrace must drop the Langfuse trace so " +
+			"background sandbox RPCs do not join the chat tree")
+	}
+	got, _ := detached.Value(types.TenantIDContextKey).(uint64)
+	if got != tenantID {
+		t.Fatalf("TenantID = %d, want %d (identity must survive the detach)", got, tenantID)
+	}
+}

--- a/internal/sandbox/cube_remote_client.go
+++ b/internal/sandbox/cube_remote_client.go
@@ -1123,6 +1123,7 @@ func normalizeCubeError(op string, err error) error {
 			kind = RemoteErrorKindUnavailable
 		}
 	}
+	kind = snapshotDeleteKind(op, kind, err.Error())
 	remoteErr := NewRemoteError(SandboxTypeCube, op, kind, err.Error(), err)
 	remoteErr.StatusCode = status
 	return remoteErr

--- a/internal/sandbox/cube_remote_client_test.go
+++ b/internal/sandbox/cube_remote_client_test.go
@@ -470,6 +470,14 @@ func TestNormalizeCubeError(t *testing.T) {
 		{"bad gateway", "List", &cubesandbox.APIError{StatusCode: http.StatusBadGateway}, RemoteErrorKindUnavailable},
 		{"deadline", "Exec", context.DeadlineExceeded, RemoteErrorKindTimeout},
 		{"unknown", "List", errors.New("unknown"), RemoteErrorKindInternal},
+		{"delete snapshot in use", "DeleteSnapshot", &cubesandbox.APIError{
+			StatusCode: http.StatusBadRequest,
+			Message:    "cannot delete template x because there are paused sandboxes using it",
+		}, RemoteErrorKindConflict},
+		{"delete snapshot bad id", "DeleteSnapshot", &cubesandbox.APIError{
+			StatusCode: http.StatusBadRequest,
+			Message:    "invalid snapshot id",
+		}, RemoteErrorKindInvalidRequest},
 	}
 
 	for _, tt := range tests {

--- a/internal/sandbox/docker_engine.go
+++ b/internal/sandbox/docker_engine.go
@@ -373,7 +373,7 @@ func dockerError(op string, err error) error {
 		return err
 	}
 	return &RemoteError{
-		Kind:     dockerErrorKind(op, err),
+		Kind:     snapshotDeleteKind(op, dockerErrorKind(op, err), err.Error()),
 		Provider: SandboxTypeDocker,
 		Op:       op,
 		Message:  err.Error(),

--- a/internal/sandbox/docker_idle_sweeper.go
+++ b/internal/sandbox/docker_idle_sweeper.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/moby/moby/client"
 )
 
@@ -78,8 +79,11 @@ func (s *dockerIdleSweeper) trigger(ctx context.Context) {
 		return
 	}
 	go func() {
+		// Drop the chat-trace parent: Engine API list/stat/delete from a
+		// sweep must not appear as siblings of agent.round after the tool
+		// that triggered the sweep has already finished its span.
 		sweepCtx, cancel := context.WithTimeout(
-			context.WithoutCancel(ctx), dockerSweepBudget,
+			logger.CloneContextWithoutTrace(ctx), dockerSweepBudget,
 		)
 		defer cancel()
 		if reclaimed, err := s.sweep(sweepCtx); err != nil {

--- a/internal/sandbox/e2b_remote_client.go
+++ b/internal/sandbox/e2b_remote_client.go
@@ -1253,6 +1253,7 @@ func normalizeE2BError(op string, err error) error {
 			}
 		}
 	}
+	kind = snapshotDeleteKind(op, kind, err.Error())
 	remoteErr := NewRemoteError(SandboxTypeE2B, op, kind, err.Error(), err)
 	remoteErr.StatusCode = status
 	return remoteErr

--- a/internal/sandbox/e2b_remote_client_test.go
+++ b/internal/sandbox/e2b_remote_client_test.go
@@ -1391,6 +1391,14 @@ func TestNormalizeE2BError(t *testing.T) {
 		{"connect data loss", "List", connect.NewError(connect.CodeDataLoss, errors.New("data loss")), RemoteErrorKindInternal},
 		{"connect unknown", "List", connect.NewError(connect.CodeUnknown, errors.New("unknown")), RemoteErrorKindInternal},
 		{"unknown", "List", errors.New("mystery"), RemoteErrorKindInternal},
+		{"delete snapshot in use", "DeleteSnapshot", &e2b.Error{
+			StatusCode: http.StatusBadRequest,
+			Message:    "cannot delete template 'tpl-1' because there are paused sandboxes using it",
+		}, RemoteErrorKindConflict},
+		{"delete snapshot bad id", "DeleteSnapshot", &e2b.Error{
+			StatusCode: http.StatusBadRequest,
+			Message:    "invalid snapshot id",
+		}, RemoteErrorKindInvalidRequest},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/sandbox/langfuse.go
+++ b/internal/sandbox/langfuse.go
@@ -1,0 +1,272 @@
+package sandbox
+
+import (
+	"context"
+	"unicode/utf8"
+
+	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
+)
+
+const sandboxSpanPreviewRunes = 256
+
+// wrapLangfuseRemoteClient records provider-neutral sandbox RPCs as Langfuse
+// spans (sandbox.exec / sandbox.connect / …) so LiteFuse shows a product-level
+// tree instead of a pile of Docker Engine HTTP calls parented to whatever
+// agent.round happened to be recording. No-op when Langfuse is disabled.
+//
+// Snapshot capability is forwarded: wrapping must not hide RemoteSnapshotManager
+// from SnapshotManagerFrom.
+func wrapLangfuseRemoteClient(inner RemoteSandboxClient) RemoteSandboxClient {
+	if inner == nil {
+		return nil
+	}
+	if _, ok := inner.(*langfuseRemoteClient); ok {
+		return inner
+	}
+	if _, ok := inner.(*langfuseSnapshotClient); ok {
+		return inner
+	}
+	wrapped := langfuseRemoteClient{inner: inner}
+	if _, ok := inner.(RemoteSnapshotManager); ok {
+		return &langfuseSnapshotClient{langfuseRemoteClient: wrapped}
+	}
+	return &wrapped
+}
+
+type langfuseRemoteClient struct {
+	inner RemoteSandboxClient
+}
+
+func (c *langfuseRemoteClient) Provider() RemoteProvider { return c.inner.Provider() }
+
+func (c *langfuseRemoteClient) Capabilities() RemoteSandboxCapabilities {
+	return c.inner.Capabilities()
+}
+
+func (c *langfuseRemoteClient) Health(ctx context.Context) error {
+	return c.inner.Health(ctx)
+}
+
+func (c *langfuseRemoteClient) Create(
+	ctx context.Context, req RemoteCreateRequest,
+) (RemoteSandboxHandle, error) {
+	ctx, span := startSandboxSpan(ctx, "sandbox.create", map[string]interface{}{
+		"template_id": req.TemplateID,
+	}, nil)
+	handle, err := c.inner.Create(ctx, req)
+	span.Finish(sandboxHandleOut(handle), nil, err)
+	return handle, err
+}
+
+func (c *langfuseRemoteClient) Connect(
+	ctx context.Context, sandboxID string,
+) (RemoteSandboxHandle, error) {
+	ctx, span := startSandboxSpan(ctx, "sandbox.connect", map[string]interface{}{
+		"sandbox_id": sandboxID,
+	}, nil)
+	handle, err := c.inner.Connect(ctx, sandboxID)
+	span.Finish(sandboxHandleOut(handle), nil, err)
+	return handle, err
+}
+
+func (c *langfuseRemoteClient) Get(
+	ctx context.Context, sandboxID string,
+) (*RemoteSandboxSummary, error) {
+	return c.inner.Get(ctx, sandboxID)
+}
+
+func (c *langfuseRemoteClient) List(
+	ctx context.Context, filter RemoteListFilter,
+) ([]RemoteSandboxSummary, error) {
+	return c.inner.List(ctx, filter)
+}
+
+func (c *langfuseRemoteClient) Delete(ctx context.Context, sandboxID string) error {
+	ctx, span := startSandboxSpan(ctx, "sandbox.delete", map[string]interface{}{
+		"sandbox_id": sandboxID,
+	}, nil)
+	err := c.inner.Delete(ctx, sandboxID)
+	span.Finish(nil, nil, err)
+	return err
+}
+
+func (c *langfuseRemoteClient) Exec(
+	ctx context.Context,
+	handle RemoteSandboxHandle,
+	req RemoteExecRequest,
+) (*RemoteExecResult, error) {
+	ctx, span := startSandboxSpan(ctx, "sandbox.exec", map[string]interface{}{
+		"command":    truncateSandboxPreview(req.Command),
+		"shell":      req.Shell,
+		"work_dir":   req.WorkDir,
+		"user":       req.User,
+		"timeout_ms": req.Timeout.Milliseconds(),
+	}, sandboxHandleMeta(handle))
+	result, err := c.inner.Exec(ctx, handle, req)
+	out := map[string]interface{}{}
+	if result != nil {
+		out["exit_code"] = result.ExitCode
+		out["killed"] = result.Killed
+		out["duration_ms"] = result.Duration.Milliseconds()
+		out["stdout_bytes"] = len(result.Stdout)
+		out["stderr_bytes"] = len(result.Stderr)
+	}
+	span.Finish(out, nil, err)
+	return result, err
+}
+
+func (c *langfuseRemoteClient) WriteFile(
+	ctx context.Context, handle RemoteSandboxHandle, path string, content []byte,
+) error {
+	ctx, span := startSandboxSpan(ctx, "sandbox.write_file", map[string]interface{}{
+		"path":  path,
+		"bytes": len(content),
+	}, sandboxHandleMeta(handle))
+	err := c.inner.WriteFile(ctx, handle, path, content)
+	span.Finish(nil, nil, err)
+	return err
+}
+
+func (c *langfuseRemoteClient) ReadFile(
+	ctx context.Context, handle RemoteSandboxHandle, path string,
+) ([]byte, error) {
+	ctx, span := startSandboxSpan(ctx, "sandbox.read_file", map[string]interface{}{
+		"path": path,
+	}, sandboxHandleMeta(handle))
+	data, err := c.inner.ReadFile(ctx, handle, path)
+	span.Finish(map[string]interface{}{"bytes": len(data)}, nil, err)
+	return data, err
+}
+
+func (c *langfuseRemoteClient) ListDir(
+	ctx context.Context, handle RemoteSandboxHandle, path string,
+) ([]RemoteDirEntry, error) {
+	ctx, span := startSandboxSpan(ctx, "sandbox.list_dir", map[string]interface{}{
+		"path": path,
+	}, sandboxHandleMeta(handle))
+	entries, err := c.inner.ListDir(ctx, handle, path)
+	span.Finish(map[string]interface{}{"entries": len(entries)}, nil, err)
+	return entries, err
+}
+
+func (c *langfuseRemoteClient) MakeDir(
+	ctx context.Context, handle RemoteSandboxHandle, path string,
+) error {
+	ctx, span := startSandboxSpan(ctx, "sandbox.make_dir", map[string]interface{}{
+		"path": path,
+	}, sandboxHandleMeta(handle))
+	err := c.inner.MakeDir(ctx, handle, path)
+	span.Finish(nil, nil, err)
+	return err
+}
+
+func (c *langfuseRemoteClient) Remove(
+	ctx context.Context, handle RemoteSandboxHandle, path string,
+) error {
+	ctx, span := startSandboxSpan(ctx, "sandbox.remove", map[string]interface{}{
+		"path": path,
+	}, sandboxHandleMeta(handle))
+	err := c.inner.Remove(ctx, handle, path)
+	span.Finish(nil, nil, err)
+	return err
+}
+
+func (c *langfuseRemoteClient) Stat(
+	ctx context.Context, handle RemoteSandboxHandle, path string,
+) (*RemoteStatEntry, error) {
+	ctx, span := startSandboxSpan(ctx, "sandbox.stat", map[string]interface{}{
+		"path": path,
+	}, sandboxHandleMeta(handle))
+	stat, err := c.inner.Stat(ctx, handle, path)
+	span.Finish(nil, nil, err)
+	return stat, err
+}
+
+type langfuseSnapshotClient struct {
+	langfuseRemoteClient
+}
+
+func (c *langfuseSnapshotClient) CreateSnapshot(
+	ctx context.Context, sandboxID string, name string,
+) (RemoteSnapshotRef, error) {
+	inner, ok := c.inner.(RemoteSnapshotManager)
+	if !ok {
+		return RemoteSnapshotRef{}, &RemoteError{
+			Kind:    RemoteErrorKindUnsupported,
+			Op:      "CreateSnapshot",
+			Message: "inner client has no snapshot manager",
+		}
+	}
+	ctx, span := startSandboxSpan(ctx, "sandbox.create_snapshot", map[string]interface{}{
+		"sandbox_id": sandboxID,
+		"name":       name,
+	}, nil)
+	ref, err := inner.CreateSnapshot(ctx, sandboxID, name)
+	span.Finish(map[string]interface{}{"snapshot_id": ref.ID}, nil, err)
+	return ref, err
+}
+
+func (c *langfuseSnapshotClient) DeleteSnapshot(ctx context.Context, snapshotID string) error {
+	inner, ok := c.inner.(RemoteSnapshotManager)
+	if !ok {
+		return nil
+	}
+	ctx, span := startSandboxSpan(ctx, "sandbox.delete_snapshot", map[string]interface{}{
+		"snapshot_id": snapshotID,
+	}, nil)
+	err := inner.DeleteSnapshot(ctx, snapshotID)
+	span.Finish(nil, nil, err)
+	return err
+}
+
+func (c *langfuseSnapshotClient) ListSnapshots(
+	ctx context.Context, sandboxID string,
+) ([]RemoteSnapshotRef, error) {
+	inner, ok := c.inner.(RemoteSnapshotManager)
+	if !ok {
+		return nil, nil
+	}
+	return inner.ListSnapshots(ctx, sandboxID)
+}
+
+func startSandboxSpan(
+	ctx context.Context,
+	name string,
+	input, extraMeta map[string]interface{},
+) (context.Context, *langfuse.Span) {
+	return langfuse.GetManager().StartSpan(ctx, langfuse.SpanOptions{
+		Name:     name,
+		Input:    input,
+		Metadata: extraMeta,
+	})
+}
+
+func sandboxHandleMeta(handle RemoteSandboxHandle) map[string]interface{} {
+	if handle == nil {
+		return nil
+	}
+	return map[string]interface{}{
+		"sandbox_id": handle.ID(),
+		"provider":   string(handle.Provider()),
+	}
+}
+
+func sandboxHandleOut(handle RemoteSandboxHandle) map[string]interface{} {
+	if handle == nil {
+		return nil
+	}
+	return map[string]interface{}{"sandbox_id": handle.ID()}
+}
+
+func truncateSandboxPreview(s string) string {
+	if s == "" || utf8.RuneCountInString(s) <= sandboxSpanPreviewRunes {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:sandboxSpanPreviewRunes]) + "…"
+}
+
+var (
+	_ RemoteSandboxClient   = (*langfuseRemoteClient)(nil)
+	_ RemoteSnapshotManager = (*langfuseSnapshotClient)(nil)
+)

--- a/internal/sandbox/langfuse.go
+++ b/internal/sandbox/langfuse.go
@@ -215,8 +215,22 @@ func (c *langfuseSnapshotClient) DeleteSnapshot(ctx context.Context, snapshotID 
 		"snapshot_id": snapshotID,
 	}, nil)
 	err := inner.DeleteSnapshot(ctx, snapshotID)
-	span.Finish(nil, nil, err)
+	out, spanErr := snapshotDeleteSpanResult(err)
+	span.Finish(out, nil, spanErr)
 	return err
+}
+
+// snapshotDeleteSpanResult keeps an in-use Conflict off the ERROR status.
+// Session sandboxes pause against the template they booted from, so the skill
+// reaper hitting this every few minutes is expected retry, not a fault.
+func snapshotDeleteSpanResult(err error) (map[string]interface{}, error) {
+	if !IsRemoteConflict(err) {
+		return nil, err
+	}
+	return map[string]interface{}{
+		"deferred": true,
+		"reason":   "in_use",
+	}, nil
 }
 
 func (c *langfuseSnapshotClient) ListSnapshots(

--- a/internal/sandbox/langfuse_test.go
+++ b/internal/sandbox/langfuse_test.go
@@ -1,0 +1,63 @@
+package sandbox
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapLangfuseRemoteClientPreservesSnapshotCapability(t *testing.T) {
+	inner := newFakeRemoteClient(SandboxTypeCube)
+	inner.capabilities.SupportsSnapshots = true
+
+	wrapped := wrapLangfuseRemoteClient(inner)
+	mgr, ok := SnapshotManagerFrom(wrapped)
+	require.True(t, ok, "wrapping must not hide RemoteSnapshotManager from SnapshotManagerFrom")
+	require.NotNil(t, mgr)
+
+	ref, err := mgr.CreateSnapshot(context.Background(), "sb-1", "snap-1")
+	require.NoError(t, err)
+	require.NotEmpty(t, ref.ID)
+}
+
+func TestWrapLangfuseRemoteClientDoesNotInventSnapshotSupport(t *testing.T) {
+	inner := &noSnapshotClient{}
+	wrapped := wrapLangfuseRemoteClient(inner)
+	mgr, ok := SnapshotManagerFrom(wrapped)
+	require.False(t, ok)
+	require.Nil(t, mgr)
+}
+
+func TestWrapLangfuseRemoteClientIdempotent(t *testing.T) {
+	inner := newFakeRemoteClient(SandboxTypeDocker)
+	once := wrapLangfuseRemoteClient(inner)
+	twice := wrapLangfuseRemoteClient(once)
+	require.Equal(t, once, twice)
+}
+
+func TestWrapLangfuseRemoteClientExecForwards(t *testing.T) {
+	inner := newFakeRemoteClient(SandboxTypeDocker)
+	handle, err := inner.Create(context.Background(), RemoteCreateRequest{TemplateID: "tpl"})
+	require.NoError(t, err)
+
+	wrapped := wrapLangfuseRemoteClient(inner)
+	result, err := wrapped.Exec(context.Background(), handle, RemoteExecRequest{
+		Command: "echo hi",
+		Shell:   true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, inner.execRequests, 1)
+	require.Equal(t, "echo hi", inner.execRequests[0].Command)
+}
+
+func TestTruncateSandboxPreview(t *testing.T) {
+	require.Equal(t, "short", truncateSandboxPreview("short"))
+	long := strings.Repeat("x", sandboxSpanPreviewRunes+8)
+	got := truncateSandboxPreview(long)
+	require.True(t, strings.HasSuffix(got, "…"))
+	require.Equal(t, sandboxSpanPreviewRunes+1, utf8.RuneCountInString(got))
+}

--- a/internal/sandbox/langfuse_test.go
+++ b/internal/sandbox/langfuse_test.go
@@ -61,3 +61,18 @@ func TestTruncateSandboxPreview(t *testing.T) {
 	require.True(t, strings.HasSuffix(got, "…"))
 	require.Equal(t, sandboxSpanPreviewRunes+1, utf8.RuneCountInString(got))
 }
+
+func TestSnapshotDeleteSpanResultDefersConflict(t *testing.T) {
+	out, spanErr := snapshotDeleteSpanResult(NewRemoteError(
+		SandboxTypeE2B, "DeleteSnapshot", RemoteErrorKindConflict,
+		"paused sandboxes using it", nil,
+	))
+	require.NoError(t, spanErr, "in-use must not mark the Langfuse span ERROR")
+	require.Equal(t, true, out["deferred"])
+	require.Equal(t, "in_use", out["reason"])
+
+	boom := NewRemoteError(SandboxTypeE2B, "DeleteSnapshot", RemoteErrorKindInternal, "boom", nil)
+	out, spanErr = snapshotDeleteSpanResult(boom)
+	require.Equal(t, boom, spanErr)
+	require.Nil(t, out)
+}

--- a/internal/sandbox/remote_errors.go
+++ b/internal/sandbox/remote_errors.go
@@ -184,6 +184,37 @@ func IsRemoteInvalidRequest(err error) bool {
 	return remoteKind(err) == RemoteErrorKindInvalidRequest
 }
 
+// IsRemoteConflict reports whether the provider refused the call because the
+// resource is busy (concurrent mutation, snapshot still referenced, …).
+func IsRemoteConflict(err error) bool {
+	return remoteKind(err) == RemoteErrorKindConflict
+}
+
+// snapshotDeleteKind reclassifies a snapshot/template delete that failed
+// because sandboxes still reference it. E2B returns that as HTTP 400
+// invalid_request; it is Conflict: the caller did nothing wrong and should
+// retry after those sandboxes (typically paused) go away.
+func snapshotDeleteKind(op string, kind RemoteErrorKind, message string) RemoteErrorKind {
+	if op != "DeleteSnapshot" && op != "DeleteTemplate" {
+		return kind
+	}
+	if kind == RemoteErrorKindConflict || snapshotInUseBySandboxes(message) {
+		return RemoteErrorKindConflict
+	}
+	return kind
+}
+
+func snapshotInUseBySandboxes(message string) bool {
+	msg := strings.ToLower(message)
+	if strings.Contains(msg, "paused sandbox") {
+		return true
+	}
+	if strings.Contains(msg, "sandboxes using") {
+		return true
+	}
+	return strings.Contains(msg, "cannot delete template") && strings.Contains(msg, "using it")
+}
+
 // IsRemoteDirAlreadyExists reports whether MakeDir failed because the
 // directory is already present. Cube's envd MakeDir is not mkdir -p: a
 // directory created by a previous call (or by a shell `mkdir -p` in

--- a/internal/sandbox/remote_errors_test.go
+++ b/internal/sandbox/remote_errors_test.go
@@ -177,3 +177,88 @@ func TestIsRemoteDirAlreadyExists(t *testing.T) {
 		})
 	}
 }
+
+func TestIsRemoteConflict(t *testing.T) {
+	t.Parallel()
+
+	if IsRemoteConflict(nil) {
+		t.Fatal("nil is not a conflict")
+	}
+	conflict := NewRemoteError(SandboxTypeE2B, "DeleteSnapshot", RemoteErrorKindConflict, "busy", nil)
+	if !IsRemoteConflict(conflict) {
+		t.Fatal("Conflict kind must match")
+	}
+	invalid := NewRemoteError(
+		SandboxTypeE2B, "DeleteSnapshot", RemoteErrorKindInvalidRequest, "bad id", nil,
+	)
+	if IsRemoteConflict(invalid) {
+		t.Fatal("InvalidRequest must not match")
+	}
+}
+
+func TestSnapshotDeleteKindPromotesInUseToConflict(t *testing.T) {
+	t.Parallel()
+
+	inUse := "cannot delete template 'upfvuzpq0q6foo1mkpbkl' because there are paused sandboxes using it"
+	jsonBody := `e2b: status 400: {"code":400,"message":"` + inUse + `"}`
+
+	tests := []struct {
+		name string
+		op   string
+		kind RemoteErrorKind
+		msg  string
+		want RemoteErrorKind
+	}{
+		{
+			name: "e2b paused sandboxes 400",
+			op:   "DeleteSnapshot",
+			kind: RemoteErrorKindInvalidRequest,
+			msg:  inUse,
+			want: RemoteErrorKindConflict,
+		},
+		{
+			name: "json-wrapped e2b 400",
+			op:   "DeleteSnapshot",
+			kind: RemoteErrorKindInvalidRequest,
+			msg:  jsonBody,
+			want: RemoteErrorKindConflict,
+		},
+		{
+			name: "cube delete template",
+			op:   "DeleteTemplate",
+			kind: RemoteErrorKindInvalidRequest,
+			msg:  "cannot delete template x because there are sandboxes using it",
+			want: RemoteErrorKindConflict,
+		},
+		{
+			name: "already conflict stays conflict",
+			op:   "DeleteSnapshot",
+			kind: RemoteErrorKindConflict,
+			msg:  "image is in use",
+			want: RemoteErrorKindConflict,
+		},
+		{
+			name: "generic 400 stays invalid",
+			op:   "DeleteSnapshot",
+			kind: RemoteErrorKindInvalidRequest,
+			msg:  "invalid snapshot id",
+			want: RemoteErrorKindInvalidRequest,
+		},
+		{
+			name: "other ops are unchanged",
+			op:   "Create",
+			kind: RemoteErrorKindInvalidRequest,
+			msg:  inUse,
+			want: RemoteErrorKindInvalidRequest,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := snapshotDeleteKind(tt.op, tt.kind, tt.msg); got != tt.want {
+				t.Fatalf("snapshotDeleteKind() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sandbox/session_manager.go
+++ b/internal/sandbox/session_manager.go
@@ -32,6 +32,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Tencent/WeKnora/internal/tracing/langfuse"
 	"github.com/Tencent/WeKnora/internal/types"
 )
 
@@ -170,8 +171,10 @@ func NewSessionBoundManager(deps SessionBoundManagerConfig) (*SessionBoundManage
 		)
 	}
 
+	client := wrapLangfuseRemoteClient(deps.Client)
+
 	lifecycle, err := newRemoteSessionLifecycle(
-		deps.Client,
+		client,
 		deps.Store,
 		deps.Checker,
 		createRequest,
@@ -185,11 +188,11 @@ func NewSessionBoundManager(deps SessionBoundManagerConfig) (*SessionBoundManage
 	m := &SessionBoundManager{
 		config:     cfg,
 		validator:  NewScriptValidator(),
-		client:     deps.Client,
+		client:     client,
 		bindings:   deps.Store,
 		checker:    deps.Checker,
 		lifecycle:  lifecycle,
-		ephemeral:  NewRemoteSandbox(deps.Client, createRequest),
+		ephemeral:  NewRemoteSandbox(client, createRequest),
 		activeType: provider,
 	}
 
@@ -301,12 +304,22 @@ func (m *SessionBoundManager) ensureSessionWorkspaceDirs(
 		return
 	}
 	execUser := DefaultSandboxExecUser
+	ctx, span := langfuse.GetManager().StartSpan(ctx, langfuse.SpanOptions{
+		Name: "sandbox.ensure_workspace",
+		Input: map[string]interface{}{
+			"input_dir":  SessionInputRoot,
+			"output_dir": outputDir,
+			"user":       execUser,
+		},
+		Metadata: sandboxHandleMeta(handle),
+	})
 	result, err := m.client.Exec(ctx, handle, RemoteExecRequest{
 		Shell:   true,
 		Command: workspaceBootstrapCommand(SessionInputRoot, outputDir),
 		User:    execUser,
 		Timeout: sessionArtifactDirBootstrapTimeout,
 	})
+	span.Finish(nil, nil, err)
 	switch {
 	case err != nil:
 		log.Printf(

--- a/internal/tracing/langfuse/context.go
+++ b/internal/tracing/langfuse/context.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/Tencent/WeKnora/internal/types"
+	"go.opentelemetry.io/otel/propagation"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // traceCtxKey is the exported context key defined in types/const.go. It lives
@@ -42,4 +44,42 @@ func traceFromCtx(ctx context.Context) (*Trace, bool) {
 // handlers that want to set the trace input/output on the active trace.
 func TraceFromContext(ctx context.Context) (*Trace, bool) {
 	return traceFromCtx(ctx)
+}
+
+// TraceparentFromContext returns the W3C traceparent for the active span, or
+// empty when Langfuse is disabled or ctx carries no span. Used to stamp the
+// originating chat trace onto derived work (follow-up suggestions) that may
+// run after the HTTP handler returns, or on a later request.
+func TraceparentFromContext(ctx context.Context) string {
+	mgr := GetManager()
+	if ctx == nil || !mgr.Enabled() {
+		return ""
+	}
+	c := propagation.MapCarrier{}
+	propagator.Inject(ctx, c)
+	return c["traceparent"]
+}
+
+// AttachTraceparent resumes the originating trace from a W3C traceparent
+// previously captured by TraceparentFromContext / InjectTracing. When ctx
+// already has a *Trace (same-request background work), it is left unchanged
+// so we do not replace a live local parent with a remote one.
+//
+// This is the in-process counterpart of AsynqMiddleware's extract path: a
+// later HTTP request (e.g. POST .../suggestions) has no GinMiddleware trace,
+// and without this StartGeneration would auto-create an orphan root named
+// after the LLM call.
+func AttachTraceparent(ctx context.Context, traceparent string) context.Context {
+	mgr := GetManager()
+	if ctx == nil || traceparent == "" || !mgr.Enabled() {
+		return ctx
+	}
+	if _, ok := traceFromCtx(ctx); ok {
+		return ctx
+	}
+	ctx = propagator.Extract(ctx, propagation.MapCarrier{"traceparent": traceparent})
+	if sc := oteltrace.SpanContextFromContext(ctx); sc.IsValid() {
+		ctx = withTrace(ctx, &Trace{ID: sc.TraceID().String(), manager: mgr})
+	}
+	return ctx
 }

--- a/internal/tracing/langfuse/tracer_test.go
+++ b/internal/tracing/langfuse/tracer_test.go
@@ -311,3 +311,83 @@ func TestTraceparentPropagation(t *testing.T) {
 	}
 	t.Fatal("weknora-root span not exported")
 }
+
+// TestAttachTraceparent_FollowUpJoinsOriginatingTrace is the follow-up
+// suggestion regression: generation often runs on a later HTTP request
+// (POST .../suggestions) after the chat handler has already ended its root
+// span. Without AttachTraceparent, StartGeneration auto-opens an orphan
+// root named after the LLM call. With it, the follow-up span and generation
+// inherit the originating chat trace id.
+func TestAttachTraceparent_FollowUpJoinsOriginatingTrace(t *testing.T) {
+	m, exp := newTestManager(t)
+
+	httpCtx, httpTrace := m.StartTrace(context.Background(), TraceOptions{Name: "POST /api/v1/agent-chat/:session_id"})
+	traceparent := TraceparentFromContext(httpCtx)
+	if traceparent == "" {
+		t.Fatal("expected a traceparent on the HTTP trace")
+	}
+	httpTrace.Finish(nil, nil)
+
+	// Separate request: no *Trace, no OTel span — this is POST /suggestions.
+	followCtx := AttachTraceparent(context.Background(), traceparent)
+	followCtx, span := m.StartSpan(followCtx, SpanOptions{Name: "follow_up.suggestions"})
+	_, gen := m.StartGeneration(followCtx, GenerationOptions{Name: "chat.completion", Model: "m"})
+	gen.Finish("qs", nil, nil)
+	span.Finish(nil, nil, nil)
+
+	var followSpan, generation tracetest.SpanStub
+	var autoRoot bool
+	for _, s := range exp.GetSpans() {
+		switch {
+		case s.Name == "follow_up.suggestions" && spanType(s) == obsTypeSpan:
+			followSpan = s
+		case s.Name == "chat.completion" && spanType(s) == obsTypeGeneration:
+			generation = s
+		case s.Name == "chat.completion" && spanType(s) == obsTypeTrace:
+			autoRoot = true
+		}
+	}
+	if followSpan.Name == "" {
+		t.Fatal("follow_up.suggestions span not exported")
+	}
+	if generation.Name == "" {
+		t.Fatal("chat.completion generation not exported")
+	}
+	if followSpan.SpanContext.TraceID().String() != httpTrace.ID {
+		t.Errorf("follow-up span trace id = %s, want HTTP %s", followSpan.SpanContext.TraceID(), httpTrace.ID)
+	}
+	if generation.SpanContext.TraceID().String() != httpTrace.ID {
+		t.Errorf("generation trace id = %s, want HTTP %s", generation.SpanContext.TraceID(), httpTrace.ID)
+	}
+	if autoRoot {
+		t.Error("StartGeneration opened an orphan chat.completion root; traceparent was not attached")
+	}
+}
+
+// TestAttachTraceparent_LeavesExistingTrace ensures same-request background
+// work (completeAssistantMessage) is not re-parented onto a stale remote
+// span when ctx already carries a live *Trace.
+func TestAttachTraceparent_LeavesExistingTrace(t *testing.T) {
+	m, exp := newTestManager(t)
+
+	otherCtx, other := m.StartTrace(context.Background(), TraceOptions{Name: "other"})
+	otherParent := TraceparentFromContext(otherCtx)
+	other.Finish(nil, nil)
+
+	ctx, live := m.StartTrace(context.Background(), TraceOptions{Name: "live"})
+	ctx = AttachTraceparent(ctx, otherParent)
+	_, gen := m.StartGeneration(ctx, GenerationOptions{Name: "chat.completion", Model: "m"})
+	gen.Finish("out", nil, nil)
+	live.Finish(nil, nil)
+
+	for _, s := range exp.GetSpans() {
+		if spanType(s) != obsTypeGeneration {
+			continue
+		}
+		if s.SpanContext.TraceID().String() != live.ID {
+			t.Errorf("generation joined foreign trace %s, want live %s", s.SpanContext.TraceID(), live.ID)
+		}
+		return
+	}
+	t.Fatal("generation span not exported")
+}

--- a/internal/types/message.go
+++ b/internal/types/message.go
@@ -337,6 +337,12 @@ type MessageExecutionContext struct {
 	WebSearchEnabled      bool                      `json:"web_search_enabled"`
 	Locale                string                    `json:"locale,omitempty"`
 	SuggestionAttribution *SuggestionAttribution    `json:"suggestion_attribution,omitempty"`
+	// LangfuseTraceparent is the W3C traceparent of the originating chat
+	// request. Follow-up suggestion generation often runs on a later HTTP
+	// call (or after the SSE handler has already finished the root span);
+	// without this the LLM wrapper auto-creates an orphan chat.completion
+	// trace instead of nesting under the agent turn.
+	LangfuseTraceparent string `json:"langfuse_traceparent,omitempty"`
 }
 
 func (c MessageExecutionContext) Value() (driver.Value, error) {


### PR DESCRIPTION
## Summary

- Follow-up generation (`POST /sessions/.../suggestions`) often races ahead of the SSE complete path and has no Langfuse parent, so `chat.completion` auto-creates an orphan root. Stamp the originating W3C `traceparent` on the assistant message and resume it before the extra LLM call (`follow_up.suggestions`).
- Docker Engine HTTP (unix socket) was parented to whatever `agent.round` was still recording. Wrap `RemoteSandboxClient` with product-level `sandbox.*` spans (`exec`, `connect`, `create`, file ops, snapshots), span `sandbox.ensure_workspace` and `sandbox.collect_artifacts`, and clone idle-sweep work **without** the chat trace so List/Stat/Delete no longer leak between rounds.

## Test plan

- [ ] Ask a follow-up question in a traced chat; the `chat.completion` for suggestions should nest under the same request (not a sibling root).
- [ ] Run a `shell_exec` tool call; Docker HTTP should sit under `sandbox.connect` / `sandbox.exec` / `sandbox.ensure_workspace`, not float as siblings of `agent.round`.
- [ ] Confirm idle-sweep List/Stat/Delete after Create/Connect do **not** appear on the chat tree between rounds.
- [ ] Confirm turn-end artifact collection is under `sandbox.collect_artifacts`.
- [ ] `go test` for `internal/tracing/langfuse`, `internal/sandbox`, `internal/logger`, `internal/application/service`, `internal/handler/session`.