### PR TITLE
fix(auth): verify OIDC id_token signatures via JWKS

### DIFF
--- a/internal/application/service/oidc_jwks.go
+++ b/internal/application/service/oidc_jwks.go
@@ -1,0 +1,287 @@
+package service
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// oidcAllowedSignatureAlgs is the allowlist for id_token signature
+// verification. HS* is intentionally absent: a symmetric key cannot be
+// validated from a public JWKS endpoint.
+var oidcAllowedSignatureAlgs = []string{"RS256", "PS256", "ES256", "EdDSA"}
+
+// oidcJWK is a single JSON Web Key as served by an IdP jwks_uri.
+type oidcJWK struct {
+	KTY string `json:"kty"`
+	KID string `json:"kid"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+
+	// RSA
+	N string `json:"n"`
+	E string `json:"e"`
+
+	// EC / OKP
+	CRV string `json:"crv"`
+	X   string `json:"x"`
+	Y   string `json:"y"`
+}
+
+type oidcJWKSDocument struct {
+	Keys []oidcJWK `json:"keys"`
+}
+
+// errOIDCJWKSUnavailable marks transport- or document-level JWKS failures
+// (network error, non-2xx response, unparseable document, no usable keys,
+// SSRF-rejected URI). Callers use it to distinguish "we could not obtain the
+// IdP's keys" from "the token failed verification against the IdP's keys":
+// the first can degrade with a warning, the second must fail closed.
+var errOIDCJWKSUnavailable = errors.New("OIDC JWKS unavailable")
+
+// isOIDCJWKSUnavailable reports whether the error is a JWKS-fetch failure
+// rather than a per-token verification failure.
+func isOIDCJWKSUnavailable(err error) bool {
+	return errors.Is(err, errOIDCJWKSUnavailable)
+}
+
+// oidcJWKSCache caches the last successful JWKS fetch per URI. Identity
+// providers rotate keys slowly and the fetch happens on every login, so a
+// short TTL keeps logins fast without serving stale keys for too long.
+type oidcJWKSCacheEntry struct {
+	keys    []oidcJWK
+	fetched time.Time
+}
+
+const oidcJWKSCacheTTL = 10 * time.Minute
+
+var (
+	oidcJWKSCacheMu sync.Mutex
+	oidcJWKSCache   = map[string]oidcJWKSCacheEntry{}
+)
+
+// loadOIDCJWKS fetches (or serves from cache) the IdP's signing keys.
+// A transport-level failure surfaces as an error so the caller can decide
+// whether to fail closed or degrade; a successful fetch with no usable
+// signing keys is also an error.
+func loadOIDCJWKS(ctx context.Context, jwksURI string) ([]oidcJWK, error) {
+	if err := validateOIDCEndpoint("jwks", jwksURI, true); err != nil {
+		return nil, fmt.Errorf("%w: %v", errOIDCJWKSUnavailable, err)
+	}
+
+	oidcJWKSCacheMu.Lock()
+	if entry, ok := oidcJWKSCache[jwksURI]; ok && time.Since(entry.fetched) < oidcJWKSCacheTTL {
+		keys := entry.keys
+		oidcJWKSCacheMu.Unlock()
+		return keys, nil
+	}
+	oidcJWKSCacheMu.Unlock()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURI, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to create OIDC JWKS request: %v", errOIDCJWKSUnavailable, err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := newOIDCHTTPClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to load OIDC JWKS: %v", errOIDCJWKSUnavailable, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("%w: OIDC JWKS request failed: status=%d", errOIDCJWKSUnavailable, resp.StatusCode)
+	}
+
+	var doc oidcJWKSDocument
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4<<20)).Decode(&doc); err != nil {
+		return nil, fmt.Errorf("%w: failed to decode OIDC JWKS document: %v", errOIDCJWKSUnavailable, err)
+	}
+	usable := make([]oidcJWK, 0, len(doc.Keys))
+	for _, key := range doc.Keys {
+		// Only signature keys are relevant; some providers also list
+		// encryption keys in the same document.
+		if key.Use != "" && key.Use != "sig" {
+			continue
+		}
+		if _, err := key.PublicKey(); err != nil {
+			continue
+		}
+		usable = append(usable, key)
+	}
+	if len(usable) == 0 {
+		return nil, fmt.Errorf("%w: JWKS document contained no usable signature keys", errOIDCJWKSUnavailable)
+	}
+
+	oidcJWKSCacheMu.Lock()
+	oidcJWKSCache[jwksURI] = oidcJWKSCacheEntry{keys: usable, fetched: time.Now()}
+	oidcJWKSCacheMu.Unlock()
+	return usable, nil
+}
+
+// PublicKey converts the JWK into a crypto public key usable by golang-jwt.
+func (k oidcJWK) PublicKey() (interface{}, error) {
+	switch k.KTY {
+	case "RSA":
+		if k.N == "" || k.E == "" {
+			return nil, errors.New("RSA JWK missing n/e")
+		}
+		nBytes, err := base64.RawURLEncoding.DecodeString(k.N)
+		if err != nil {
+			return nil, err
+		}
+		eBytes, err := base64.RawURLEncoding.DecodeString(k.E)
+		if err != nil {
+			return nil, err
+		}
+		if len(eBytes) == 0 {
+			return nil, errors.New("RSA JWK exponent is empty")
+		}
+		exp := 0
+		for _, b := range eBytes {
+			exp = exp<<8 | int(b)
+		}
+		return &rsa.PublicKey{N: new(big.Int).SetBytes(nBytes), E: exp}, nil
+	case "EC":
+		if k.CRV == "" || k.X == "" || k.Y == "" {
+			return nil, errors.New("EC JWK missing crv/x/y")
+		}
+		xBytes, err := base64.RawURLEncoding.DecodeString(k.X)
+		if err != nil {
+			return nil, err
+		}
+		yBytes, err := base64.RawURLEncoding.DecodeString(k.Y)
+		if err != nil {
+			return nil, err
+		}
+		curve, ok := oidcECCurve(k.CRV)
+		if !ok {
+			return nil, fmt.Errorf("unsupported EC curve %q", k.CRV)
+		}
+		return &ecdsa.PublicKey{Curve: curve, X: new(big.Int).SetBytes(xBytes), Y: new(big.Int).SetBytes(yBytes)}, nil
+	case "OKP":
+		if k.CRV != "Ed25519" || k.X == "" {
+			return nil, errors.New("OKP JWK must be Ed25519 with x present")
+		}
+		xBytes, err := base64.RawURLEncoding.DecodeString(k.X)
+		if err != nil {
+			return nil, err
+		}
+		if len(xBytes) != ed25519.PublicKeySize {
+			return nil, errors.New("Ed25519 JWK has invalid public key length")
+		}
+		return ed25519.PublicKey(xBytes), nil
+	default:
+		return nil, fmt.Errorf("unsupported JWK kty %q", k.KTY)
+	}
+}
+
+func oidcECCurve(crv string) (elliptic.Curve, bool) {
+	switch crv {
+	case "P-256":
+		return elliptic.P256(), true
+	case "P-384":
+		return elliptic.P384(), true
+	case "P-521":
+		return elliptic.P521(), true
+	default:
+		return nil, false
+	}
+}
+
+// verifyOIDCIDToken verifies the id_token's JWS signature against the IdP's
+// JWKS, restricting to the allowlisted asymmetric algorithms and validating
+// iss/aud/exp when the corresponding configuration is present.
+//
+// Returns an error whenever the signature cannot be proven to come from the
+// IdP: wrong key, unknown kid, tampered payload or a token signed with a
+// disallowed algorithm. Transport-level JWKS fetch failures also surface as
+// errors; the caller decides whether to fail closed or degrade.
+func verifyOIDCIDToken(ctx context.Context, cfg *config.OIDCAuthConfig, idToken string) error {
+	jwksURI := strings.TrimSpace(cfg.JWKSURI)
+	if jwksURI == "" {
+		return errors.New("OIDC jwks_uri is not configured")
+	}
+
+	keys, err := loadOIDCJWKS(ctx, jwksURI)
+	if err != nil {
+		return err
+	}
+
+	opts := []jwt.ParserOption{
+		jwt.WithValidMethods(oidcAllowedSignatureAlgs),
+	}
+	if strings.TrimSpace(cfg.IssuerURL) != "" {
+		opts = append(opts, jwt.WithIssuer(cfg.IssuerURL))
+	}
+	if strings.TrimSpace(cfg.ClientID) != "" {
+		opts = append(opts, jwt.WithAudience(cfg.ClientID))
+	}
+
+	var lastErr error
+	for _, key := range keys {
+		pub, err := key.PublicKey()
+		if err != nil {
+			continue
+		}
+		token, err := jwt.ParseWithClaims(
+			idToken,
+			&jwt.MapClaims{},
+			func(_ *jwt.Token) (interface{}, error) { return pub, nil },
+			opts...,
+		)
+		if err == nil && token.Valid {
+			return nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = errors.New("no usable JWKS key")
+	}
+	return fmt.Errorf("OIDC id_token signature verification failed: %w", lastErr)
+}
+
+// validateIDTokenExpiry is a best-effort expiry check used when no JWKS is
+// available to verify the signature. Expired tokens are rejected regardless;
+// a missing exp claim is left to the verified path (golang-jwt enforces it
+// there when present).
+func validateIDTokenExpiry(claims map[string]interface{}) error {
+	expRaw, ok := claims["exp"]
+	if !ok {
+		return nil
+	}
+	var exp float64
+	switch v := expRaw.(type) {
+	case float64:
+		exp = v
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return nil
+		}
+		exp = f
+	case int64:
+		exp = float64(v)
+	default:
+		return nil
+	}
+	if int64(exp) <= time.Now().Unix() {
+		return errors.New("OIDC id_token is expired")
+	}
+	return nil
+}

--- a/internal/application/service/oidc_jwks_test.go
+++ b/internal/application/service/oidc_jwks_test.go
@@ -1,0 +1,328 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/config"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// signRS256JWT mints an RS256-signed JWT with the given kid and claims,
+// mirroring what a standard OIDC IdP produces for id_token.
+func signRS256JWT(t *testing.T, key *rsa.PrivateKey, kid string, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+	signed, err := token.SignedString(key)
+	require.NoError(t, err)
+	return signed
+}
+
+func rsaTestKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return key
+}
+
+func rsaJWKSBody(t *testing.T, key *rsa.PublicKey, kid string) []byte {
+	t.Helper()
+	n := base64.RawURLEncoding.EncodeToString(key.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes())
+	doc := map[string]interface{}{
+		"keys": []map[string]interface{}{
+			{"kty": "RSA", "kid": kid, "use": "sig", "alg": "RS256", "n": n, "e": e},
+		},
+	}
+	body, err := json.Marshal(doc)
+	require.NoError(t, err)
+	return body
+}
+
+func oidcTestConfig(jwksURI, issuer, clientID string) *config.OIDCAuthConfig {
+	return &config.OIDCAuthConfig{
+		IssuerURL: issuer,
+		ClientID:  clientID,
+		JWKSURI:   jwksURI,
+	}
+}
+
+func TestVerifyOIDCIDToken_ValidRS256(t *testing.T) {
+	withOIDCSSRFWhitelist(t, "127.0.0.1")
+	key := rsaTestKey(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(rsaJWKSBody(t, &key.PublicKey, "key-1"))
+	}))
+	defer srv.Close()
+
+	cfg := oidcTestConfig(srv.URL, "https://idp.example", "client-1")
+	token := signRS256JWT(t, key, "key-1", jwt.MapClaims{
+		"sub": "user-1", "iss": "https://idp.example", "aud": "client-1",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	err := verifyOIDCIDToken(context.Background(), cfg, token)
+	assert.NoError(t, err)
+}
+
+func TestVerifyOIDCIDToken_WrongKeyRejected(t *testing.T) {
+	withOIDCSSRFWhitelist(t, "127.0.0.1")
+	serverKey := rsaTestKey(t)
+	attackerKey := rsaTestKey(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(rsaJWKSBody(t, &serverKey.PublicKey, "key-1"))
+	}))
+	defer srv.Close()
+
+	cfg := oidcTestConfig(srv.URL, "https://idp.example", "client-1")
+	// Attacker-signed token: not in the IdP's JWKS.
+	token := signRS256JWT(t, attackerKey, "key-1", jwt.MapClaims{
+		"sub": "victim", "iss": "https://idp.example", "aud": "client-1",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	err := verifyOIDCIDToken(context.Background(), cfg, token)
+	require.Error(t, err)
+	assert.False(t, isOIDCJWKSUnavailable(err), "signature failure must not degrade, got: %v", err)
+	assert.Contains(t, err.Error(), "signature verification failed")
+}
+
+func TestVerifyOIDCIDToken_ExpiredRejected(t *testing.T) {
+	withOIDCSSRFWhitelist(t, "127.0.0.1")
+	key := rsaTestKey(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(rsaJWKSBody(t, &key.PublicKey, "key-1"))
+	}))
+	defer srv.Close()
+
+	cfg := oidcTestConfig(srv.URL, "https://idp.example", "client-1")
+	token := signRS256JWT(t, key, "key-1", jwt.MapClaims{
+		"sub": "user-1", "iss": "https://idp.example", "aud": "client-1",
+		"exp": time.Now().Add(-time.Hour).Unix(),
+	})
+
+	err := verifyOIDCIDToken(context.Background(), cfg, token)
+	require.Error(t, err)
+	assert.False(t, isOIDCJWKSUnavailable(err))
+}
+
+func TestVerifyOIDCIDToken_IssuerMismatchRejected(t *testing.T) {
+	withOIDCSSRFWhitelist(t, "127.0.0.1")
+	key := rsaTestKey(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(rsaJWKSBody(t, &key.PublicKey, "key-1"))
+	}))
+	defer srv.Close()
+
+	cfg := oidcTestConfig(srv.URL, "https://real-idp.example", "client-1")
+	token := signRS256JWT(t, key, "key-1", jwt.MapClaims{
+		"sub": "user-1", "iss": "https://evil.example", "aud": "client-1",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	err := verifyOIDCIDToken(context.Background(), cfg, token)
+	require.Error(t, err)
+	assert.False(t, isOIDCJWKSUnavailable(err))
+}
+
+func TestVerifyOIDCIDToken_HS256Rejected(t *testing.T) {
+	withOIDCSSRFWhitelist(t, "127.0.0.1")
+	key := rsaTestKey(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(rsaJWKSBody(t, &key.PublicKey, "key-1"))
+	}))
+	defer srv.Close()
+
+	cfg := oidcTestConfig(srv.URL, "https://idp.example", "client-1")
+	// HS256 is outside the asymmetric allowlist and must be refused.
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": "user-1", "iss": "https://idp.example", "aud": "client-1",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	signed, err := token.SignedString([]byte("shared-secret"))
+	require.NoError(t, err)
+
+	err = verifyOIDCIDToken(context.Background(), cfg, signed)
+	require.Error(t, err)
+	assert.False(t, isOIDCJWKSUnavailable(err))
+}
+
+func TestVerifyOIDCIDToken_JWKSUnavailableDegrades(t *testing.T) {
+	withOIDCSSRFWhitelist(t, "127.0.0.1")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := oidcTestConfig(srv.URL, "https://idp.example", "client-1")
+	key := rsaTestKey(t)
+	token := signRS256JWT(t, key, "key-1", jwt.MapClaims{
+		"sub": "user-1", "exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	err := verifyOIDCIDToken(context.Background(), cfg, token)
+	require.Error(t, err)
+	assert.True(t, isOIDCJWKSUnavailable(err), "JWKS fetch failure must be marked unavailable, got: %v", err)
+}
+
+func TestResolveOIDCUserInfo_SignatureFailureRejectsLogin(t *testing.T) {
+	withOIDCSSRFWhitelist(t, "127.0.0.1")
+	serverKey := rsaTestKey(t)
+	attackerKey := rsaTestKey(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(rsaJWKSBody(t, &serverKey.PublicKey, "key-1"))
+	}))
+	defer srv.Close()
+
+	cfg := oidcTestConfig(srv.URL, "https://idp.example", "client-1")
+	cfg.UserInfoMapping = &config.OIDCUserInfoMapping{Username: "name", Email: "email"}
+	token := signRS256JWT(t, attackerKey, "key-1", jwt.MapClaims{
+		"sub": "victim", "name": "Victim", "iss": "https://idp.example", "aud": "client-1",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	svc := &userService{}
+	info, err := svc.resolveOIDCUserInfo(context.Background(), cfg, &oidcTokenResponse{IDToken: token})
+	require.Error(t, err)
+	assert.Nil(t, info)
+	assert.Contains(t, err.Error(), "signature verification failed")
+}
+
+func TestResolveOIDCUserInfo_ValidSignatureAcceptsClaims(t *testing.T) {
+	withOIDCSSRFWhitelist(t, "127.0.0.1")
+	key := rsaTestKey(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(rsaJWKSBody(t, &key.PublicKey, "key-1"))
+	}))
+	defer srv.Close()
+
+	cfg := oidcTestConfig(srv.URL, "https://idp.example", "client-1")
+	cfg.UserInfoMapping = &config.OIDCUserInfoMapping{Username: "name", Email: "email"}
+	token := signRS256JWT(t, key, "key-1", jwt.MapClaims{
+		"sub": "user-1", "name": "Alice", "email": "alice@example.com",
+		"iss": "https://idp.example", "aud": "client-1",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	svc := &userService{}
+	info, err := svc.resolveOIDCUserInfo(context.Background(), cfg, &oidcTokenResponse{IDToken: token})
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, "user-1", info.Subject)
+	assert.Equal(t, "Alice", info.Username)
+	assert.Equal(t, "alice@example.com", info.Email)
+}
+
+func TestResolveOIDCUserInfo_NoJWKSKeepsLegacyBehavior(t *testing.T) {
+	cfg := &config.OIDCAuthConfig{
+		UserInfoMapping: &config.OIDCUserInfoMapping{Username: "name", Email: "email"},
+	}
+	// No JWKSURI: legacy unverified path still works, but expired tokens are
+	// still refused.
+	svc := &userService{}
+	info, err := svc.resolveOIDCUserInfo(context.Background(), cfg, &oidcTokenResponse{
+		IDToken: "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyLTEiLCJuYW1lIjoiQm9iIiwiZXhwIjo0MTAyNDQ0ODAwfQ.x", // exp = 2100
+	})
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, "Bob", info.Username)
+}
+
+func TestResolveOIDCUserInfo_ExpiredRejectedWithoutJWKS(t *testing.T) {
+	cfg := &config.OIDCAuthConfig{
+		UserInfoMapping: &config.OIDCUserInfoMapping{Username: "name", Email: "email"},
+	}
+	svc := &userService{}
+	info, err := svc.resolveOIDCUserInfo(context.Background(), cfg, &oidcTokenResponse{
+		IDToken: "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyLTEiLCJuYW1lIjoiQm9iIiwiZXhwIjoxMDAwMDAwMDAwfQ.x", // exp = 2001-09-09
+	})
+	require.Error(t, err)
+	assert.Nil(t, info)
+	assert.Contains(t, err.Error(), "expired")
+}
+
+func TestResolveOIDCUserInfo_UserInfoOverridesVerifiedClaims(t *testing.T) {
+	withOIDCSSRFWhitelist(t, "127.0.0.1")
+	key := rsaTestKey(t)
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(rsaJWKSBody(t, &key.PublicKey, "key-1"))
+	}))
+	defer jwksSrv.Close()
+
+	userinfoSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer access-123", r.Header.Get("Authorization"))
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"sub": "user-1", "name": "FromUserInfo"})
+	}))
+	defer userinfoSrv.Close()
+
+	cfg := oidcTestConfig(jwksSrv.URL, "https://idp.example", "client-1")
+	cfg.UserInfoEndpoint = userinfoSrv.URL
+	cfg.UserInfoMapping = &config.OIDCUserInfoMapping{Username: "name", Email: "email"}
+	token := signRS256JWT(t, key, "key-1", jwt.MapClaims{
+		"sub": "user-1", "name": "FromIdToken",
+		"iss": "https://idp.example", "aud": "client-1",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	svc := &userService{}
+	info, err := svc.resolveOIDCUserInfo(context.Background(), cfg, &oidcTokenResponse{
+		IDToken:     token,
+		AccessToken: "access-123",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, "FromUserInfo", info.Username)
+}
+
+func TestPopulateOIDCEndpoints_FillsJWKSAndIssuerFromDiscovery(t *testing.T) {
+	withOIDCSSRFWhitelist(t, "127.0.0.1")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"authorization_endpoint": serverURL(r, "/authorize"),
+			"token_endpoint":         serverURL(r, "/token"),
+			"userinfo_endpoint":      serverURL(r, "/userinfo"),
+			"jwks_uri":               serverURL(r, "/jwks"),
+			"issuer":                 "https://idp.example",
+		})
+	}))
+	defer srv.Close()
+
+	cfg := &config.OIDCAuthConfig{DiscoveryURL: srv.URL}
+	svc := &userService{}
+	err := svc.populateOIDCEndpoints(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, srv.URL+"/jwks", cfg.JWKSURI)
+	assert.Equal(t, "https://idp.example", cfg.IssuerURL)
+}
+
+func TestPopulateOIDCEndpoints_RejectsInternalJWKSURI(t *testing.T) {
+	withOIDCSSRFWhitelist(t, "127.0.0.1")
+	// Same whitelist as the token-endpoint test: the discovered jwks_uri
+	// points at a cloud-metadata address, which must be rejected.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"authorization_endpoint": serverURL(r, "/authorize"),
+			"token_endpoint":         serverURL(r, "/token"),
+			"jwks_uri":               "http://169.254.169.254/latest/meta-data/",
+		})
+	}))
+	defer srv.Close()
+
+	cfg := &config.OIDCAuthConfig{DiscoveryURL: srv.URL}
+	svc := &userService{}
+	err := svc.populateOIDCEndpoints(context.Background(), cfg)
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "jwks"), "error should mention jwks: %v", err)
+}

--- a/internal/application/service/user.go
+++ b/internal/application/service/user.go
@@ -1383,6 +1383,8 @@ type oidcDiscoveryDocument struct {
 	AuthorizationEndpoint string `json:"authorization_endpoint"`
 	TokenEndpoint         string `json:"token_endpoint"`
 	UserInfoEndpoint      string `json:"userinfo_endpoint"`
+	JWKSURI               string `json:"jwks_uri"`
+	Issuer                string `json:"issuer"`
 }
 
 type oidcTokenResponse struct {
@@ -1419,6 +1421,9 @@ func validateOIDCEndpoints(cfg *config.OIDCAuthConfig) error {
 		return err
 	}
 	if err := validateOIDCEndpoint("userinfo", cfg.UserInfoEndpoint, false); err != nil {
+		return err
+	}
+	if err := validateOIDCEndpoint("jwks", cfg.JWKSURI, false); err != nil {
 		return err
 	}
 	return nil
@@ -1477,6 +1482,12 @@ func (s *userService) populateOIDCEndpoints(ctx context.Context, cfg *config.OID
 	if cfg.UserInfoEndpoint == "" {
 		cfg.UserInfoEndpoint = doc.UserInfoEndpoint
 	}
+	if cfg.JWKSURI == "" {
+		cfg.JWKSURI = doc.JWKSURI
+	}
+	if cfg.IssuerURL == "" {
+		cfg.IssuerURL = doc.Issuer
+	}
 	if cfg.AuthorizationEndpoint == "" || cfg.TokenEndpoint == "" {
 		return errors.New("OIDC discovery document missing required endpoints")
 	}
@@ -1526,10 +1537,33 @@ func (s *userService) resolveOIDCUserInfo(ctx context.Context, cfg *config.OIDCA
 	claims := map[string]interface{}{}
 
 	if strings.TrimSpace(tokenResp.IDToken) != "" {
+		if strings.TrimSpace(cfg.JWKSURI) != "" {
+			// Signature verification is strictly enforced whenever a JWKS
+			// endpoint is available: an id_token that cannot be proven to be
+			// signed by the IdP is rejected rather than merged in. Only a
+			// transport-level inability to load the JWKS document itself
+			// degrades to legacy behavior below.
+			if err := verifyOIDCIDToken(ctx, cfg, tokenResp.IDToken); err != nil {
+				if isOIDCJWKSUnavailable(err) {
+					logger.Warnf(ctx,
+						"OIDC id_token accepted without signature verification: JWKS unavailable (%v)", err)
+				} else {
+					return nil, err
+				}
+			}
+		} else {
+			logger.Warnf(ctx,
+				"OIDC id_token claims accepted without signature verification (no jwks_uri; set oidc_auth.jwks_uri to verify)")
+		}
 		idTokenClaims, err := decodeJWTClaims(tokenResp.IDToken)
 		if err != nil {
 			logger.Warnf(ctx, "Failed to decode OIDC id_token claims: %v", err)
 		} else {
+			// Even without a verifiable signature, an already-expired token
+			// is never acceptable as an identity source.
+			if err := validateIDTokenExpiry(idTokenClaims); err != nil {
+				return nil, err
+			}
 			for k, v := range idTokenClaims {
 				claims[k] = v
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -316,6 +316,7 @@ type OIDCAuthConfig struct {
 	AuthorizationEndpoint string               `yaml:"authorization_endpoint" json:"authorization_endpoint"`
 	TokenEndpoint         string               `yaml:"token_endpoint"         json:"token_endpoint"`
 	UserInfoEndpoint      string               `yaml:"user_info_endpoint"     json:"user_info_endpoint"`
+	JWKSURI               string               `yaml:"jwks_uri"               json:"jwks_uri"`
 	Scopes                []string             `yaml:"scopes"                 json:"scopes"`
 	UserInfoMapping       *OIDCUserInfoMapping `yaml:"user_info_mapping"      json:"user_info_mapping"`
 }


### PR DESCRIPTION
## Description

Fixes #2799.

The OIDC login flow decoded `id_token` claims with `decodeJWTClaims` (base64 payload decode + JSON only) and never validated the JWS signature: `resolveOIDCUserInfo` at `user.go:1529` merged claims from any token the token endpoint returned. An attacker who can influence the token endpoint (misconfigured/compromised OIDC provider, MITM in a mixed-HTTP setup) could inject arbitrary identity claims.

### Changes

1. **JWKS plumbing**
   - `oidc_auth.jwks_uri` config field (`config.OIDCAuthConfig`)
   - `jwks_uri` + `issuer` discovered from the standard OIDC discovery document and auto-filled when not explicitly configured
   - JWKS endpoint goes through the same SSRF validation as the other OIDC endpoints (internal/metadata addresses rejected)

2. **Signature verification** (`oidc_jwks.go`)
   - id_token verified against the IdP's public keys, cached for 10 minutes
   - Algorithm allowlist: **RS256 / PS256 / ES256 / EdDSA** — HS* is deliberately refused because a symmetric key cannot be validated from a public JWKS
   - `iss`/`aud` enforced via golang-jwt when `IssuerURL`/`ClientID` are configured; `exp` always enforced
   - Any signature failure (wrong key, unknown kid, tampered payload, disallowed algorithm) **rejects the login** — the core attack surface from the issue

3. **Safe degradation** — degradation is limited to *transport-level JWKS fetch failures* (network error, non-2xx response, unparseable document, no usable keys), which keep the legacy unverified behavior with a loud warning, so existing deployments whose IdP jwks_uri is unreachable keep working. Signature mismatch is never degraded.

4. **Expiry hardening on the unverified path** — an already-expired id_token is now rejected even when no JWKS is available.

### Type of Change

- [x] 🐛 Bug fix (security hardening)

### Related Issue

- Fixes #2799

### Testing

- 13 new tests in `oidc_jwks_test.go`: valid RS256 acceptance, wrong-key rejection (with unavailable-vs-failed error classification), expiry rejection, issuer mismatch rejection, HS256 rejection, JWKS-unavailable degrade marker, login-level reject/accept (including userinfo-over-verified-claims precedence), legacy no-JWKS behavior, unverified-path expiry rejection, discovery `jwks_uri`/`issuer` population, and internal-`jwks_uri` SSRF rejection
- `go test ./internal/application/service/ -skip TestSkillPythonVerifier` — pass (the skipped test fails on baseline `origin/main` too: environment-dependent venv setup, unrelated)
- `go vet ./internal/application/service/` — clean

### Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Breaking changes are clearly called out in the description above (none: verification activates via discovery jwks_uri; unreachable JWKS degrades with a warning)