### PR TITLE
fix: normalize nullable Gemini tool schemas

### DIFF
--- a/internal/models/chat/gemini_schema.go
+++ b/internal/models/chat/gemini_schema.go
@@ -1,0 +1,57 @@
+package chat
+
+import "strings"
+
+// normalizeGeminiToolSchemas adapts the JSON Schema emitted by MCP tools to
+// the subset accepted by Google's OpenAPI Schema. In particular, a JSON
+// Schema union such as {"type":["string","null"]} cannot be decoded by
+// Gemini's proto field, which expects one scalar type string.
+func normalizeGeminiToolSchemas(body map[string]any) {
+	tools, ok := body["tools"].([]any)
+	if !ok {
+		return
+	}
+	for _, rawTool := range tools {
+		tool, ok := rawTool.(map[string]any)
+		if !ok {
+			continue
+		}
+		function, ok := tool["function"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if parameters, ok := function["parameters"].(map[string]any); ok {
+			function["parameters"] = normalizeGeminiSchema(parameters)
+		}
+	}
+}
+
+func normalizeGeminiSchema(value any) any {
+	switch schema := value.(type) {
+	case map[string]any:
+		if rawType, ok := schema["type"].([]any); ok {
+			for _, candidate := range rawType {
+				typeName, ok := candidate.(string)
+				if !ok || strings.EqualFold(typeName, "null") {
+					continue
+				}
+				schema["type"] = typeName
+				break
+			}
+			if _, ok := schema["type"].([]any); ok {
+				// A null-only union has no useful Gemini type. Omitting the
+				// field lets the gateway infer it from the remaining schema.
+				delete(schema, "type")
+			}
+		}
+		for key, child := range schema {
+			schema[key] = normalizeGeminiSchema(child)
+		}
+		return schema
+	case []any:
+		for i, child := range schema {
+			schema[i] = normalizeGeminiSchema(child)
+		}
+	}
+	return value
+}

--- a/internal/models/chat/openai_request.go
+++ b/internal/models/chat/openai_request.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/Tencent/WeKnora/internal/models/provider"
 	"github.com/sashabaranov/go-openai"
 )
 
@@ -196,6 +197,9 @@ func (c *RemoteAPIChat) buildProviderOpenAIRequest(
 	var out map[string]any
 	if err := json.Unmarshal(data, &out); err != nil {
 		return nil, fmt.Errorf("unmarshal provider request: %w", err)
+	}
+	if c.provider == provider.ProviderGemini {
+		normalizeGeminiToolSchemas(out)
 	}
 
 	providerMessages := make([]map[string]any, 0, len(openAIMessages))

--- a/internal/models/chat/remote_api_test.go
+++ b/internal/models/chat/remote_api_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Tencent/WeKnora/internal/models/provider"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/sashabaranov/go-openai"
 	"github.com/stretchr/testify/assert"
@@ -127,6 +128,35 @@ func TestBuildChatCompletionRequest_MCPToolsFormat(t *testing.T) {
 		assert.Regexp(t, `^[a-zA-Z0-9_-]+$`, name, "tool name must match OpenAI pattern")
 		assert.LessOrEqual(t, len(name), 64, "tool name must be <= 64 chars")
 	}
+}
+
+func TestGeminiToolSchemaNormalizesNullableTypes(t *testing.T) {
+	chat := newTestRemoteChat(t)
+	chat.provider = provider.ProviderGemini
+	chat.adapter = geminiProvider{}
+
+	body, _, raw, err := chat.buildOutbound([]Message{{Role: "user", Content: "hello"}}, &ChatOptions{
+		Tools: []Tool{{
+			Type: "function",
+			Function: FunctionDef{
+				Name:       "lookup",
+				Parameters: json.RawMessage(`{"type":"object","properties":{"query":{"type":["string","null"]},"items":{"type":"array","items":{"type":["integer","null"]}}}}`),
+			},
+		}},
+	}, false)
+	require.NoError(t, err)
+	require.True(t, raw)
+
+	request, ok := body.(map[string]any)
+	require.True(t, ok)
+	tools, ok := request["tools"].([]any)
+	require.True(t, ok)
+	function := tools[0].(map[string]any)["function"].(map[string]any)
+	parameters := function["parameters"].(map[string]any)
+	properties := parameters["properties"].(map[string]any)
+	assert.Equal(t, "string", properties["query"].(map[string]any)["type"])
+	items := properties["items"].(map[string]any)["items"].(map[string]any)
+	assert.Equal(t, "integer", items["type"])
 }
 
 // TestBuildChatCompletionRequest_GPT5MaxCompletionTokens 验证 GPT-5 / o-series


### PR DESCRIPTION
## Description

Normalize nullable JSON Schema type arrays in Gemini tool requests to the scalar type accepted by the Gemini protobuf schema, including nested properties and array items.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🧪 Test

## Related Issue
Fixes #1709

## Testing
- gofmt -l internal passed.
- git diff --check origin/main...HEAD passed.
- Added nested nullable-schema regression coverage.
- go test ./internal/models/chat -count=1 is blocked locally before package tests because CGO is disabled and pg_query.Parse/Deparse are unavailable; the machine also has no C compiler for CGO-enabled tests.
