### PR TITLE
feat: configure embedder runtime limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -337,6 +337,12 @@ OLLAMA_OPTIONAL=true
 OLLAMA_BASE_URL=http://host.docker.internal:11434
 # 批量 embedding 大小（留空走代码默认）。
 # BATCH_EMBED_SIZE=
+# Embedding API 请求超时；支持 Go duration（如 120s、2m）或纯秒数，默认 120s。
+# WEKNORA_EMBED_TIMEOUT=120s
+# Embedding API 失败后的最大重试次数，默认 3。
+# WEKNORA_EMBED_MAX_RETRIES=3
+# 后台 embedding 请求的默认并发上限，模型自身的 max_concurrency 优先，默认 20。
+# WEKNORA_EMBED_MAX_CONCURRENCY=20
 # VLM 单次 HTTP 请求超时（秒，默认 180；慢端点超时报 context deadline 时调大）。
 # VLM_HTTP_TIMEOUT_SECONDS=180
 # LLM 流原始转储（排查上下文问题；1 启用，默认目录 ~/.weknora/investigate/llm-stream）。

--- a/internal/models/embedding/aliyun.go
+++ b/internal/models/embedding/aliyun.go
@@ -110,7 +110,8 @@ func NewAliyunEmbedder(apiKey, baseURL, modelName string,
 		truncatePromptTokens = 511
 	}
 
-	timeout := 60 * time.Second
+	runtimeConfig := loadEmbeddingRuntimeConfig()
+	timeout := runtimeConfig.Timeout
 
 	if err := validateEmbeddingBaseURL(baseURL); err != nil {
 		return nil, err
@@ -126,7 +127,7 @@ func NewAliyunEmbedder(apiKey, baseURL, modelName string,
 		dimensions:           dimensions,
 		modelID:              modelID,
 		timeout:              timeout,
-		maxRetries:           3,
+		maxRetries:           runtimeConfig.MaxRetries,
 	}, nil
 }
 

