### PR TITLE
feat: show file upload error details

### DIFF
--- a/frontend/src/utils/apiError.test.ts
+++ b/frontend/src/utils/apiError.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getApiErrorMessage } from './apiError'
+
+test('prefers backend error message and appends its details', () => {
+  assert.equal(
+    getApiErrorMessage({ error: { message: 'parse failed', details: 'unsupported encoding' } }),
+    'parse failed: unsupported encoding',
+  )
+})
+
+test('supports axios response envelopes and object details', () => {
+  assert.equal(
+    getApiErrorMessage({
+      response: { data: { error: { code: 'bad_file', details: { line: 3 } } } },
+    }),
+    '{"line":3}',
+  )
+})
+
+test('falls back to top-level message and explicit fallback', () => {
+  assert.equal(getApiErrorMessage({ message: 'network failed' }), 'network failed')
+  assert.equal(getApiErrorMessage({}, 'upload failed'), 'upload failed')
+})

--- a/frontend/src/utils/apiError.ts
+++ b/frontend/src/utils/apiError.ts
@@ -1,0 +1,35 @@
+function stringifyErrorPart(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const text = value.trim()
+    return text || undefined
+  }
+  if (value == null) return undefined
+
+  try {
+    const text = JSON.stringify(value)
+    return text && text !== '{}' ? text : undefined
+  } catch (_) {
+    return undefined
+  }
+}
+
+/** Extracts a useful message from the API error envelope used by the backend. */
+export function getApiErrorMessage(error: any, fallback?: string): string | undefined {
+  const data = error?.response?.data ?? error?.data ?? error
+  if (typeof data === 'string') return stringifyErrorPart(data) || fallback
+
+  const envelope = data && typeof data === 'object' ? data : {}
+  const nestedError = envelope.error
+  const errorObject = nestedError && typeof nestedError === 'object' ? nestedError : undefined
+  const message = stringifyErrorPart(
+    typeof nestedError === 'string'
+      ? nestedError
+      : errorObject?.message ?? envelope.message ?? error?.message,
+  )
+  const details = stringifyErrorPart(
+    errorObject?.details ?? envelope.details ?? error?.details,
+  )
+
+  if (message && details && details !== message) return `${message}: ${details}`
+  return message || details || fallback
+}

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import { generateRandomString, MAX_FILE_SIZE_MB } from "./index";
 import i18n from '@/i18n'
 import { getApiBaseUrl } from './api-base';
+import { getApiErrorMessage } from './apiError';
 
 const t = (key: string) => i18n.global.t(key)
 
@@ -226,18 +227,7 @@ instance.interceptors.response.use(
     // 将HTTP状态码一并抛出，方便上层判断401等场景
     // 后端返回格式: { success: false, error: { code, message, details } }
     // 提取 error.message 作为顶层 message，方便前端使用 error?.message 获取
-    let errorMessage: string | undefined;
-    if (typeof data === 'object') {
-      if (typeof data?.error === 'string') {
-        errorMessage = data.error;
-      } else if (data?.error?.message) {
-        errorMessage = data.error.message;
-      } else {
-        errorMessage = data?.message;
-      }
-    } else if (typeof data === 'string') {
-      errorMessage = data;
-    }
+    const errorMessage = getApiErrorMessage(data);
     return Promise.reject({ 
       status, 
       message: errorMessage,

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -42,6 +42,7 @@ import {
   type KnowledgeFolderTree,
 } from "@/api/knowledge-base/index";
 import { knowledgeSpansPayloadHasTrace } from '@/utils/knowledgeTrace';
+import { getApiErrorMessage } from '@/utils/apiError';
 import FAQEntryManager from './components/FAQEntryManager.vue';
 import DocumentListView from './components/DocumentListView.vue';
 import DocumentCardView from './components/DocumentCardView.vue';
@@ -1687,12 +1688,8 @@ const executeUploadBatch = async (
       } else {
         failCount++;
         if (totalCount === 1) {
-          let errorMessage = t('knowledgeBase.uploadFailed');
-          if (responseData?.error?.message) {
-            errorMessage = responseData.error.message;
-          } else if (responseData?.message) {
-            errorMessage = responseData.message;
-          }
+          let errorMessage = getApiErrorMessage(responseData, t('knowledgeBase.uploadFailed'))
+            || t('knowledgeBase.uploadFailed');
           if (responseData?.code === 'duplicate_file' || responseData?.error?.code === 'duplicate_file') {
             errorMessage = t('knowledgeBase.fileExists');
           }
@@ -1702,7 +1699,8 @@ const executeUploadBatch = async (
     } catch (error: any) {
       failCount++;
       if (totalCount === 1) {
-        let errorMessage = error?.error?.message || error?.message || t('knowledgeBase.uploadFailed');
+        let errorMessage = getApiErrorMessage(error, t('knowledgeBase.uploadFailed'))
+          || t('knowledgeBase.uploadFailed');
         if (error?.code === 'duplicate_file') {
           errorMessage = t('knowledgeBase.fileExists');
         }


### PR DESCRIPTION
## Description

Expose backend error details through a shared API error helper and use it in the knowledge-base file upload flow, while preserving the existing duplicate-file message.

## Type of Change
- [x] ✨ New feature
- [x] 🧪 Test

## Related Issue
Fixes #1565

## Testing
- git diff --check origin/main...HEAD passed.
- Added unit coverage for backend and Axios error envelopes.
- Frontend npm run type-check and npm test are blocked locally because the isolated worktree has no usable node_modules dependencies, including @vue/tsconfig and tsx.
