### PR TITLE
fix(frontend): use latest system setting value

### DIFF
--- a/frontend/src/views/system/SystemSettings.vue
+++ b/frontend/src/views/system/SystemSettings.vue
@@ -496,6 +496,7 @@ import {
   type SystemSettingItem,
 } from '@/api/system'
 import { useAuthStore } from '@/stores/auth'
+import { isSettingValueDirty, resolveCurrentSetting } from './systemSettingsEdit'
 
 const authStore = useAuthStore()
 const currentUserId = computed(() => authStore.currentUserId)
@@ -866,16 +867,7 @@ async function snapSsrfWhitelistToSaved(item: SystemSettingItem) {
 }
 
 function isDirty(item: SystemSettingItem): boolean {
-  const cur = editValues[item.key]
-  const orig = item.value
-  if (Array.isArray(cur) && Array.isArray(orig)) {
-    if (cur.length !== orig.length) return true
-    for (let i = 0; i < cur.length; i++) {
-      if (cur[i] !== orig[i]) return true
-    }
-    return false
-  }
-  return cur !== orig
+  return isSettingValueDirty(editValues[item.key], item.value)
 }
 
 function formatDate(isoString: string): string {
@@ -929,7 +921,7 @@ async function loadSettings() {
 // onChange persists non-SSRF settings. SSRF whitelist and system admins
 // have dedicated handlers with inline popconfirm.
 async function onChange(item: SystemSettingItem) {
-  const currentItem = settingsByKey.value.get(item.key)
+  const currentItem = resolveCurrentSetting(settingsByKey.value, item.key)
   if (!currentItem) return
   if (!isDirty(currentItem)) return
 
@@ -943,15 +935,17 @@ async function onChange(item: SystemSettingItem) {
 }
 
 async function onHighRiskSelectChange(item: SystemSettingItem) {
+  const currentItem = resolveCurrentSetting(settingsByKey.value, item.key)
+  if (!currentItem) return
   const newValue = editValues[item.key]
-  if (newValue === item.value) return
+  if (!isDirty(currentItem)) return
 
   // Revert the select immediately so cancel leaves the saved value
   // visible; re-apply only after the inline popconfirm is confirmed.
-  editValues[item.key] = item.value
+  editValues[item.key] = currentItem.value
 
   const ok = await highRiskPopconfirm.ask({
-    content: highRiskConfirmBody(item, newValue),
+    content: highRiskConfirmBody(currentItem, newValue),
     theme: 'danger',
     confirmBtn: {
       content: t('system.globalSettings.confirm.confirmBtn'),
@@ -961,7 +955,7 @@ async function onHighRiskSelectChange(item: SystemSettingItem) {
   if (!ok) return
 
   editValues[item.key] = newValue
-  await persistSetting(item)
+  await persistSetting(currentItem)
 }
 
 function confirmSsrfListEntryChange(

--- a/frontend/src/views/system/SystemSettings.vue
+++ b/frontend/src/views/system/SystemSettings.vue
@@ -642,7 +642,7 @@ const SETTINGS_SECTION_KEYS: Record<Exclude<SettingsSection, 'other'>, readonly 
 
 const activeSettingsSection = ref<SettingsSection>('access')
 const knownSettingKeys = new Set(Object.values(SETTINGS_SECTION_KEYS).flat())
-const settingsByKey = computed(() => new Map(settings.value.map((item) => [item.key, item])))
+const settingsByKey = computed<Map<string, SystemSettingItem>>(() => new Map(settings.value.map((item) => [item.key, item])))
 const unknownSettings = computed(() => settings.value.filter((item) => !knownSettingKeys.has(item.key)))
 const hasUnknownSettings = computed(() => unknownSettings.value.length > 0)
 
@@ -929,7 +929,9 @@ async function loadSettings() {
 // onChange persists non-SSRF settings. SSRF whitelist and system admins
 // have dedicated handlers with inline popconfirm.
 async function onChange(item: SystemSettingItem) {
-  if (!isDirty(item)) return
+  const currentItem = settingsByKey.value.get(item.key)
+  if (!currentItem) return
+  if (!isDirty(currentItem)) return
 
   // SSRF whitelist gets the per-entry confirm flow — same shape as the
   // admin tag-input above. Adding or removing each host/CIDR is its
@@ -937,7 +939,7 @@ async function onChange(item: SystemSettingItem) {
   // the egress firewall), so we ask once per delta instead of once
   // per "save". This matches the operator's mental model: every tag
   // they touch is acknowledged on its own.
-  await persistSetting(item)
+  await persistSetting(currentItem)
 }
 
 async function onHighRiskSelectChange(item: SystemSettingItem) {

--- a/frontend/src/views/system/systemSettingsEdit.test.ts
+++ b/frontend/src/views/system/systemSettingsEdit.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { isSettingValueDirty, resolveCurrentSetting } from './systemSettingsEdit.ts'
+
+test('treats scalar edits as dirty', () => {
+  assert.equal(isSettingValueDirty(true, false), true)
+  assert.equal(isSettingValueDirty(false, false), false)
+  assert.equal(isSettingValueDirty('invite', 'open'), true)
+})
+
+test('treats list edits as dirty by value, not by reference', () => {
+  assert.equal(isSettingValueDirty(['a'], ['a']), false)
+  assert.equal(isSettingValueDirty(['a', 'b'], ['a']), true)
+  assert.equal(isSettingValueDirty(['a'], ['b']), true)
+})
+
+test('resolves the latest setting so a reused row does not keep the pre-save value', () => {
+  const stale = { key: 'tenant.auto_create_api_key', value: false }
+  const current = { key: 'tenant.auto_create_api_key', value: true }
+  const settingsByKey = new Map([[current.key, current]])
+
+  const resolved = resolveCurrentSetting(settingsByKey, stale.key)
+  assert.equal(resolved, current)
+
+  // User toggled back to the original loaded value. The stale object looks
+  // clean; the canonical post-save object is dirty and must PUT.
+  const editValue = false
+  assert.equal(isSettingValueDirty(editValue, stale.value), false)
+  assert.equal(isSettingValueDirty(editValue, resolved?.value), true)
+})
+
+test('high-risk cancel restores the latest saved value, not the first-loaded object', () => {
+  const stale = { key: 'auth.registration_mode', value: 'open' }
+  const current = { key: 'auth.registration_mode', value: 'invite' }
+  const settingsByKey = new Map([[current.key, current]])
+
+  const resolved = resolveCurrentSetting(settingsByKey, stale.key)
+  assert.equal(resolved?.value, 'invite')
+  assert.notEqual(stale.value, resolved?.value)
+})

--- a/frontend/src/views/system/systemSettingsEdit.ts
+++ b/frontend/src/views/system/systemSettingsEdit.ts
@@ -1,0 +1,23 @@
+// Setting rows keep a stable Vue key (`item.key`) while persistSetting
+// replaces the object in `settings`. Reused TDesign controls can therefore
+// fire @change/@blur with a stale item whose `.value` is the pre-save
+// snapshot. Event handlers must resolve by key from the latest map before
+// dirty-checking or reverting the control.
+
+export function resolveCurrentSetting<T extends { key: string }>(
+  settingsByKey: ReadonlyMap<string, T>,
+  key: string,
+): T | undefined {
+  return settingsByKey.get(key)
+}
+
+export function isSettingValueDirty(current: unknown, original: unknown): boolean {
+  if (Array.isArray(current) && Array.isArray(original)) {
+    if (current.length !== original.length) return true
+    for (let i = 0; i < current.length; i++) {
+      if (current[i] !== original[i]) return true
+    }
+    return false
+  }
+  return current !== original
+}


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
修复系统设置页面存在Bug，变更设置项时，比如点击switch开关，不是每次都会调用设置接口。0.7.2和最新的main分支都可以稳定重现。
由于 setting-row 基于稳定的 key 复用组件实例，@change="onChange(item)" 可能引用旧的设置项对象，导致变更操作使用非最新的设置值。
在 onChange 中根据设置项 key 从最新的 settingsByKey 获取设置对象，确保变更操作使用当前正确的设置值。

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
- [x] npm test
- [x] npm run type-check

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
