### PR TITLE
fix(sandbox): grant appuser the docker.sock group inside the app container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - ./skills/preloaded:/app/skills/preloaded
       # Docker 沙箱默认关闭（见 WEKNORA_SANDBOX_DOCKER_ENABLED）。需要本机 daemon 时
       # 同时设 true 并挂载实际 socket——这等同宿主机 root，仅私有化单机。
+      # 入口脚本会按 socket GID 把 appuser 加入对应组（compose group_add 在 gosu 后无效）。
       # - /var/run/docker.sock:/var/run/docker.sock
       # Optional: declarative built-in models. Copy config/builtin_models.yaml.example
       # to config/builtin_models.yaml, edit it for your deployment, then

--- a/docs/sandbox-docker-backend.md
+++ b/docs/sandbox-docker-backend.md
@@ -145,7 +145,10 @@ Debian 系基础镜像天然带 find 和 timeout。
 
 WeKnora 自己跑在容器里时，要把 **实际的** docker socket 挂进 app 容器（并接受它等同宿主机 root 的事实），
 或者改用远程 daemon。Linux 上通常是 `/var/run/docker.sock`；macOS 上 Colima / Docker Desktop / OrbStack
-各自有 `$HOME` 下的 socket，以 `docker context show` 为准。
+各自有 `$HOME` 下的 socket，以 `docker context show` 为准。入口脚本在 `gosu` 降权前会按
+socket 的 GID 把 `appuser` 加入对应组；不要依赖 compose `group_add`，也不要 `chmod 666`
+宿主机 socket。若 socket 是 `root:root` 且仅所有者可写，容器内无法安全补权，需在宿主机把
+socket 改成非 root 组的 `660`。
 
 ## 边界
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -39,5 +39,50 @@ if [ -d "$BUILTIN_DIR" ]; then
     chown -R appuser:appuser "$PRELOADED_DIR"
 fi
 
+# ─── Docker socket access for the sandbox backend ───
+# The Engine API socket is typically root:docker 0660. This process then
+# drops to appuser via gosu, which calls initgroups and therefore drops
+# compose group_add. Match the socket's GID in /etc/group before gosu.
+# Never chmod the host socket: that would weaken daemon access on the host.
+grant_docker_sock_to_appuser() {
+    local sock="$1"
+    local gid grp
+    [ -S "$sock" ] || return 0
+    if gosu appuser sh -c "test -r \"$sock\" && test -w \"$sock\"" 2>/dev/null; then
+        return 0
+    fi
+    gid="$(stat -c '%g' "$sock" 2>/dev/null || true)"
+    if [ -z "$gid" ]; then
+        echo "weknora: cannot stat $sock; Docker sandbox may be unable to reach the daemon" >&2
+        return 0
+    fi
+    if [ "$gid" = "0" ]; then
+        echo "weknora: $sock is not writable by appuser and owned by GID 0; Docker sandbox needs a group-writable socket with a non-root GID" >&2
+        return 0
+    fi
+    if ! getent group "$gid" >/dev/null 2>&1; then
+        if ! groupadd -g "$gid" dockersock >/dev/null 2>&1; then
+            echo "weknora: failed to create group for $sock GID $gid; Docker sandbox may be unable to reach the daemon" >&2
+            return 0
+        fi
+    fi
+    grp="$(getent group "$gid" | cut -d: -f1)"
+    if [ -z "$grp" ]; then
+        echo "weknora: no group name for GID $gid on $sock" >&2
+        return 0
+    fi
+    if ! usermod -aG "$grp" appuser >/dev/null 2>&1; then
+        echo "weknora: failed to add appuser to $grp for $sock; Docker sandbox may be unable to reach the daemon" >&2
+        return 0
+    fi
+}
+
+grant_docker_sock_to_appuser /var/run/docker.sock
+case "${DOCKER_HOST:-}" in
+    unix://*)
+        grant_docker_sock_to_appuser "${DOCKER_HOST#unix://}"
+        ;;
+esac
+
 # ─── Drop privileges and exec the main process ───
 exec gosu appuser "$@"

--- a/website-docs/01-getting-started/02-installation.md
+++ b/website-docs/01-getting-started/02-installation.md
@@ -127,7 +127,7 @@ make dev-logs / dev-status / dev-stop / dev-restart
 
 | Dockerfile | 产物镜像 | 要点 |
 | --- | --- | --- |
