### PR TITLE
fix(knowledge): recover stale processing spans

### DIFF
--- a/internal/application/service/knowledge_housekeeping.go
+++ b/internal/application/service/knowledge_housekeeping.go
@@ -1,8 +1,8 @@
 // Package service: knowledge housekeeping.
 //
-// HousekeepingService periodically scans for knowledge rows that have been
-// stuck in "processing" longer than any reasonable execution window and
-// marks them as failed. This is the safety net that catches anything the
+// HousekeepingService periodically scans for knowledge rows and trace spans
+// that have been stuck longer than any reasonable execution window and marks
+// them as failed. This is the safety net that catches anything the
 // other defences (asynq retry, dead-letter callback, image_multimodal
 // finalize-on-last-attempt) miss — for example:
 //
@@ -32,6 +32,8 @@ import (
 	"github.com/robfig/cron/v3"
 	"gorm.io/gorm"
 )
+
+const staleSpanTimeoutErrorCode = "STALE_SPAN_TIMEOUT"
 
 // HousekeepingService runs background sweeps to recover stuck rows.
 type HousekeepingService struct {
@@ -89,6 +91,15 @@ func (h *HousekeepingService) Start(ctx context.Context) error {
 	}); err != nil {
 		return err
 	}
+	// The periodic cron does not run until the next five-minute boundary.
+	// Close spans orphaned by a previous process immediately so a restart
+	// repairs the trace UI without waiting for that first tick. This startup
+	// pass only touches terminal knowledge rows, so it cannot race queued or
+	// currently executing work while the task system is still bootstrapping.
+	threshold := h.staleThreshold()
+	h.recoverStaleOpenSpans(
+		context.Background(), time.Now().Add(-threshold), threshold,
+	)
 	h.cron.Start()
 	h.started = true
 	logger.Infof(ctx, "[Housekeeping] started with 5-minute sweep")
@@ -197,6 +208,13 @@ func (h *HousekeepingService) runSweep(ctx context.Context) {
 			queueSkipped)
 	}
 
+	// A child span can be left running even after its parent knowledge row is
+	// terminal (for example when a Wiki reducer is interrupted after the
+	// parent finalizer completes). Such rows are invisible to Sweep A because
+	// completed/failed knowledge is intentionally not considered stuck.
+	// Repair those orphan trace rows independently.
+	h.recoverStaleOpenSpans(ctx, cutoff, threshold)
+
 	// Sweep B: knowledge summary stuck. Summary is post-parse; threshold
 	// is shorter because summary tasks are bounded by a single LLM call.
 	// No span heartbeat exists for the summary stage (it lives in a
@@ -209,6 +227,50 @@ func (h *HousekeepingService) runSweep(ctx context.Context) {
 		logger.Warnf(ctx, "[Housekeeping] summary sweep failed: %v", resSummary.Error)
 	} else if resSummary.RowsAffected > 0 {
 		logger.Infof(ctx, "[Housekeeping] recovered %d stuck summary rows", resSummary.RowsAffected)
+	}
+}
+
+// recoverStaleOpenSpans fails pending/running spans that have exceeded the
+// housekeeping threshold after their owning knowledge became terminal.
+//
+// The terminal-parent gate is what makes this safe: an old span under a
+// processing/finalizing knowledge may still belong to a slow live task and is
+// handled by Sweep A's heartbeat + queue checks instead. The created_at
+// fallback covers old pending rows that never received started_at; the direct
+// started_at branch remains compatible with the existing status/time index.
+func (h *HousekeepingService) recoverStaleOpenSpans(
+	ctx context.Context, cutoff time.Time, threshold time.Duration,
+) {
+	terminalKnowledgeIDs := h.db.WithContext(ctx).
+		Model(&types.Knowledge{}).
+		Select("id").
+		Where("parse_status IN ?", []string{
+			types.ParseStatusCompleted,
+			types.ParseStatusFailed,
+		})
+
+	now := time.Now()
+	res := h.db.WithContext(ctx).
+		Model(&types.KnowledgeProcessingSpan{}).
+		Where("status IN ?", []string{
+			types.SpanStatusPending,
+			types.SpanStatusRunning,
+		}).
+		Where("started_at < ? OR (started_at IS NULL AND created_at < ?)", cutoff, cutoff).
+		Where("knowledge_id IN (?)", terminalKnowledgeIDs).
+		Updates(map[string]interface{}{
+			"status":        types.SpanStatusFailed,
+			"error_code":    staleSpanTimeoutErrorCode,
+			"error_message": "span left open after parent knowledge became terminal for more than " + threshold.String(),
+			"finished_at":   now,
+			"updated_at":    now,
+		})
+	if res.Error != nil {
+		logger.Warnf(ctx, "[Housekeeping] stale span sweep failed: %v", res.Error)
+	} else if res.RowsAffected > 0 {
+		logger.Infof(ctx,
+			"[Housekeeping] recovered %d stale open span(s) owned by terminal knowledge (threshold=%s)",
+			res.RowsAffected, threshold)
 	}
 }
 

