### PR TITLE
fix: support legacy POST-init MCP SSE endpoints

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -68,6 +68,11 @@ type mcpGoClient struct {
 	service     *types.MCPService
 	client      *client.Client
 	oauth       *oauthRuntime
+	httpClient  *http.Client
+	headers     map[string]string
+	oauthConfig transport.OAuthConfig
+	useOAuth    bool
+	legacySSE   bool
 	connected   bool
 	initialized bool
 }
@@ -229,8 +234,12 @@ func NewMCPClient(config *ClientConfig) (MCPClient, error) {
 	}
 
 	instance := &mcpGoClient{
-		service: config.Service,
-		client:  mcpClient,
+		service:     config.Service,
+		client:      mcpClient,
+		httpClient:  httpClient,
+		headers:     headers,
+		oauthConfig: oauthConfig,
+		useOAuth:    useOAuth,
 	}
 	if useOAuth {
 		instance.oauth = newOAuthRuntime(
@@ -387,9 +396,14 @@ func (c *mcpGoClient) Initialize(ctx context.Context) (*InitializeResult, error)
 		},
 	}
 
-	result, err := oauthCall(ctx, c, func() (*mcp.InitializeResult, error) {
-		return c.client.Initialize(ctx, req)
-	})
+	result, err := c.initializeWithOAuth(ctx, req)
+	if err != nil && c.service.TransportType == types.MCPTransportHTTPStreamable && !c.legacySSE && errors.Is(err, transport.ErrLegacySSEServer) {
+		logger.GetLogger(ctx).Warnf("MCP streamable HTTP endpoint rejected initialize POST; retrying with legacy POST-init SSE: %s", *c.service.URL)
+		if fallbackErr := c.switchToLegacySSE(ctx); fallbackErr != nil {
+			return nil, fmt.Errorf("failed to initialize with legacy SSE fallback: %w", fallbackErr)
+		}
+		result, err = c.initializeWithOAuth(ctx, req)
+	}
 	if err != nil {
 		c.checkErrorAndDisconnectIfNeeded(err)
 		if oerr := asOAuthRequired(err); oerr != nil {
@@ -409,6 +423,44 @@ func (c *mcpGoClient) Initialize(ctx context.Context) (*InitializeResult, error)
 			Description: result.ServerInfo.Description,
 		},
 	}, nil
+}
+
+func (c *mcpGoClient) initializeWithOAuth(ctx context.Context, req mcp.InitializeRequest) (*mcp.InitializeResult, error) {
+	return oauthCall(ctx, c, func() (*mcp.InitializeResult, error) {
+		return c.client.Initialize(ctx, req)
+	})
+}
+
+func (c *mcpGoClient) switchToLegacySSE(ctx context.Context) error {
+	if c.legacySSE {
+		return nil
+	}
+	if c.service.URL == nil || *c.service.URL == "" {
+		return errors.New("URL is required for legacy SSE transport")
+	}
+	legacyTransport, err := newLegacySSETransport(
+		*c.service.URL,
+		c.httpClient,
+		c.headers,
+		c.oauthConfig,
+		c.useOAuth,
+	)
+	if err != nil {
+		return err
+	}
+	legacyClient := client.NewClient(legacyTransport)
+	if err := legacyClient.Start(ctx); err != nil {
+		_ = legacyClient.Close()
+		return fmt.Errorf("failed to start legacy SSE transport: %w", err)
+	}
+	legacyClient.OnConnectionLost(c.onConnectionLost)
+	oldClient := c.client
+	c.client = legacyClient
+	c.legacySSE = true
+	if oldClient != nil {
+		_ = oldClient.Close()
+	}
+	return nil
 }
 
 // ListTools retrieves the list of available tools