--- a/internal/models/embedding/azure_openai.go
+++ b/internal/models/embedding/azure_openai.go
@@ -62,6 +62,7 @@ func NewAzureOpenAIEmbedder(apiKey, baseURL, modelName string,
 	if truncatePromptTokens == 0 {
 		truncatePromptTokens = 511
 	}
+	runtimeConfig := loadEmbeddingRuntimeConfig()
 
 	if err := validateEmbeddingBaseURL(baseURL); err != nil {
 		return nil, err
@@ -75,8 +76,8 @@ func NewAzureOpenAIEmbedder(apiKey, baseURL, modelName string,
 		dimensions:           dimensions,
 		modelID:              modelID,
 		apiVersion:           apiVersion,
-		httpClient:           newEmbeddingHTTPClient(60 * time.Second),
-		maxRetries:           3,
+		httpClient:           newEmbeddingHTTPClient(runtimeConfig.Timeout),
+		maxRetries:           runtimeConfig.MaxRetries,
 		EmbedderPooler:       pooler,
 	}, nil
 }

--- a/internal/models/embedding/embedder.go
+++ b/internal/models/embedding/embedder.go
@@ -51,7 +51,7 @@ type Config struct {
 	ModelID                   string            `json:"model_id"`
 	Provider                  string            `json:"provider"`
 	// MaxConcurrency caps concurrent background calls to this model; 0 falls
-	// back to the process-wide default (see limiter.GateN).
+	// back to WEKNORA_EMBED_MAX_CONCURRENCY.
 	MaxConcurrency int               `json:"max_concurrency"`
 	ExtraConfig    map[string]string `json:"extra_config"`
 	// CustomHeaders 允许在调用远程 API 时附加自定义 HTTP 请求头（类似 OpenAI Python SDK 的 extra_headers）。
@@ -87,6 +87,14 @@ func ConfigFromModel(m *types.Model, appID, appSecret string) Config {
 
 // NewEmbedder creates an embedder based on the configuration
 func NewEmbedder(config Config, pooler EmbedderPooler, ollamaService *ollama.OllamaService) (Embedder, error) {
+	runtimeConfig := loadEmbeddingRuntimeConfig()
+	if config.MaxConcurrency <= 0 {
+		config.MaxConcurrency = runtimeConfig.MaxConcurrency
+	}
+	logger.GetLogger(context.Background()).Infof(
+		"[Embedding] runtime config: timeout=%s max_retries=%d max_concurrency=%d",
+		runtimeConfig.Timeout, runtimeConfig.MaxRetries, config.MaxConcurrency,
+	)
 	e, err := newEmbedder(config, pooler, ollamaService)
 	if err != nil {
 		return e, err

--- a/internal/models/embedding/gemini.go
+++ b/internal/models/embedding/gemini.go
@@ -78,7 +78,8 @@ func NewGeminiEmbedder(apiKey, baseURL, modelName string,
 		baseURL = strings.TrimSuffix(baseURL, "/openai")
 	}
 
-	timeout := 60 * time.Second
+	runtimeConfig := loadEmbeddingRuntimeConfig()
+	timeout := runtimeConfig.Timeout
 
 	if err := validateEmbeddingBaseURL(baseURL); err != nil {
 		return nil, err
@@ -93,7 +94,7 @@ func NewGeminiEmbedder(apiKey, baseURL, modelName string,
 		modelID:              modelID,
 		httpClient:           newEmbeddingHTTPClient(timeout),
 		timeout:              timeout,
-		maxRetries:           3,
+		maxRetries:           runtimeConfig.MaxRetries,
 		EmbedderPooler:       pooler,
 	}, nil
 }

--- a/internal/models/embedding/jina.go
+++ b/internal/models/embedding/jina.go
@@ -67,7 +67,8 @@ func NewJinaEmbedder(apiKey, baseURL, modelName string,
 		return nil, fmt.Errorf("model name is required")
 	}
 
-	timeout := 60 * time.Second
+	runtimeConfig := loadEmbeddingRuntimeConfig()
+	timeout := runtimeConfig.Timeout
 
 	if err := validateEmbeddingBaseURL(baseURL); err != nil {
 		return nil, err
@@ -82,7 +83,7 @@ func NewJinaEmbedder(apiKey, baseURL, modelName string,
 		dimensions:     dimensions,
 		modelID:        modelID,
 		timeout:        timeout,
-		maxRetries:     3,
+		maxRetries:     runtimeConfig.MaxRetries,
 	}, nil
 }
 

--- a/internal/models/embedding/nvidia.go
+++ b/internal/models/embedding/nvidia.go
@@ -68,7 +68,8 @@ func NewNvidiaEmbedder(apiKey, baseURL, modelName string,
 		return nil, fmt.Errorf("model name is required")
 	}
 
-	timeout := 60 * time.Second
+	runtimeConfig := loadEmbeddingRuntimeConfig()
+	timeout := runtimeConfig.Timeout
 
 	if err := validateEmbeddingBaseURL(baseURL); err != nil {
 		return nil, err
@@ -83,7 +84,7 @@ func NewNvidiaEmbedder(apiKey, baseURL, modelName string,
 		dimensions:     dimensions,
 		modelID:        modelID,
 		timeout:        timeout,
-		maxRetries:     3, // Maximum retry count
+		maxRetries:     runtimeConfig.MaxRetries,
 	}, nil
 }
 

--- a/internal/models/embedding/openai.go
+++ b/internal/models/embedding/openai.go
@@ -62,7 +62,8 @@ func NewOpenAIEmbedder(apiKey, baseURL, modelName string,
 		truncatePromptTokens = 511
 	}
 
-	timeout := 60 * time.Second
+	runtimeConfig := loadEmbeddingRuntimeConfig()
+	timeout := runtimeConfig.Timeout
 
 	if err := validateEmbeddingBaseURL(baseURL); err != nil {
 		return nil, err
@@ -78,7 +79,7 @@ func NewOpenAIEmbedder(apiKey, baseURL, modelName string,
 		dimensions:           dimensions,
 		modelID:              modelID,
 		timeout:              timeout,
-		maxRetries:           3, // Maximum retry count
+		maxRetries:           runtimeConfig.MaxRetries,
 	}, nil
 }
 

--- a/internal/models/embedding/runtime_config.go
+++ b/internal/models/embedding/runtime_config.go
@@ -1,0 +1,70 @@
+package embedding
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultEmbeddingTimeout        = 120 * time.Second
+	defaultEmbeddingMaxRetries     = 3
+	defaultEmbeddingMaxConcurrency = 20
+)
+
+// embeddingRuntimeConfig contains process-wide defaults for remote embedding
+// requests. Model-level max_concurrency remains the higher-priority override.
+type embeddingRuntimeConfig struct {
+	Timeout        time.Duration
+	MaxRetries     int
+	MaxConcurrency int
+}
+
+func loadEmbeddingRuntimeConfig() embeddingRuntimeConfig {
+	return embeddingRuntimeConfig{
+		Timeout:        embeddingDurationEnv("WEKNORA_EMBED_TIMEOUT", defaultEmbeddingTimeout),
+		MaxRetries:     embeddingNonNegativeIntEnv("WEKNORA_EMBED_MAX_RETRIES", defaultEmbeddingMaxRetries),
+		MaxConcurrency: embeddingPositiveIntEnv("WEKNORA_EMBED_MAX_CONCURRENCY", defaultEmbeddingMaxConcurrency),
+	}
+}
+
+func embeddingDurationEnv(name string, fallback time.Duration) time.Duration {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return fallback
+	}
+	if duration, err := time.ParseDuration(value); err == nil && duration > 0 {
+		return duration
+	}
+	// Accept a plain number as seconds for consistency with the other numeric
+	// deployment settings and to make the environment variable easy to use.
+	if seconds, err := strconv.Atoi(value); err == nil && seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	return fallback
+}
+
+func embeddingNonNegativeIntEnv(name string, fallback int) int {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return fallback
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed < 0 {
+		return fallback
+	}
+	return parsed
+}
+
+func embeddingPositiveIntEnv(name string, fallback int) int {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return fallback
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		return fallback
+	}
+	return parsed
+}

--- a/internal/models/embedding/runtime_config_test.go
+++ b/internal/models/embedding/runtime_config_test.go
@@ -1,0 +1,52 @@
+package embedding
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoadEmbeddingRuntimeConfigDefaults(t *testing.T) {
+	t.Setenv("WEKNORA_EMBED_TIMEOUT", "")
+	t.Setenv("WEKNORA_EMBED_MAX_RETRIES", "")
+	t.Setenv("WEKNORA_EMBED_MAX_CONCURRENCY", "")
+
+	got := loadEmbeddingRuntimeConfig()
+	if got.Timeout != defaultEmbeddingTimeout {
+		t.Fatalf("timeout = %s, want %s", got.Timeout, defaultEmbeddingTimeout)
+	}
+	if got.MaxRetries != defaultEmbeddingMaxRetries {
+		t.Fatalf("max retries = %d, want %d", got.MaxRetries, defaultEmbeddingMaxRetries)
+	}
+	if got.MaxConcurrency != defaultEmbeddingMaxConcurrency {
+		t.Fatalf("max concurrency = %d, want %d", got.MaxConcurrency, defaultEmbeddingMaxConcurrency)
+	}
+}
+
+func TestLoadEmbeddingRuntimeConfigParsesValues(t *testing.T) {
+	t.Setenv("WEKNORA_EMBED_TIMEOUT", "2m")
+	t.Setenv("WEKNORA_EMBED_MAX_RETRIES", "0")
+	t.Setenv("WEKNORA_EMBED_MAX_CONCURRENCY", "7")
+
+	got := loadEmbeddingRuntimeConfig()
+	if got.Timeout != 2*time.Minute || got.MaxRetries != 0 || got.MaxConcurrency != 7 {
+		t.Fatalf("unexpected runtime config: %+v", got)
+	}
+}
+
+func TestLoadEmbeddingRuntimeConfigAcceptsTimeoutSeconds(t *testing.T) {
+	t.Setenv("WEKNORA_EMBED_TIMEOUT", "45")
+	if got := loadEmbeddingRuntimeConfig().Timeout; got != 45*time.Second {
+		t.Fatalf("timeout = %s, want 45s", got)
+	}
+}
+
+func TestLoadEmbeddingRuntimeConfigRejectsInvalidValues(t *testing.T) {
+	t.Setenv("WEKNORA_EMBED_TIMEOUT", "-1s")
+	t.Setenv("WEKNORA_EMBED_MAX_RETRIES", "-1")
+	t.Setenv("WEKNORA_EMBED_MAX_CONCURRENCY", "0")
+
+	got := loadEmbeddingRuntimeConfig()
+	if got.Timeout != defaultEmbeddingTimeout || got.MaxRetries != defaultEmbeddingMaxRetries || got.MaxConcurrency != defaultEmbeddingMaxConcurrency {
+		t.Fatalf("invalid values should use defaults, got %+v", got)
+	}
+}

--- a/internal/models/embedding/volcengine.go
+++ b/internal/models/embedding/volcengine.go
@@ -116,7 +116,8 @@ func NewVolcengineEmbedder(apiKey, baseURL, modelName string,
 		truncatePromptTokens = 511
 	}
 
-	timeout := 60 * time.Second
+	runtimeConfig := loadEmbeddingRuntimeConfig()
+	timeout := runtimeConfig.Timeout
 
 	if err := validateEmbeddingBaseURL(baseURL); err != nil {
 		return nil, err
@@ -132,7 +133,7 @@ func NewVolcengineEmbedder(apiKey, baseURL, modelName string,
 		dimensions:           dimensions,
 		modelID:              modelID,
 		timeout:              timeout,
-		maxRetries:           3,
+		maxRetries:           runtimeConfig.MaxRetries,
 	}, nil
 }
 

--- a/internal/models/embedding/weknoracloud.go
+++ b/internal/models/embedding/weknoracloud.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/models/provider"
 	"github.com/Tencent/WeKnora/internal/models/utils"
 	"github.com/google/uuid"
@@ -28,6 +29,7 @@ type WeKnoraCloudEmbedder struct {
 	dimensions                int
 	supportsDimensionOverride bool
 	client                    *http.Client
+	maxRetries                int
 	EmbedderPooler
 }
 
@@ -50,6 +52,7 @@ func NewWeKnoraCloudEmbedder(config Config) (*WeKnoraCloudEmbedder, error) {
 	if err := validateEmbeddingBaseURL(baseURL); err != nil {
 		return nil, err
 	}
+	runtimeConfig := loadEmbeddingRuntimeConfig()
 	return &WeKnoraCloudEmbedder{
 		modelName:                 config.ModelName,
 		remoteModelName:           remoteModelName,
@@ -59,7 +62,8 @@ func NewWeKnoraCloudEmbedder(config Config) (*WeKnoraCloudEmbedder, error) {
 		baseURL:                   baseURL,
 		dimensions:                config.Dimensions,
 		supportsDimensionOverride: config.SupportsDimensionOverride,
-		client:                    newEmbeddingHTTPClient(60 * time.Second),
+		client:                    newEmbeddingHTTPClient(runtimeConfig.Timeout),
+		maxRetries:                runtimeConfig.MaxRetries,
 	}, nil
 }
 
@@ -98,19 +102,7 @@ func (e *WeKnoraCloudEmbedder) BatchEmbed(ctx context.Context, texts []string) (
 		return nil, fmt.Errorf("weknoracloud embedder: marshal: %w", err)
 	}
 
-	requestID := uuid.New().String()
-	headers := utils.Sign(e.appID, e.apiKey, requestID, string(bodyBytes))
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.baseURL+weKnoraCloudEmbedPath, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("weknoracloud embedder: create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
-
-	resp, err := e.client.Do(req)
+	resp, err := e.doRequestWithRetry(ctx, bodyBytes)
 	if err != nil {
 		return nil, fmt.Errorf("weknoracloud embedder: do request: %w", err)
 	}
@@ -151,6 +143,66 @@ func (e *WeKnoraCloudEmbedder) BatchEmbed(ctx context.Context, texts []string) (
 		}
 	}
 	return result, nil
+}
+
+func (e *WeKnoraCloudEmbedder) doRequestWithRetry(ctx context.Context, bodyBytes []byte) (*http.Response, error) {
+	var resp *http.Response
+	var err error
+
+	for attempt := 0; attempt <= e.maxRetries; attempt++ {
+		if attempt > 0 {
+			backoffTime := time.Duration(1<<uint(attempt-1)) * time.Second
+			if backoffTime > 10*time.Second {
+				backoffTime = 10 * time.Second
+			}
+			logger.GetLogger(ctx).Infof(
+				"WeKnoraCloudEmbedder retrying request (%d/%d), waiting %v",
+				attempt,
+				e.maxRetries,
+				backoffTime,
+			)
+			select {
+			case <-time.After(backoffTime):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+
+		// The signature contains the request ID, so each retry must create a
+		// fresh ID and signature even though the request body is unchanged.
+		requestID := uuid.New().String()
+		headers := utils.Sign(e.appID, e.apiKey, requestID, string(bodyBytes))
+		req, requestErr := http.NewRequestWithContext(
+			ctx,
+			http.MethodPost,
+			e.baseURL+weKnoraCloudEmbedPath,
+			bytes.NewReader(bodyBytes),
+		)
+		if requestErr != nil {
+			err = requestErr
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+		for key, value := range headers {
+			req.Header.Set(key, value)
+		}
+
+		resp, err = e.client.Do(req)
+		if err == nil {
+			return resp, nil
+		}
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		logger.GetLogger(ctx).Errorf(
+			"WeKnoraCloudEmbedder request failed (attempt %d/%d): %v",
+			attempt+1,
+			e.maxRetries+1,
+			err,
+		)
+	}
+
+	return nil, err
 }
 
 func (e *WeKnoraCloudEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string) ([][]float32, error) {

--- a/internal/models/embedding/weknoracloud_test.go
+++ b/internal/models/embedding/weknoracloud_test.go
@@ -2,13 +2,21 @@ package embedding
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
 )
+
+type weKnoraCloudRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f weKnoraCloudRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func newWeKnoraCloudEmbedderTestServer(t *testing.T, response string) *WeKnoraCloudEmbedder {
 	t.Helper()
@@ -96,5 +104,38 @@ func TestWeKnoraCloudBatchEmbedRejectsMalformedResponse(t *testing.T) {
 				t.Fatalf("BatchEmbed error = %q, want it to contain %q", err, tt.wantErrMsg)
 			}
 		})
+	}
+}
+
+func TestWeKnoraCloudBatchEmbedRetriesTransportErrors(t *testing.T) {
+	attempts := 0
+	embedder := &WeKnoraCloudEmbedder{
+		modelName:  "test-embedding",
+		appID:      "test-app-id",
+		apiKey:     "test-api-key",
+		baseURL:    "https://cloud.example.test",
+		maxRetries: 1,
+		client: &http.Client{Transport: weKnoraCloudRoundTripper(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts < 2 {
+				return nil, errors.New("temporary network failure")
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"data":[{"index":0,"embedding":[0.1,0.2]}]}`)),
+				Request:    req,
+			}, nil
+		})},
+	}
+
+	got, err := embedder.BatchEmbed(context.Background(), []string{"first"})
+	if err != nil {
+		t.Fatalf("BatchEmbed returned error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("request attempts = %d, want 2", attempts)
+	}
+	if !reflect.DeepEqual(got, [][]float32{{0.1, 0.2}}) {
+		t.Fatalf("BatchEmbed result = %v, want [[0.1 0.2]]", got)
 	}
 }

--- a/internal/models/embedding/zhipu.go
+++ b/internal/models/embedding/zhipu.go
@@ -63,7 +63,8 @@ func NewZhipuEmbedder(apiKey, baseURL, modelName string,
 		truncatePromptTokens = 511
 	}
 
-	timeout := 60 * time.Second
+	runtimeConfig := loadEmbeddingRuntimeConfig()
+	timeout := runtimeConfig.Timeout
 
 	if err := validateEmbeddingBaseURL(baseURL); err != nil {
 		return nil, err
@@ -79,7 +80,7 @@ func NewZhipuEmbedder(apiKey, baseURL, modelName string,
 		dimensions:           dimensions,
 		modelID:              modelID,
 		timeout:              timeout,
-		maxRetries:           3, // Maximum retry count
+		maxRetries:           runtimeConfig.MaxRetries,
 	}, nil
 }
 


### PR DESCRIPTION
## Description

Make embedder timeout, retry count, and maximum concurrency configurable through WEKNORA_EMBED_TIMEOUT, WEKNORA_EMBED_MAX_RETRIES, and WEKNORA_EMBED_MAX_CONCURRENCY. Apply the effective settings to supported remote embedders and retry transient WeKnora Cloud transport failures.

## Type of Change
- [x] ✨ New feature
- [x] 🧪 Test
- [x] 🔧 Configuration / Build / CI

## Related Issue
Fixes #1803

## Testing
- gofmt -l internal passed.
- git diff --check origin/main...HEAD passed.
- Added runtime configuration parsing and retry regression coverage.
- go test ./internal/models/embedding -count=1 is blocked locally before package tests because CGO is disabled and pg_query.Parse/Deparse are unavailable; the machine also has no C compiler for CGO-enabled tests.
