### PR TITLE
feat(mcp): support updating manual knowledge

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### 新增
 - 新增 `create_knowledge_from_text` 工具：通过手动 Markdown 文本创建知识条目，调用既有 `/knowledge-bases/{id}/knowledge/manual` 接口，补齐 #323 中"文本"部分。默认 `status="publish"`，创建后即进入解析/索引流程、可被检索；可传 `status="draft"` 仅保存不索引。
+- 新增 `update_knowledge_from_text` 工具：通过既有 `PUT /knowledge/manual/{id}` 接口更新手工 Markdown 知识；默认重新索引，也可保存为草稿，补齐 #2378。
 - README 工具清单补列既有的 `create_knowledge_from_file`。
 
 ## [1.1.1] - 2026-07-30

--- a/mcp-server/EXAMPLES.md
+++ b/mcp-server/EXAMPLES.md
@@ -135,6 +135,21 @@ echo "WEKNORA_API_KEY=your_api_key_here" >> .env
 }
 ```
 
+#### 更新手工知识
+```json
+{
+  "tool": "update_knowledge_from_text",
+  "arguments": {
+    "knowledge_id": "know_789012",
+    "title": "注意力机制摘要（修订版）",
+    "content": "# 注意力机制\n\n这里是修订后的 Markdown 内容...",
+    "status": "publish"
+  }
+}
+```
+
+省略 `title` 或传空字符串会保留原标题；将 `status` 设为 `draft` 可只保存内容而不重新索引。
+
 #### 列出知识
 ```json
 {

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -123,6 +123,7 @@ python test_module.py
 - `create_knowledge_from_file` - 从本地文件创建知识
 - `create_knowledge_from_url` - 从 URL 创建知识
 - `create_knowledge_from_text` - 从文本创建知识
+- `update_knowledge_from_text` - 更新手工 Markdown 知识，可重新索引或保存为草稿
 - `list_knowledge` - 列出知识
 - `get_knowledge` - 获取知识详情
 - `delete_knowledge` - 删除知识

--- a/mcp-server/test_mcp_transports.py
+++ b/mcp-server/test_mcp_transports.py
@@ -66,7 +66,7 @@ class TransportRegressionTest(unittest.TestCase):
 
 
 class StdioToolsListTest(unittest.TestCase):
-    def test_tools_list_returns_30_tools(self):
+    def test_tools_list_returns_31_tools(self):
         async def _run() -> int:
             from mcp import ClientSession, StdioServerParameters
             from mcp.client.stdio import stdio_client
@@ -86,7 +86,7 @@ class StdioToolsListTest(unittest.TestCase):
                     return len(tools.tools)
 
         count = asyncio.run(_run())
-        self.assertEqual(count, 30)
+        self.assertEqual(count, 31)
 
 
 class HttpStatelessSmokeTest(unittest.TestCase):

--- a/mcp-server/test_update_knowledge_from_text.py
+++ b/mcp-server/test_update_knowledge_from_text.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Tests for the update_knowledge_from_text MCP tool and client method."""
+
+import unittest
+from unittest import mock
+
+import weknora_mcp_server as srv
+
+
+class UpdateKnowledgeFromTextTest(unittest.TestCase):
+    def test_client_puts_manual_update_to_expected_endpoint(self):
+        client = srv.WeKnoraClient("http://localhost:8080/api/v1", "k")
+        with mock.patch.object(client, "_request") as req:
+            req.return_value = {"ok": True}
+            result = client.update_knowledge_from_text(
+                "knowledge-1", "# Updated", title="New title"
+            )
+
+        self.assertEqual(result, {"ok": True})
+        req.assert_called_once_with(
+            "PUT",
+            "/knowledge/manual/knowledge-1",
+            json={
+                "title": "New title",
+                "content": "# Updated",
+                "status": "publish",
+            },
+        )
+
+    def test_client_can_save_a_draft_and_keep_the_title(self):
+        client = srv.WeKnoraClient("http://localhost:8080/api/v1", "k")
+        with mock.patch.object(client, "_request") as req:
+            req.return_value = {"ok": True}
+            client.update_knowledge_from_text(
+                "knowledge-1", "Draft content", status="draft"
+            )
+
+        self.assertEqual(
+            req.call_args.kwargs["json"],
+            {"title": "", "content": "Draft content", "status": "draft"},
+        )
+
+    def test_tool_forwards_all_update_fields(self):
+        with mock.patch.object(
+            srv.client, "update_knowledge_from_text", return_value={"ok": True}
+        ) as method:
+            result = srv.update_knowledge_from_text(
+                "knowledge-1", "Body", title="Title", status="draft"
+            )
+
+        self.assertEqual(result, {"ok": True})
+        method.assert_called_once_with(
+            "knowledge-1", "Body", title="Title", status="draft"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp-server/weknora_mcp_server.py
+++ b/mcp-server/weknora_mcp_server.py
@@ -360,6 +360,26 @@ class WeKnoraClient:
             "POST", f"/knowledge-bases/{kb_id}/knowledge/manual", json=data
         )
 
+    def update_knowledge_from_text(
+        self,
+        knowledge_id: str,
+        content: str,
+        title: str = "",
+        status: str = "publish",
+    ) -> Dict:
+        """Update an existing manual Markdown knowledge entry.
+
+        An empty ``title`` keeps the current title. ``status`` defaults to
+        ``"publish"`` so the updated content is re-indexed immediately; pass
+        ``"draft"`` to save it without indexing.
+        """
+        data = {
+            "title": title,
+            "content": content,
+            "status": status,
+        }
+        return self._request("PUT", f"/knowledge/manual/{knowledge_id}", json=data)
+
     def list_knowledge(self, kb_id: str, page: int = 1, page_size: int = 20) -> Dict:
         """List knowledge in a knowledge base"""
         params = {"page": page, "page_size": page_size}
@@ -757,6 +777,25 @@ def create_knowledge_from_text(
     """
     return client.create_knowledge_from_text(
         client.resolve_kb_id(kb_id), title, content, tag_ids=tag_ids, status=status
+    )
+
+
+@mcp.tool()
+def update_knowledge_from_text(
+    knowledge_id: str,
+    content: str,
+    title: str = "",
+    status: str = "publish",
+) -> dict:
+    """Update an existing manual Markdown knowledge entry.
+
+    ``knowledge_id`` is the ID returned by ``create_knowledge_from_text`` or
+    ``list_knowledge``. ``content`` is required. Leave ``title`` empty to keep
+    the current title. ``status`` defaults to ``"publish"`` so the new content
+    is re-indexed; pass ``"draft"`` to save without indexing.
+    """
+    return client.update_knowledge_from_text(
+        knowledge_id, content, title=title, status=status
     )
 
 


### PR DESCRIPTION
## Description

Add an MCP tool for updating existing manual Markdown knowledge without requiring clients to call the REST API directly.

- add `WeKnoraClient.update_knowledge_from_text`, backed by the existing `PUT /knowledge/manual/{id}` endpoint
- expose `update_knowledge_from_text` through MCP with publish/draft behavior and title preservation
- add request/forwarding regression coverage and update the MCP tool-count guard
- document the tool and usage example

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2378

## Testing

- `python -m unittest test_update_knowledge_from_text -v` — 3 passed
- stdio `tools/list` regression test — passed and reports 31 tools
- manual Streamable HTTP initialize probe — `HTTP/1.1 200 OK`, no session header
- `python -m black --check test_update_knowledge_from_text.py` — passed
- `python -m flake8 --max-line-length=88 test_update_knowledge_from_text.py` — passed
- `python -m compileall -q weknora_mcp_server.py test_update_knowledge_from_text.py` — passed
- `git diff --check origin/main...HEAD` — passed

The full Windows discovery run passed 23/26 tests. The three remaining failures are existing Windows test-harness incompatibilities: two temporary-directory tests retain the directory as the current working directory during cleanup, and the HTTP smoke test invokes `curl.exe -o /dev/null` (the same server probe succeeds with Windows `NUL`). Linux CI remains the authoritative full-suite gate.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source hunks and the new test follow the existing format
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository check limitations are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation
- [x] No breaking changes

## Screenshots / Recordings

No UI changes.
