### PR TITLE
fix(chat): fall back to tenant default rerank model for builtin agents

### DIFF
--- a/internal/application/service/session_knowledge_qa.go
+++ b/internal/application/service/session_knowledge_qa.go
@@ -153,6 +153,25 @@ func (s *sessionService) KnowledgeQA(
 	// rewrite, fallback, FAQ strategy, history turns)
 	s.applyAgentOverridesToChatManage(ctx, req.CustomAgent, chatManage)
 
+	// Resolve a default rerank model when the effective agent config left
+	// RerankModelID empty. Builtin agents (builtin-quick-answer /
+	// builtin-smart-reasoning) ship without a rerank_model_id in their
+	// YAML definition, so without this fallback quick-answer silently
+	// skipped reranking (unranked top-K, ballooning SSE responses) and
+	// smart-reasoning could only hard-error on fresh installs. See #1800.
+	// Resolution order: agent config > tenant default (is_default=true) >
+	// first available rerank model.
+	if chatManage.RerankModelID == "" {
+		if defaultID := s.resolveDefaultRerankModelID(ctx); defaultID != "" {
+			chatManage.RerankModelID = defaultID
+			logger.Infof(ctx,
+				"[KnowledgeQA] rerank_model_id unset after agent overrides; using default rerank model %s", defaultID)
+		} else {
+			logger.Warnf(ctx,
+				"[KnowledgeQA] rerank_model_id unset and no tenant rerank model available; rerank stage will be skipped")
+		}
+	}
+
 	// An agent may opt out of long-term memory. The preference is per-request
 	// rather than per-user, so it travels in the context that the recall
 	// plugin reads.
@@ -1239,6 +1258,35 @@ func (s *sessionService) emitFallbackAnswer(ctx context.Context, chatManage *typ
 	} else {
 		logger.Infof(ctx, "Fallback answer event emitted successfully")
 	}
+}
+
+// resolveDefaultRerankModelID returns a rerank model ID to fall back to when
+// no agent-level rerank_model_id is configured. Priority: the tenant's
+// default rerank model (is_default=true), then the first available rerank
+// model. Download-failed models are never eligible — the rerank stage would
+// error on them anyway. Returns "" when the tenant has no rerank model.
+func (s *sessionService) resolveDefaultRerankModelID(ctx context.Context) string {
+	models, err := s.modelService.ListModels(ctx)
+	if err != nil {
+		logger.Warnf(ctx, "Failed to list models for default rerank resolution: %v", err)
+		return ""
+	}
+	var firstAvailable string
+	for _, m := range models {
+		if m == nil || m.Type != types.ModelTypeRerank {
+			continue
+		}
+		if m.Status == types.ModelStatusDownloadFailed || m.Status == types.ModelStatusDownloading {
+			continue
+		}
+		if firstAvailable == "" {
+			firstAvailable = m.ID
+		}
+		if m.IsDefault {
+			return m.ID
+		}
+	}
+	return firstAvailable
 }
 
 // resolveWebSearchProviderID returns the web search provider ID to use for a pipeline request.

--- a/internal/application/service/session_knowledge_qa_test.go
+++ b/internal/application/service/session_knowledge_qa_test.go
@@ -181,3 +181,38 @@ func TestHandleModelFallback_IncludesHistoryMessages(t *testing.T) {
 	assert.Equal(t, "user", chatModel.lastMessages[3].Role)
 	assert.Contains(t, chatModel.lastMessages[3].Content, "现在还能继续讲吗？")
 }
