### PR TITLE
fix: report embedding dimension mismatches

### DIFF
--- a/internal/application/service/knowledgebase_search.go
+++ b/internal/application/service/knowledgebase_search.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
 	apperrors "github.com/Tencent/WeKnora/internal/errors"
@@ -41,7 +42,38 @@ func (s *knowledgeBaseService) GetQueryEmbedding(ctx context.Context, kbID strin
 		return nil, err
 	}
 
-	return embeddingModel.Embed(ctx, queryText)
+	vector, err := embeddingModel.Embed(ctx, queryText)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateQueryEmbeddingDimension(embeddingModel, len(vector)); err != nil {
+		logger.Errorf(ctx, "GetQueryEmbedding: %v", err)
+		return nil, err
+	}
+	return vector, nil
+}
+
+// validateQueryEmbeddingDimension catches provider/model configuration drift
+// before a malformed query reaches the vector store. Without this check, a
+// provider returning a different vector size is reported as the misleading
+// generic 2201 "bound store unavailable" error (or, for dimension-partitioned
+// stores, silently produces no matches).
+func validateQueryEmbeddingDimension(model embedding.Embedder, actual int) error {
+	if model == nil || actual == 0 {
+		return nil
+	}
+	expected := model.GetDimensions()
+	if expected <= 0 || expected == actual {
+		return nil
+	}
+	return apperrors.NewVectorStoreUnavailableError(
+		"embedding vector dimension does not match the configured model",
+	).WithDetails(map[string]any{
+		"model":              model.GetModelName(),
+		"expected_dimension": expected,
+		"actual_dimension":   actual,
+		"hint":               fmt.Sprintf("check the embedding model configuration and rebuild the affected index (%d dimensions)", expected),
+	})
 }
 
 // ResolveEmbeddingModelKeys resolves embedding model IDs to their actual model
@@ -477,6 +509,10 @@ func (s *knowledgeBaseService) resolveQueryEmbedding(
 	queryEmbedding, err := embeddingModel.Embed(ctx, params.QueryText)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to embed query text, query text: %s, error: %v", params.QueryText, err)
+		return nil, err
+	}
+	if err := validateQueryEmbeddingDimension(embeddingModel, len(queryEmbedding)); err != nil {
+		logger.Errorf(ctx, "resolveQueryEmbedding: %v", err)
 		return nil, err
 	}
 	logger.Infof(ctx, "Query embedding generated successfully, embedding vector length: %d", len(queryEmbedding))

--- a/internal/application/service/knowledgebase_search_dimension_test.go
+++ b/internal/application/service/knowledgebase_search_dimension_test.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	apperrors "github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type dimensionTestEmbedder struct {
+	embedding.Embedder
+	name       string
+	dimensions int
+}
+
+func (e dimensionTestEmbedder) GetModelName() string { return e.name }
+func (e dimensionTestEmbedder) GetDimensions() int   { return e.dimensions }
+func (e dimensionTestEmbedder) Embed(context.Context, string) ([]float32, error) {
+	return make([]float32, 768), nil
+}
+
+func TestValidateQueryEmbeddingDimension(t *testing.T) {
+	err := validateQueryEmbeddingDimension(dimensionTestEmbedder{
+		name:       "configured-embedding",
+		dimensions: 1536,
+	}, 768)
+	require.Error(t, err)
+	appErr, ok := err.(*apperrors.AppError)
+	require.True(t, ok)
+	assert.Equal(t, apperrors.ErrVectorStoreUnavailable, appErr.Code)
+	assert.Equal(t, "configured-embedding", appErr.Details.(map[string]any)["model"])
+	assert.Equal(t, 1536, appErr.Details.(map[string]any)["expected_dimension"])
+	assert.Equal(t, 768, appErr.Details.(map[string]any)["actual_dimension"])
+}
+
+func TestValidateQueryEmbeddingDimensionAllowsUnknownOrMatchingSize(t *testing.T) {
+	assert.NoError(t, validateQueryEmbeddingDimension(dimensionTestEmbedder{dimensions: 768}, 768))
+	assert.NoError(t, validateQueryEmbeddingDimension(dimensionTestEmbedder{dimensions: 0}, 768))
+	assert.NoError(t, validateQueryEmbeddingDimension(dimensionTestEmbedder{dimensions: 1536}, 0))
+}


### PR DESCRIPTION
## Description

Validate provider-generated query embeddings against the knowledge base vector dimension before retrieval and return a typed error containing the model, expected dimension, actual dimension, and remediation hint.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🧪 Test

## Related Issue
Fixes #2751

## Testing
- gofmt -l internal passed.
- git diff --check origin/main...HEAD passed.
- Added regression coverage for the dimension mismatch error details.
- go test ./internal/application/service -count=1 is blocked locally before package tests because CGO is disabled and pg_query.Parse/Deparse are unavailable; the machine also has no C compiler for CGO-enabled tests.