--- a/internal/mcp/legacy_sse.go
+++ b/internal/mcp/legacy_sse.go
@@ -1,0 +1,304 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/mark3labs/mcp-go/client/transport"
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+// legacySSETransport implements the pre-streamable HTTP MCP dialect used by
+// servers that accept every JSON-RPC request as a POST to the configured URL
+// and return the response as an SSE event. Unlike mcp-go's regular SSE
+// transport, this dialect does not require a preliminary GET /sse endpoint.
+type legacySSETransport struct {
+	endpoint   string
+	httpClient *http.Client
+	headers    map[string]string
+
+	oauthHandler *transport.OAuthHandler
+
+	started atomic.Bool
+	closed  atomic.Bool
+
+	protocolVersion atomic.Value
+
+	notificationMu      sync.RWMutex
+	notificationHandler func(mcpgo.JSONRPCNotification)
+
+	connectionLostMu sync.RWMutex
+	connectionLost   func(error)
+}
+
+func newLegacySSETransport(endpoint string, httpClient *http.Client, headers map[string]string, oauthConfig transport.OAuthConfig, useOAuth bool) (*legacySSETransport, error) {
+	if strings.TrimSpace(endpoint) == "" {
+		return nil, errors.New("legacy SSE endpoint is required")
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	transportClient := &legacySSETransport{
+		endpoint:   endpoint,
+		httpClient: httpClient,
+		headers:    make(map[string]string, len(headers)),
+	}
+	for key, value := range headers {
+		transportClient.headers[key] = value
+	}
+	if useOAuth {
+		oauthHandler := transport.NewOAuthHandler(oauthConfig)
+		oauthHandler.SetBaseURL(endpoint)
+		transportClient.oauthHandler = oauthHandler
+	}
+	return transportClient, nil
+}
+
+func (t *legacySSETransport) Start(context.Context) error {
+	if t.closed.Load() {
+		return errors.New("legacy SSE transport has been closed")
+	}
+	t.started.Store(true)
+	return nil
+}
+
+func (t *legacySSETransport) SendRequest(ctx context.Context, request transport.JSONRPCRequest) (*transport.JSONRPCResponse, error) {
+	if err := t.ensureStarted(); err != nil {
+		return nil, err
+	}
+
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal legacy SSE request: %w", err)
+	}
+	response, err := t.doPost(ctx, payload, request.Header)
+	if err != nil {
+		return nil, err
+	}
+
+	return t.decodeResponse(response, request.ID)
+}
+
+func (t *legacySSETransport) SendNotification(ctx context.Context, notification mcpgo.JSONRPCNotification) error {
+	if err := t.ensureStarted(); err != nil {
+		return err
+	}
+
+	payload, err := json.Marshal(notification)
+	if err != nil {
+		return fmt.Errorf("failed to marshal legacy SSE notification: %w", err)
+	}
+	response, err := t.doPost(ctx, payload, nil)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, response.Body)
+	return nil
+}
+
+func (t *legacySSETransport) SetNotificationHandler(handler func(mcpgo.JSONRPCNotification)) {
+	t.notificationMu.Lock()
+	defer t.notificationMu.Unlock()
+	t.notificationHandler = handler
+}
+
+func (t *legacySSETransport) SetProtocolVersion(version string) {
+	t.protocolVersion.Store(version)
+}
+
+func (t *legacySSETransport) SetConnectionLostHandler(handler func(error)) {
+	t.connectionLostMu.Lock()
+	defer t.connectionLostMu.Unlock()
+	t.connectionLost = handler
+}
+
+func (t *legacySSETransport) Close() error {
+	if t.closed.Swap(true) {
+		return nil
+	}
+	t.started.Store(false)
+	return nil
+}
+
+func (t *legacySSETransport) GetSessionId() string { return "" }
+
+func (t *legacySSETransport) ensureStarted() error {
+	switch {
+	case t.closed.Load():
+		return errors.New("legacy SSE transport has been closed")
+	case !t.started.Load():
+		return errors.New("legacy SSE transport has not been started")
+	default:
+		return nil
+	}
+}
+
+func (t *legacySSETransport) doPost(ctx context.Context, payload []byte, requestHeaders http.Header) (*http.Response, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, t.endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create legacy SSE request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	if version := t.protocolVersion.Load(); version != nil {
+		if value, ok := version.(string); ok && value != "" {
+			request.Header.Set(transport.HeaderKeyProtocolVersion, value)
+		}
+	}
+	for key, value := range t.headers {
+		request.Header.Set(key, value)
+	}
+	for key, values := range requestHeaders {
+		if _, exists := request.Header[key]; exists {
+			continue
+		}
+		for _, value := range values {
+			request.Header.Add(key, value)
+		}
+	}
+	if t.oauthHandler != nil {
+		authorization, err := t.oauthHandler.GetAuthorizationHeader(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get OAuth authorization header: %w", err)
+		}
+		request.Header.Set("Authorization", authorization)
+	}
+
+	response, err := t.httpClient.Do(request)
+	if err != nil {
+		t.notifyConnectionLost(err)
+		return nil, fmt.Errorf("failed to send legacy SSE request: %w", err)
+	}
+	if response.StatusCode == http.StatusUnauthorized {
+		defer response.Body.Close()
+		if t.oauthHandler != nil {
+			t.oauthHandler.HandleUnauthorizedResponse(response)
+			return nil, &transport.OAuthAuthorizationRequiredError{
+				Handler: t.oauthHandler,
+			}
+		}
+		return nil, &transport.AuthorizationRequiredError{}
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		defer response.Body.Close()
+		body, _ := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+		return nil, fmt.Errorf("legacy SSE request failed with status %d: %s", response.StatusCode, body)
+	}
+	return response, nil
+}
+
+func (t *legacySSETransport) decodeResponse(response *http.Response, expectedID mcpgo.RequestId) (*transport.JSONRPCResponse, error) {
+	defer response.Body.Close()
+
+	contentType, _, _ := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if contentType != "text/event-stream" {
+		body, err := io.ReadAll(io.LimitReader(response.Body, 4<<20))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read legacy SSE response: %w", err)
+		}
+		return unmarshalLegacySSEResponse(body)
+	}
+
+	return t.readSSEResponse(response.Body, expectedID)
+}
+
+func (t *legacySSETransport) readSSEResponse(reader io.Reader, expectedID mcpgo.RequestId) (*transport.JSONRPCResponse, error) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 4096), 4<<20)
+
+	var dataLines []string
+	var rawLines []string
+	flushEvent := func() (*transport.JSONRPCResponse, error) {
+		if len(dataLines) == 0 {
+			return nil, nil
+		}
+		payload := []byte(strings.Join(dataLines, "\n"))
+		response, err := unmarshalLegacySSEResponse(payload)
+		if err != nil {
+			return nil, err
+		}
+		if response.ID.IsNil() {
+			var notification mcpgo.JSONRPCNotification
+			if err := json.Unmarshal(payload, &notification); err == nil {
+				t.notifyNotification(notification)
+			}
+			return nil, nil
+		}
+		if response.ID.String() != expectedID.String() {
+			return nil, nil
+		}
+		return response, nil
+	}
+
+	for scanner.Scan() {
+		line := strings.TrimSuffix(scanner.Text(), "\r")
+		rawLines = append(rawLines, line)
+		if line == "" {
+			response, err := flushEvent()
+			if err != nil {
+				return nil, err
+			}
+			if response != nil {
+				return response, nil
+			}
+			dataLines = nil
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		if data, ok := strings.CutPrefix(line, "data:"); ok {
+			dataLines = append(dataLines, strings.TrimPrefix(data, " "))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read legacy SSE response: %w", err)
+	}
+	if response, err := flushEvent(); err != nil || response != nil {
+		return response, err
+	}
+	if len(dataLines) == 0 && len(rawLines) > 0 {
+		if response, err := unmarshalLegacySSEResponse([]byte(strings.Join(rawLines, "\n"))); err == nil {
+			return response, nil
+		}
+	}
+	return nil, errors.New("legacy SSE response did not contain a JSON-RPC response")
+}
+
+func (t *legacySSETransport) notifyNotification(notification mcpgo.JSONRPCNotification) {
+	t.notificationMu.RLock()
+	handler := t.notificationHandler
+	t.notificationMu.RUnlock()
+	if handler != nil {
+		handler(notification)
+	}
+}
+
+func (t *legacySSETransport) notifyConnectionLost(err error) {
+	t.connectionLostMu.RLock()
+	handler := t.connectionLost
+	t.connectionLostMu.RUnlock()
+	if handler != nil {
+		handler(err)
+	}
+}
+
+func unmarshalLegacySSEResponse(body []byte) (*transport.JSONRPCResponse, error) {
+	var response transport.JSONRPCResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to decode legacy SSE JSON-RPC response: %w", err)
+	}
+	return &response, nil
+}

