### PR TITLE
fix(agent): defer terminal event until empty-response retries finish

### DIFF
--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -634,9 +634,21 @@ func (e *AgentEngine) runReActIteration(
 			// Retries exhausted — use fallback message rather than empty answer
 			logger.Warnf(ctx, "[Agent][Round-%d] Empty content after %d retries - using fallback",
 				round, maxEmptyResponseRetries)
-			state.FinalAnswer = "I'm sorry, I was unable to generate a response. Please try again."
+			fallback := "I'm sorry, I was unable to generate a response. Please try again."
+			state.FinalAnswer = fallback
 			state.IsComplete = true
 			state.RoundSteps = append(state.RoundSteps, verdict.step)
+			if err := e.eventBus.Emit(ctx, event.Event{
+				ID:        generateEventID("answer"),
+				Type:      event.EventAgentFinalAnswer,
+				SessionID: sessionID,
+				Data: event.AgentFinalAnswerData{
+					Content: fallback,
+					Done:    true,
+				},
+			}); err != nil {
+				logger.Warnf(ctx, "[Agent][Round-%d] Failed to emit empty-response fallback: %v", round, err)
+			}
 			return iterOutcomeBreak, nil
 		}
 		state.FinalAnswer = verdict.finalAnswer

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -317,6 +317,17 @@ func TestExecuteLoop_EmptyContentWithStop_ShouldNotCompleteWithEmpty(t *testing.
 	}
 
 	engine := newTestEngine(t, mock)
+	var answerContent string
+	var doneCount int
+	engine.eventBus.On(event.EventAgentFinalAnswer, func(_ context.Context, evt event.Event) error {
+		if data, ok := evt.Data.(event.AgentFinalAnswerData); ok {
+			answerContent += data.Content
+			if data.Done {
+				doneCount++
+			}
+		}
+		return nil
+	})
 	state := &types.AgentState{}
 	ctx := context.Background()
 
@@ -327,6 +338,8 @@ func TestExecuteLoop_EmptyContentWithStop_ShouldNotCompleteWithEmpty(t *testing.
 	assert.NotEmpty(t, state.FinalAnswer,
 		"BUG: FinalAnswer is empty when LLM returns empty content with stop. "+
 			"analyzeResponse() should not allow empty content to be accepted as final answer.")
+	assert.Equal(t, state.FinalAnswer, answerContent)
+	assert.Equal(t, 1, doneCount, "empty retry attempts must not emit terminal answer events")
 }
 
 // ---------------------------------------------------------------------------
@@ -370,6 +383,17 @@ func TestExecuteLoop_EmptyThenNonEmpty_ShouldRetryAndComplete(t *testing.T) {
 	}
 
 	engine := newTestEngine(t, mock)
+	var answerContent string
+	var doneCount int
+	engine.eventBus.On(event.EventAgentFinalAnswer, func(_ context.Context, evt event.Event) error {
+		if data, ok := evt.Data.(event.AgentFinalAnswerData); ok {
+			answerContent += data.Content
+			if data.Done {
+				doneCount++
+			}
+		}
+		return nil
+	})
 	state := &types.AgentState{}
 	ctx := context.Background()
 
@@ -378,6 +402,8 @@ func TestExecuteLoop_EmptyThenNonEmpty_ShouldRetryAndComplete(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, state.IsComplete)
 	assert.Equal(t, "Here is the answer.", state.FinalAnswer)
+	assert.Equal(t, state.FinalAnswer, answerContent)
+	assert.Equal(t, 1, doneCount, "the empty first attempt must not terminate downstream consumers")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/agent/observe.go
+++ b/internal/agent/observe.go
@@ -281,6 +281,17 @@ func (e *AgentEngine) analyzeResponse(
 			"answer_len": len(response.Content),
 		})
 
+		// An empty natural stop is not a terminal answer. The caller retries this
+		// response with a nudge, so emitting Done here would make downstream
+		// consumers (notably IM) finalize and cancel the still-running retry.
+		if response.Content == "" {
+			return responseVerdict{
+				isDone:       true,
+				emptyContent: true,
+				step:         step,
+			}
+		}
+
 		// Emit the final answer. The answer text reaches the UI by one of two
 		// paths:
 		//   (a) Already streamed live during the think phase — the common case
@@ -320,10 +331,9 @@ func (e *AgentEngine) analyzeResponse(
 		})
 
 		return responseVerdict{
-			isDone:       true,
-			finalAnswer:  response.Content,
-			emptyContent: response.Content == "",
-			step:         step,
+			isDone:      true,
+			finalAnswer: response.Content,
+			step:        step,
 		}
 	}
 


### PR DESCRIPTION
## Description

An empty natural-stop response is retryable, but `analyzeResponse` currently emits `EventAgentFinalAnswer{Done:true}` before the engine evaluates `emptyContent` and starts that retry. Downstream consumers can therefore terminate while the Agent is still running.

This change:

- returns the empty-response verdict before emitting answer or terminal events;
- emits the selected fallback as the single terminal answer when empty retries are exhausted;
- extends the existing empty-response tests to verify collected answer content and exactly one terminal event.

Non-empty answer streaming and the existing retry count/prompt are unchanged.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2906

Related to #818 / #819 and #2339, but fixes a distinct terminal-event ordering race.

## Testing

Passed on upstream `main` base `af0aeb7cc284d76e2c59b4eaf686132e0d5b8caa`:

- `make fmt` (no diff)
- `git diff --check upstream/main...HEAD`
- `go test ./internal/agent -count=1`
- `go test -race ./internal/agent -count=1`
- `go vet ./internal/agent`
- `golangci-lint run --new-from-rev=upstream/main ./internal/agent/...` (`0 issues`)
- `go build ./cmd/server`

Full `go test ./...` was run. It is blocked by environment-dependent SSRF tests because this environment resolves example domains (`example.com`, `api.notion.com`, `example.openai.azure.com`, and similar) into the restricted benchmark range `198.18.0.0/15`. Failures occur in unrelated packages including `internal/application/service`, `internal/application/service/file`, `internal/datasource/connector/notion`, `internal/models/chat`, `internal/models/embedding`, and `internal/utils`.

Full `make lint` was also checked during this contribution and reports 263 pre-existing repository-wide findings. The diff-scoped lint command above passes with zero findings.

## Checklist

- [x] `git diff --check upstream/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, and unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation — not applicable; no user-facing configuration or API changed
- [x] Breaking changes are clearly called out — none

## Screenshots / Recordings

Not applicable; this fixes backend event ordering.