+
+// TestResolveDefaultRerankModelID covers the tenant-default rerank fallback
+// used by KnowledgeQA when an agent (e.g. a builtin agent whose YAML has no
+// rerank_model_id) leaves RerankModelID empty. See #1800.
+func TestResolveDefaultRerankModelID(t *testing.T) {
+	newSvc := func(models []*types.Model) *sessionService {
+		return &sessionService{modelService: &stubModelService{availableModels: models}}
+	}
+	rerankPlain := &types.Model{ID: "rerank-a", Type: types.ModelTypeRerank}
+	rerankDefault := &types.Model{ID: "rerank-d", Type: types.ModelTypeRerank, IsDefault: true}
+	rerankDownloading := &types.Model{ID: "rerank-dl", Type: types.ModelTypeRerank, Status: types.ModelStatusDownloading}
+	rerankFailed := &types.Model{ID: "rerank-f", Type: types.ModelTypeRerank, Status: types.ModelStatusDownloadFailed}
+	chatModel := &types.Model{ID: "chat-1", Type: types.ModelTypeKnowledgeQA}
+
+	t.Run("prefers the tenant default rerank model", func(t *testing.T) {
+		svc := newSvc([]*types.Model{rerankPlain, rerankDefault})
+		require.Equal(t, "rerank-d", svc.resolveDefaultRerankModelID(context.Background()))
+	})
+	t.Run("falls back to the first rerank model when none is default", func(t *testing.T) {
+		svc := newSvc([]*types.Model{chatModel, rerankPlain})
+		require.Equal(t, "rerank-a", svc.resolveDefaultRerankModelID(context.Background()))
+	})
+	t.Run("skips downloading and download-failed models", func(t *testing.T) {
+		svc := newSvc([]*types.Model{rerankFailed, rerankDownloading, rerankPlain})
+		require.Equal(t, "rerank-a", svc.resolveDefaultRerankModelID(context.Background()))
+	})
+	t.Run("returns empty when the tenant has no usable rerank model", func(t *testing.T) {
+		svc := newSvc([]*types.Model{chatModel})
+		require.Equal(t, "", svc.resolveDefaultRerankModelID(context.Background()))
+	})
+	t.Run("returns empty when the model list is empty", func(t *testing.T) {
+		svc := newSvc(nil)
+		require.Equal(t, "", svc.resolveDefaultRerankModelID(context.Background()))
+	})
+}


### PR DESCRIPTION
## Description

Fixes #1800 (KnowledgeQA 部分：内置智能体 rerank_model_id 为空时静默跳过 rerank 的问题)。

代码层确认的问题链：

- `config/builtin_agents.yaml`：内置 `builtin-quick-answer` / `builtin-smart-reasoning` 均未声明 `rerank_model_id`；
- `session_qa_helpers.go` 的 `applyAgentOverridesToChatManage` 只在 agent 配置非空时设置 `RerankModelID`，因此内置智能体走 KnowledgeQA 时该字段恒为空；
- `chat_pipeline/rerank.go:57` 遇到空 `RerankModelID` 仅记一条 warn 后静默跳过 rerank → 50 个候选块不做重排直接返回，SSE 响应膨胀（issue 实测 ~416KB），且用户无感知。

本次改动：KnowledgeQA 在 agent 覆盖应用之后，若 `RerankModelID` 仍为空，则回退到租户级默认 rerank 模型（`is_default=true` 优先，其次第一个可用的 rerank 模型），并打印清晰的 info/warn 日志。解析顺序与既有的 `resolveWebSearchProviderID`（agent 配置 > 租户默认）模式一致。

### Change

- `internal/application/service/session_knowledge_qa.go`：新增 `resolveDefaultRerankModelID` 辅助函数（优先 `is_default=true`，跳过 `downloading` / `download_failed` 状态的模型，无可用模型时返回空串）。
- 同一文件 `KnowledgeQA`：agent overrides 之后对空 `RerankModelID` 做默认回退并记录日志；无可用模型时显式 warn（不再无声降级）。
- `session_knowledge_qa_test.go`：新增 `TestResolveDefaultRerankModelID` 5 个子用例（默认优先 / 无默认时首个可用 / 跳过下载中与下载失败 / 无可用模型返回空 / 空列表返回空）。

### Scope note

未改动 smart-reasoning 的 agent 管线路径（`session_agent_qa.go`）。该路径对自定义智能体空 rerank 配置的硬报错是维护者的既有设计（注释明确说明有意移除租户级静默回退，强迫用户显式配置），不在本 PR 范围内。若今后需要覆盖内置智能体的 agent 路径，可在此基础上扩展。

### Type of Change

- [x] 🐛 Bug fix

### Related Issue

- Fixes #1800

### Testing

- 新增测试：`TestResolveDefaultRerankModelID` — 覆盖默认优先、无默认回退首个可用、跳过 downloading/download_failed、无可用模型/空列表返回空（含失败路径）。
- `go test ./internal/application/service/ -run TestResolveDefaultRerankModelID -count=1 -v` — PASS（5/5 子用例）
- `go test ./internal/application/service/ -count=1` — 见下方说明
- `go vet ./internal/application/service/` — clean
- `gofmt -l` 无输出；`git diff --check` 干净

### Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Breaking changes: none（无破坏性变更；仅在 agent 未配置 rerank 时启用租户默认模型回退，可被显式配置覆盖）