### PR TITLE
fix(frontend): disable gzip for /api/ proxied responses

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: ./frontend
     container_name: WeKnora-frontend
+    volumes:
+      - ./frontend/nginx.conf:/etc/nginx/templates/default.conf.template:ro
     ports:
       - "${FRONTEND_PORT:-80}:80"
     environment:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -116,6 +116,7 @@ server {
     # APP_SCHEME 默认 http，远程 HTTPS 后端可设为 https
     location /api/ {
         proxy_pass ${APP_SCHEME}://${APP_HOST}:${APP_PORT}/api/;
+        gzip off;   # disable gzip for /api/ proxied responses (protects SSE/streaming content-length)
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Description
`frontend/nginx.conf` enables gzip globally (`application/json` in `gzip_types`), so `/api/` proxied responses — including SSE/streaming for AI chat / RAG Q&A — are gzip-compressed, breaking streaming (framing/content-length altered; some clients can't decompress proxied gzip).

This PR adds `gzip off;` inside `location /api/` (static assets keep gzip), and mounts `frontend/nginx.conf` as `/etc/nginx/templates/default.conf.template:ro` in `docker-compose.yml` so container deployments pick up the fix.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
No related issue.

## Testing
- `git diff --check origin/main...HEAD` passes.
- Verified on a live deployment: `/api/` no longer gzip-compressed; SSE/chat streaming works.
- No Go/TS source changed -> lints N/A; compose validated via `docker compose config`.

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted (diff-check clean)
- [x] Targeted tests pass (config-only; verified on live deployment)
- [x] Diff-scoped lint passes where applicable (N/A: no Go/TS source)
- [x] Full-repo checks run or failures documented (not run: config-only)
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change (N/A: config-only)
- [x] Updated related documentation (N/A)
- [x] Breaking changes clearly called out (none)

## Screenshots / Recordings
N/A — no user-visible UI change.