--- a/internal/mcp/legacy_sse_test.go
+++ b/internal/mcp/legacy_sse_test.go
@@ -1,0 +1,36 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/client/transport"
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLegacySSETransportSendsPostAndReadsEvent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\n\n")
+	}))
+	defer server.Close()
+
+	legacy, err := newLegacySSETransport(server.URL, server.Client(), nil, transport.OAuthConfig{}, false)
+	require.NoError(t, err)
+	require.NoError(t, legacy.Start(context.Background()))
+
+	response, err := legacy.SendRequest(context.Background(), transport.JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mcpgo.NewRequestId(int64(1)),
+		Method:  "initialize",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "1", response.ID.String())
+	require.JSONEq(t, `{"ok":true}`, string(response.Result))
+}

--- a/internal/mcp/legacy_sse_test.go
+++ b/internal/mcp/legacy_sse_test.go
@@ -31,6 +31,6 @@ func TestLegacySSETransportSendsPostAndReadsEvent(t *testing.T) {
 		Method:  "initialize",
 	})
 	require.NoError(t, err)
-	require.Equal(t, "1", response.ID.String())
+	require.Equal(t, int64(1), response.ID.Value())
 	require.JSONEq(t, `{"ok":true}`, string(response.Result))
 }


### PR DESCRIPTION
## Description

Some HTTP SSE MCP servers implement the legacy POST-init handshake: the endpoint accepts initialize via POST and streams JSON-RPC responses as SSE. Add a fallback transport for this protocol when streamable HTTP initialization returns ErrLegacySSEServer.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🧪 Test

## Related Issue
Fixes #1913

## Testing
- gofmt -l internal passed.
- git diff --check origin/main...HEAD passed.
- Added httptest coverage for POST initialization and SSE response decoding.
- `go test ./internal/mcp/legacy_sse.go ./internal/mcp/legacy_sse_test.go -run TestLegacySSETransportSendsPostAndReadsEvent -count=100` passed after correcting the assertion to inspect the numeric ID with `Value()`. The original assertion was reproduced failing locally before this change.
- go test ./internal/mcp -count=1 is blocked locally before package tests because CGO is disabled and pg_query.Parse/Deparse are unavailable; the machine also has no C compiler for CGO-enabled tests.
