### PR TITLE
fix: allow safe public IPs from mixed DNS results

### DIFF
--- a/internal/infrastructure/web_fetch/fetcher.go
+++ b/internal/infrastructure/web_fetch/fetcher.go
@@ -237,12 +237,11 @@ func (f *Fetcher) pinnedDialContext() func(context.Context, string, string) (net
 		if len(ips) == 0 {
 			return nil, fmt.Errorf("DNS resolution failed: no addresses for %s", host)
 		}
-		for _, ip := range ips {
-			if !utils.IsPublicIP(ip) {
-				return nil, fmt.Errorf("connection blocked: %s resolves to restricted IP %s", host, ip)
-			}
+		publicIPs := filterPublicIPs(ips)
+		if len(publicIPs) == 0 {
+			return nil, fmt.Errorf("connection blocked: %s resolves only to restricted IPs", host)
 		}
-		pinnedAddress := net.JoinHostPort(ips[0].String(), port)
+		pinnedAddress := net.JoinHostPort(publicIPs[0].String(), port)
 		if f.dialContext != nil {
 			return f.dialContext(ctx, network, pinnedAddress)
 		}
@@ -278,13 +277,23 @@ func (f *Fetcher) resolvePinnedTarget(ctx context.Context, rawURL string) (pinne
 		return pinnedTarget{}, newFetchError(ErrorDNS, true, "DNS lookup returned no addresses for %s", parsedURL.Hostname())
 	}
 	if !utils.IsSSRFWhitelisted(parsedURL.Hostname()) {
-		for _, ip := range ips {
-			if !utils.IsPublicIP(ip) {
-				return pinnedTarget{}, newFetchError(ErrorSSRFRejected, false, "host resolves to restricted IP %s", ip)
-			}
+		publicIPs := filterPublicIPs(ips)
+		if len(publicIPs) == 0 {
+			return pinnedTarget{}, newFetchError(ErrorSSRFRejected, false, "host resolves only to restricted IPs")
 		}
+		return pinnedTarget{URL: parsedURL, Host: parsedURL.Hostname(), Port: port, IP: publicIPs[0]}, nil
 	}
 	return pinnedTarget{URL: parsedURL, Host: parsedURL.Hostname(), Port: port, IP: ips[0]}, nil
+}
+
+func filterPublicIPs(ips []net.IP) []net.IP {
+	public := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		if utils.IsPublicIP(ip) {
+			public = append(public, ip)
+		}
+	}
+	return public
 }
 
 func lookupPublicDNS(ctx context.Context, host string) ([]net.IP, error) {

--- a/internal/infrastructure/web_fetch/fetcher_test.go
+++ b/internal/infrastructure/web_fetch/fetcher_test.go
@@ -193,11 +193,30 @@ func TestPinnedDialUsesValidatedIPAndPreservesPort(t *testing.T) {
 	assert.EqualError(t, err, "stop dial")
 }
 
-func TestPinnedDialRejectsRebindingToRestrictedIP(t *testing.T) {
-	dialCalled := false
+func TestPinnedDialSkipsRestrictedIPWhenPublicAnswerExists(t *testing.T) {
+	var dialedAddress string
 	fetcher := &Fetcher{
 		resolveIPs: func(context.Context, string) ([]net.IP, error) {
 			return []net.IP{net.ParseIP("93.184.216.34"), net.ParseIP("127.0.0.1")}, nil
+		},
+		dialContext: func(_ context.Context, _, address string) (net.Conn, error) {
+			dialedAddress = address
+			return nil, errors.New("stop dial")
+		},
+	}
+
+	_, err := fetcher.pinnedDialContext()(context.Background(), "tcp", "example.com:443")
+
+	require.Error(t, err)
+	assert.Equal(t, "93.184.216.34:443", dialedAddress)
+	assert.EqualError(t, err, "stop dial")
+}
+
+func TestPinnedDialRejectsWhenAllDNSAnswersAreRestricted(t *testing.T) {
+	dialCalled := false
+	fetcher := &Fetcher{
+		resolveIPs: func(context.Context, string) ([]net.IP, error) {
+			return []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("10.0.0.1")}, nil
 		},
 		dialContext: func(context.Context, string, string) (net.Conn, error) {
 			dialCalled = true
@@ -208,7 +227,7 @@ func TestPinnedDialRejectsRebindingToRestrictedIP(t *testing.T) {
 	_, err := fetcher.pinnedDialContext()(context.Background(), "tcp", "example.com:443")
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "connection blocked")
+	assert.Contains(t, err.Error(), "restricted IPs")
 	assert.False(t, dialCalled)
 }
 

--- a/internal/utils/security.go
+++ b/internal/utils/security.go
@@ -353,6 +353,16 @@ func IsPublicIP(ip net.IP) bool {
 	return !restricted
 }
 
+func publicIPs(ips []net.IP) []net.IP {
+	public := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		if IsPublicIP(ip) {
+			public = append(public, ip)
+		}
+	}
+	return public
+}
+
 // isZeros checks if a byte slice is all zeros
 func isZeros(b []byte) bool {
 	for _, v := range b {
@@ -470,11 +480,17 @@ func isSSRFSafeURL(rawURL string) (bool, string) {
 		return false, fmt.Sprintf("DNS resolution failed for hostname %s: cannot verify if it resolves to safe IP", hostname)
 	}
 
-	// Check if any resolved IP is restricted
-	for _, resolvedIP := range ips {
-		if restricted, reason := isRestrictedIP(resolvedIP); restricted {
-			return false, fmt.Sprintf("hostname %s resolves to restricted IP %s: %s", hostname, resolvedIP.String(), reason)
+	// A hostname can legitimately have both public and private DNS answers
+	// (for example, split-horizon DNS). The dial-time guard below pins the
+	// connection to a public answer, so reject only hosts that have no public
+	// answer at all. This keeps the validation and the final TCP sink aligned.
+	if len(publicIPs(ips)) == 0 {
+		for _, resolvedIP := range ips {
+			if restricted, reason := isRestrictedIP(resolvedIP); restricted {
+				return false, fmt.Sprintf("hostname %s resolves to restricted IP %s: %s", hostname, resolvedIP.String(), reason)
+			}
 		}
+		return false, fmt.Sprintf("hostname %s has no public DNS address", hostname)
 	}
 
 	// Check for suspicious port numbers
@@ -930,22 +946,34 @@ func SSRFSafeDialContext(ctx context.Context, network, addr string) (net.Conn, e
 		return nil, fmt.Errorf("DNS resolution returned no addresses for %s", host)
 	}
 
-	// Validate all resolved IPs
+	// Split-horizon DNS may return both public and private addresses. Never dial
+	// the restricted answers, but allow the host when at least one public address
+	// is available. This preserves the DNS-rebinding protection at the TCP sink.
+	publicAddresses := make([]net.IP, 0, len(ips))
 	for _, ipAddr := range ips {
-		if restricted, reason := isRestrictedIP(ipAddr.IP); restricted {
-			return nil, fmt.Errorf("connection blocked: %s resolves to restricted IP %s (%s)", host, ipAddr.IP.String(), reason)
+		if IsPublicIP(ipAddr.IP) {
+			publicAddresses = append(publicAddresses, ipAddr.IP)
 		}
 	}
+	if len(publicAddresses) == 0 {
+		for _, ipAddr := range ips {
+			if restricted, reason := isRestrictedIP(ipAddr.IP); restricted {
+				return nil, fmt.Errorf("connection blocked: %s resolves to restricted IP %s (%s)", host, ipAddr.IP.String(), reason)
+			}
+		}
+		return nil, fmt.Errorf("connection blocked: %s has no public DNS address", host)
+	}
 
-	// If we get here, all IPs are safe. Pin the connection to the validated DNS
-	// answers; TLS still uses the request hostname for SNI/certificate checks.
+	// If we get here, at least one public IP is available. Pin the connection to
+	// the validated DNS answers; TLS still uses the request hostname for
+	// SNI/certificate checks.
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}
 	var lastErr error
-	for _, ipAddr := range ips {
-		pinnedAddr := net.JoinHostPort(ipAddr.IP.String(), port)
+	for _, ip := range publicAddresses {
+		pinnedAddr := net.JoinHostPort(ip.String(), port)
 		conn, dialErr := dialer.DialContext(ctx, network, pinnedAddr)
 		if dialErr == nil {
 			return conn, nil


### PR DESCRIPTION
## Description

Allow a hostname when DNS returns both restricted and public addresses, then pin outbound connections to the safe public addresses only. Hostname-based TLS behavior and whitelist handling remain unchanged.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🧪 Test

## Related Issue
Fixes #2299

## Testing
- gofmt -l internal passed.
- git diff --check origin/main...HEAD passed.
- Added coverage for mixed public and restricted DNS answers and all-restricted rejection.
- go test ./internal/infrastructure/web_fetch ./internal/utils -count=1 is blocked locally before package tests because CGO is disabled and pg_query.Parse/Deparse are unavailable; the machine also has no C compiler for CGO-enabled tests.