--- a/internal/application/service/knowledge_housekeeping_test.go
+++ b/internal/application/service/knowledge_housekeeping_test.go
@@ -121,9 +121,10 @@ func insertKnowledge(t *testing.T, db *gorm.DB, id, status string, updatedAt tim
 func insertSpan(t *testing.T, db *gorm.DB, kid string, attempt int, spanID, status string, updatedAt time.Time) {
 	t.Helper()
 	require.NoError(t, db.Exec(
-		`INSERT INTO knowledge_processing_spans (knowledge_id, attempt, span_id, name, kind, status, updated_at)
-		 VALUES (?, ?, ?, 'docreader', 'stage', ?, ?)`,
-		kid, attempt, spanID, status, updatedAt,
+		`INSERT INTO knowledge_processing_spans
+		 (knowledge_id, attempt, span_id, name, kind, status, started_at, created_at, updated_at)
+		 VALUES (?, ?, ?, 'docreader', 'stage', ?, ?, ?, ?)`,
+		kid, attempt, spanID, status, updatedAt, updatedAt, updatedAt,
 	).Error)
 }
 
@@ -273,6 +274,50 @@ func TestHousekeeping_NoFalseKill_StaleSpanRecovers(t *testing.T) {
 	).Row().Scan(&status))
 	assert.Equal(t, types.ParseStatusFailed, status,
 		"genuinely stuck knowledge (knowledge AND spans both stale) must still be recovered")
+
+	var span types.KnowledgeProcessingSpan
+	require.NoError(t, db.Where("knowledge_id = ? AND span_id = ?", "kid-stuck", "docreader-1").First(&span).Error)
+	assert.Equal(t, types.SpanStatusFailed, span.Status)
+	assert.Equal(t, staleSpanTimeoutErrorCode, span.ErrorCode)
+	assert.NotNil(t, span.FinishedAt)
+}
+
+func TestHousekeeping_StartRecoversStaleOpenSpanForCompletedKnowledge(t *testing.T) {
+	t.Setenv("WEKNORA_HOUSEKEEPING_ENABLED", "true")
+	db := setupHousekeepingDB(t)
+	svc := newHousekeepingSvcForTest(db)
+	stale := time.Now().Add(-3 * time.Hour)
+	insertKnowledge(t, db, "kid-completed", types.ParseStatusCompleted, time.Now())
+	insertSpan(t, db, "kid-completed", 1, "wiki-page-1", types.SpanStatusRunning, stale)
+
+	require.NoError(t, svc.Start(context.Background()))
+	defer svc.Stop()
+
+	var span types.KnowledgeProcessingSpan
+	require.NoError(t, db.Where(
+		"knowledge_id = ? AND span_id = ?", "kid-completed", "wiki-page-1",
+	).First(&span).Error)
+	assert.Equal(t, types.SpanStatusFailed, span.Status)
+	assert.Equal(t, staleSpanTimeoutErrorCode, span.ErrorCode)
+	assert.Contains(t, span.ErrorMessage, "parent knowledge became terminal")
+	assert.NotNil(t, span.FinishedAt)
+}
+
+func TestHousekeeping_PreservesFreshOpenSpanForCompletedKnowledge(t *testing.T) {
+	db := setupHousekeepingDB(t)
+	svc := newHousekeepingSvcForTest(db)
+	insertKnowledge(t, db, "kid-just-completed", types.ParseStatusCompleted, time.Now())
+	insertSpan(t, db, "kid-just-completed", 1, "wiki-page-1", types.SpanStatusRunning, time.Now())
+
+	svc.runSweep(context.Background())
+
+	var span types.KnowledgeProcessingSpan
+	require.NoError(t, db.Where(
+		"knowledge_id = ? AND span_id = ?", "kid-just-completed", "wiki-page-1",
+	).First(&span).Error)
+	assert.Equal(t, types.SpanStatusRunning, span.Status)
+	assert.Empty(t, span.ErrorCode)
+	assert.Nil(t, span.FinishedAt)
 }
 
 // TestHousekeeping_NoFalseKill_TasksStillQueued is the regression test


### PR DESCRIPTION
## Description

修复知识已经进入终态后，历史 `pending` / `running` processing span 永久残留的问题。

- 启动 housekeeping 时立即清理上一次进程遗留的超时 open span，无需等待首个 5 分钟 cron tick
- 在周期 sweep 中持续清理父知识已 `completed` / `failed` 的超时 open span
- 只处理超过现有 housekeeping threshold 的 span，避免和刚完成知识的尾部写入竞争
- 将恢复后的 span 标记为 `failed`，写入 `STALE_SPAN_TIMEOUT`、错误信息和 `finished_at`
- 当 housekeeping 同时把卡死知识置为 failed 时，一并收尾其 stale span

非终态知识仍沿用现有的 span heartbeat + durable queue + task inspector 三重判断，不会因为本次清理被误杀。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2619

## Testing

在 Ubuntu 24.04 WSL、Go 1.26.2、CGO/GCC 环境执行：

- `go test ./internal/application/service -run '^TestHousekeeping_' -count=1 -v` — 12 项全部通过
- `go test ./internal/application/service -count=1` — 通过（10.393s）
- `go vet ./internal/application/service` — 通过
- `gofmt` — 已应用于两个改动文件
- `git diff --check origin/main...HEAD` — 通过

未运行全仓库测试；改动仅位于 `internal/application/service`，该包完整测试已通过。

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository check scope is documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (无用户配置或接口变化)
- [x] No breaking changes

## Screenshots / Recordings

无 UI 改动。