-| `docker/Dockerfile.app` | `wechatopenai/weknora-app` | 两阶段：`golang:1.26-bookworm` 编译（`make build-prod`，默认 `WITH_ANYDOC=1` 链接进程内 office 解析引擎，注入版本信息，预下载 DuckDB 扩展 `cmd/download/duckdb`）→ `debian:12.12-slim` 运行层（含 `migrate` 迁移工具、python3/node/uvx（供 stdio MCP 与 Skills 使用）、ffmpeg（ASR）、gosu 降权）。入口 `scripts/docker-entrypoint.sh`：修复挂载目录属主、把 `_builtin` 内置 Skills 合并回 `skills/preloaded`，再以 appuser 运行 `./WeKnora`。`EXPOSE 8080` |
+| `docker/Dockerfile.app` | `wechatopenai/weknora-app` | 两阶段：`golang:1.26-bookworm` 编译（`make build-prod`，默认 `WITH_ANYDOC=1` 链接进程内 office 解析引擎，注入版本信息，预下载 DuckDB 扩展 `cmd/download/duckdb`）→ `debian:12.12-slim` 运行层（含 `migrate` 迁移工具、python3/node/uvx（供 stdio MCP 与 Skills 使用）、ffmpeg（ASR）、gosu 降权）。入口 `scripts/docker-entrypoint.sh`：修复挂载目录属主、把 `_builtin` 内置 Skills 合并回 `skills/preloaded`；若挂载了 docker.sock，按 socket GID 把 appuser 加入对应组（compose `group_add` 在 gosu 后无效），再以 appuser 运行 `./WeKnora`。`EXPOSE 8080` |
 | `docker/Dockerfile.docreader` | `wechatopenai/weknora-docreader` | Python 3.10 + uv 依赖锁定；生成 protobuf；运行层安装 LibreOffice、OpenJDK 17、antiword、Playwright（webkit）与 `grpc_health_probe`。轻量版不含 PaddleOCR。`EXPOSE 50051`。支持 `APT_MIRROR` 构建参数 |
 | `docker/Dockerfile.odl-hybrid` | `weknora-odl-hybrid:local` | 安装 `opendataloader-pdf[hybrid]`（Docling），监听 5002，默认 `--no-ocr`；仅本地构建不发布 |
 | `docker/Dockerfile.sandbox` | `wechatopenai/weknora-sandbox` | Python 3.11-slim + Node 20 + jq，非 root 用户 `user`(UID 1000)，Agent Skills 的会话沙箱镜像 |
@@ -170,7 +170,7 @@ make docker-build-frontend
 | `scripts/build_images.sh` | 构建镜像并注入版本（git tag / commit / build time），支持跨架构 |
 | `scripts/build_frontend_dist.sh` | 构建前端静态产物 `frontend/dist`（frontend 镜像的前置步骤） |
 | `scripts/migrate.sh` | golang-migrate 封装 |
-| `scripts/docker-entrypoint.sh` | app 容器入口（属主修复 + 内置 Skills 合并 + gosu 降权） |
+| `scripts/docker-entrypoint.sh` | app 容器入口（属主修复 + 内置 Skills 合并 + docker.sock GID 补组 + gosu 降权） |
 | `scripts/package-lite.sh` / `package-mac-app.sh` | Lite tarball / macOS .app 打包 |
 
 ## 六、Helm 部署（helm/）


### PR DESCRIPTION
## Description

When WeKnora itself runs in Docker and the operator mounts the host Engine API socket, the app process still dropped to `appuser` via `gosu`. `compose group_add` is lost at that drop, so connecting to `unix:///var/run/docker.sock` failed with `permission denied` even after the socket was mounted.

The entrypoint now matches the socket GID (and `DOCKER_HOST=unix://…` when set) and adds `appuser` to that group before dropping privileges. It does not `chmod` the host socket, and it does not add `appuser` to GID 0. Docker sandbox remains opt-in (`WEKNORA_SANDBOX_DOCKER_ENABLED` / System Settings, default off).

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #

## Testing
- `bash -n scripts/docker-entrypoint.sh`
- On a compose deploy with `/var/run/docker.sock` mounted (`root:docker` GID 991): stripped `appuser` from the docker group, restarted with the new entrypoint, confirmed `id appuser` includes `991(docker)` and a unix-socket connect as `appuser` succeeds.
- `git diff --check github_public/main...HEAD` passes.

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [ ] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
N/A (entrypoint / deploy docs only)