### PR TITLE
fix: omit chat template kwargs for reasoning models

### DIFF
--- a/internal/models/chat/provider.go
+++ b/internal/models/chat/provider.go
@@ -163,6 +163,20 @@ type genericProvider struct{ baseProvider }
 func (genericProvider) Name() provider.ProviderName { return provider.ProviderGeneric }
 func (genericProvider) Thinking() ThinkingStrategy  { return chatTemplateKwargs{} }
 
+// genericOpenAIReasoningProvider handles OpenAI-compatible deployments of
+// GPT-5 and o-series models. These models reject the vLLM-specific
+// chat_template_kwargs field, even when the deployment is configured as the
+// generic provider.
+type genericOpenAIReasoningProvider struct{ baseProvider }
+
+func (genericOpenAIReasoningProvider) Name() provider.ProviderName { return provider.ProviderGeneric }
+func (genericOpenAIReasoningProvider) Matches(model string) bool {
+	return provider.IsOpenAIReasoningOrGPT5Model(model)
+}
+func (genericOpenAIReasoningProvider) ShapeRequest(req *openai.ChatCompletionRequest, _ *ChatOptions, _ bool) {
+	shapeOpenAIReasoning(req)
+}
+
 type nvidiaProvider struct{ baseProvider }
 
 func (nvidiaProvider) Name() provider.ProviderName { return provider.ProviderNvidia }
@@ -276,6 +290,7 @@ var providerRegistry = []providerAdapter{
 	qwenThinkingProvider{},
 	lkeapProvider{},
 	deepseekProvider{},
+	genericOpenAIReasoningProvider{},
 	genericProvider{},
 	geminiProvider{},
 	volcengineProvider{},

--- a/internal/models/chat/provider_test.go
+++ b/internal/models/chat/provider_test.go
@@ -26,6 +26,7 @@ func TestResolveProvider(t *testing.T) {
 		{"lkeap r1 falls back", provider.ProviderLKEAP, "deepseek-r1", baseProvider{}},
 		{"qwen thinking", provider.ProviderAliyun, "qwen3-32b", qwenThinkingProvider{}},
 		{"generic", provider.ProviderGeneric, "anything", genericProvider{}},
+		{"generic GPT-5 reasoning", provider.ProviderGeneric, "gpt-5.6-sol", genericOpenAIReasoningProvider{}},
 		{"gemini", provider.ProviderGemini, "gemini-3-flash-preview", geminiProvider{}},
 		{"nvidia", provider.ProviderNvidia, "anything", nvidiaProvider{}},
 		{"volcengine", provider.ProviderVolcengine, "doubao", volcengineProvider{}},
@@ -142,6 +143,21 @@ func TestBuildOutbound_Thinking(t *testing.T) {
 // to live inline in BuildChatCompletionRequest.
 func TestBuildOutbound_ShapeRequest(t *testing.T) {
 	msgs := []Message{{Role: "user", Content: "hi"}}
+
+	t.Run("generic GPT-5 does not add vLLM thinking kwargs", func(t *testing.T) {
+		c := newOutboundChat(t, string(provider.ProviderGeneric), "gpt-5.6-sol", nil)
+		body, _, useRaw, err := c.buildOutbound(msgs, &ChatOptions{
+			Thinking:  ptrBool(true),
+			MaxTokens: 128,
+		}, true)
+		require.NoError(t, err)
+		require.False(t, useRaw)
+		req, ok := body.(*openai.ChatCompletionRequest)
+		require.True(t, ok)
+		assert.Nil(t, req.ChatTemplateKwargs)
+		assert.Zero(t, req.MaxTokens)
+		assert.Equal(t, 128, req.MaxCompletionTokens)
+	})
 
 	t.Run("deepseek strips tool_choice", func(t *testing.T) {
 		c := newOutboundChat(t, string(provider.ProviderDeepSeek), "deepseek-chat", nil)

--- a/internal/models/chat/remote_api_test.go
+++ b/internal/models/chat/remote_api_test.go
@@ -164,6 +164,7 @@ func TestBuildChatCompletionRequest_GPT5MaxCompletionTokens(t *testing.T) {
 		{"OpenAI o1-mini", "openai", "o1-mini", true},
 		{"OpenAI o3", "openai", "o3", true},
 		{"OpenAI o4-mini", "openai", "o4-mini", true},
+		{"Generic GPT-5", "generic", "gpt-5.6-sol", true},
 		{"OpenAI gpt-4o (unchanged)", "openai", "gpt-4o", false},
 		{"AzureOpenAI gpt-4 (unchanged)", "azure_openai", "gpt-4", false},
 	}


### PR DESCRIPTION
## Description

Route generic OpenAI-compatible GPT-5 reasoning models through the reasoning request shaping path so requests do not include the unsupported chat_template_kwargs field. MaxTokens is also mapped to MaxCompletionTokens for these models.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🧪 Test

## Related Issue
Fixes #2058

## Testing
- gofmt -l internal passed.
- git diff --check origin/main...HEAD passed.
- Added provider resolution and request-shaping regression coverage.
- go test ./internal/models/chat -count=1 is blocked locally before package tests because CGO is disabled and pg_query.Parse/Deparse are unavailable; the machine also has no C compiler for CGO-enabled tests.
