### PR TITLE
fix(tenant): prevent account deadlock when deleting the last workspace

### DIFF
--- a/internal/application/repository/tenant.go
+++ b/internal/application/repository/tenant.go
@@ -121,10 +121,16 @@ func (r *tenantRepository) UpdateTenant(ctx context.Context, tenant *types.Tenan
 // DeleteTenant soft-deletes the tenant and every active membership row
 // for that tenant in one transaction. Without the membership purge,
 // /auth/me still lists the defunct tenant (name lookup fails → UI shows
-// "#<id>").
+// "#<id>"). It also NULLs users.tenant_id for members whose home tenant
+// was the deleted one (NULL, not 0 — the column is nullable and FK-checked
+// in PostgreSQL, see userRepository.UpdateUser), so login never resolves
+// to a soft-deleted tenant.
 func (r *tenantRepository) DeleteTenant(ctx context.Context, id uint64) error {
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where("tenant_id = ?", id).Delete(&types.TenantMember{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&types.User{}).Where("tenant_id = ?", id).UpdateColumn("tenant_id", nil).Error; err != nil {
 			return err
 		}
 		return tx.Where("id = ?", id).Delete(&types.Tenant{}).Error

--- a/internal/application/repository/tenant_test.go
+++ b/internal/application/repository/tenant_test.go
@@ -16,7 +16,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&types.Tenant{}, &types.TenantMember{}))
+	require.NoError(t, db.AutoMigrate(&types.Tenant{}, &types.TenantMember{}, &types.User{}))
 	return db
 }
 
@@ -54,4 +54,38 @@ func TestDeleteTenant_SoftDeletesMemberships(t *testing.T) {
 	var rawMemberCount int64
 	require.NoError(t, db.Unscoped().Model(&types.TenantMember{}).Count(&rawMemberCount).Error)
 	assert.Equal(t, int64(1), rawMemberCount)
+}
+
+func TestDeleteTenant_ClearsHomeTenantPointer(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	repo := NewTenantRepository(db)
+
+	tenant := &types.Tenant{Name: "home", Status: "active"}
+	require.NoError(t, db.Create(tenant).Error)
+
+	user := &types.User{
+		ID:           "home-owner",
+		Username:     "home-owner",
+		Email:        "home-owner@example.com",
+		PasswordHash: "hashed",
+		TenantID:     tenant.ID,
+		IsActive:     true,
+	}
+	require.NoError(t, db.Create(user).Error)
+
+	require.NoError(t, repo.DeleteTenant(ctx, tenant.ID))
+
+	// The dangling home pointer is cleared so login never resolves to the
+	// soft-deleted tenant; the read hydrates SQL NULL back as the zero value.
+	var stored types.User
+	require.NoError(t, db.First(&stored, "id = ?", user.ID).Error)
+	assert.Equal(t, uint64(0), stored.TenantID)
+
+	// Stored as NULL, not 0 — users.tenant_id is nullable and FK-checked in
+	// PostgreSQL (see userRepository.UpdateUser).
+	var nullCount int64
+	require.NoError(t, db.Table("users").
+		Where("id = ? AND tenant_id IS NULL", user.ID).Count(&nullCount).Error)
+	assert.Equal(t, int64(1), nullCount)
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -31,6 +31,12 @@ const (
 	ErrTenantInvalidStatus    ErrorCode = 2004
 	ErrTenantCreationDisabled ErrorCode = 2005
 
+	// ErrLastWorkspaceDeleteDenied guards a user from deleting the only
+	// workspace they still belong to, which would strand the account on the
+	// tenantless onboarding screen (and, where self-service creation is
+	// disabled, leave no way back without an invitation).
+	ErrLastWorkspaceDeleteDenied ErrorCode = 2006
+
 	// Agent related error codes (2100-2199)
 	ErrAgentMissingThinkingModel ErrorCode = 2100
 	ErrAgentMissingAllowedTools  ErrorCode = 2101
@@ -191,6 +197,16 @@ func NewTenantCreationDisabledError() *AppError {
 	return &AppError{
 		Code:     ErrTenantCreationDisabled,
 		Message:  "self-service workspace creation is disabled; join a workspace by invitation",
+		HTTPCode: http.StatusForbidden,
+	}
+}
+
+// NewLastWorkspaceDeleteDeniedError reports that deleting the workspace would
+// leave the caller with no remaining workspace membership.
+func NewLastWorkspaceDeleteDeniedError() *AppError {
+	return &AppError{
+		Code:     ErrLastWorkspaceDeleteDenied,
+		Message:  "cannot delete your last workspace; join or create another workspace before deleting this one",
 		HTTPCode: http.StatusForbidden,
 	}
 }

--- a/internal/handler/tenant.go
+++ b/internal/handler/tenant.go
@@ -1134,6 +1134,39 @@ func (h *TenantHandler) DeleteTenant(c *gin.Context) {
 
 	logger.Infof(ctx, "Deleting tenant, ID: %d", id)
 
+	// Last-workspace guard: an ordinary user deleting their only remaining
+	// membership would strand the account on the tenantless onboarding screen
+	// (and, where self-service creation is disabled, leave no way back without
+	// an invitation). Cross-tenant superusers and platform API keys manage the
+	// tenant catalog and are exempt; deployments wired without a member service
+	// keep the previous behavior.
+	caller, err := h.userService.GetCurrentUser(ctx)
+	if err != nil || caller == nil {
+		c.Error(errors.NewUnauthorizedError("authentication required"))
+		return
+	}
+	apiKeyScope, hasAPIKeyScope := types.TenantAPIKeyScopeFromContext(ctx)
+	catalogManager := caller.CanAccessAllTenants || (hasAPIKeyScope && apiKeyScope.IsPlatform())
+	if !catalogManager && h.memberService != nil {
+		memberships, listErr := h.memberService.ListByUser(ctx, caller.ID)
+		if listErr != nil {
+			logger.ErrorWithFields(ctx, listErr, map[string]interface{}{"user_id": caller.ID})
+			c.Error(errors.NewInternalServerError("Failed to validate workspace membership").WithDetails(listErr.Error()))
+			return
+		}
+		remaining := 0
+		for _, m := range memberships {
+			if m != nil && m.Status == types.TenantMemberStatusActive && m.TenantID != id {
+				remaining++
+			}
+		}
+		if remaining == 0 {
+			logger.Warnf(ctx, "Denied last-workspace delete: user %s, tenant %d", caller.ID, id)
+			c.Error(errors.NewLastWorkspaceDeleteDeniedError())
+			return
+		}
+	}
+
 	if err := h.service.DeleteTenant(ctx, id); err != nil {
 		if appErr, ok := errors.IsAppError(err); ok {
 			logger.Error(ctx, "Failed to delete workspace: application error", appErr)

--- a/internal/handler/tenant_delete_guard_test.go
+++ b/internal/handler/tenant_delete_guard_test.go
@@ -1,0 +1,141 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	apperrors "github.com/Tencent/WeKnora/internal/errors"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/gin-gonic/gin"
+)
+
+// tenantDeleteErrorCapture renders the full AppError struct (not just the
+// message) so tests can assert the typed error code, mirroring
+// tenantPolicyErrorCapture.
+func tenantDeleteErrorCapture() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+		if len(c.Errors) == 0 {
+			return
+		}
+		if appErr, ok := c.Errors.Last().Err.(*apperrors.AppError); ok {
+			c.JSON(appErr.HTTPCode, gin.H{"error": appErr})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": c.Errors.Last().Err.Error()})
+	}
+}
+
+type tenantDeleteUserService struct {
+	interfaces.UserService
+	user *types.User
+}
+
+func (s *tenantDeleteUserService) GetCurrentUser(context.Context) (*types.User, error) {
+	return s.user, nil
+}
+
+type tenantDeleteMemberService struct {
+	interfaces.TenantMemberService
+	members []*types.TenantMember
+}
+
+func (s *tenantDeleteMemberService) ListByUser(context.Context, string) ([]*types.TenantMember, error) {
+	return s.members, nil
+}
+
+type tenantDeleteTenantService struct {
+	interfaces.TenantService
+	deleteCalls int
+}
+
+func (s *tenantDeleteTenantService) DeleteTenant(context.Context, uint64) error {
+	s.deleteCalls++
+	return nil
+}
+
+func newTenantDeleteRouter(h *TenantHandler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(tenantDeleteErrorCapture())
+	r.DELETE("/tenants/:id", h.DeleteTenant)
+	return r
+}
+
+func doDeleteTenant(t *testing.T, r *gin.Engine, id string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodDelete, "/tenants/"+id, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestDeleteTenantRejectsLastWorkspace(t *testing.T) {
+	svc := &tenantDeleteTenantService{}
+	h := &TenantHandler{
+		service:     svc,
+		userService: &tenantDeleteUserService{user: &types.User{ID: "owner"}},
+		memberService: &tenantDeleteMemberService{members: []*types.TenantMember{
+			{UserID: "owner", TenantID: 7, Role: types.TenantRoleOwner, Status: types.TenantMemberStatusActive},
+		}},
+	}
+	r := newTenantDeleteRouter(h)
+	w := doDeleteTenant(t, r, "7")
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if svc.deleteCalls != 0 {
+		t.Fatalf("DeleteTenant called %d times, want 0", svc.deleteCalls)
+	}
+	if !strings.Contains(w.Body.String(), `"code":2006`) {
+		t.Fatalf("response missing typed code 2006: %s", w.Body.String())
+	}
+}
+
+func TestDeleteTenantAllowsWhenAnotherMembershipRemains(t *testing.T) {
+	svc := &tenantDeleteTenantService{}
+	h := &TenantHandler{
+		service:     svc,
+		userService: &tenantDeleteUserService{user: &types.User{ID: "owner"}},
+		memberService: &tenantDeleteMemberService{members: []*types.TenantMember{
+			{UserID: "owner", TenantID: 7, Status: types.TenantMemberStatusActive},
+			{UserID: "owner", TenantID: 9, Status: types.TenantMemberStatusActive},
+		}},
+	}
+	r := newTenantDeleteRouter(h)
+	w := doDeleteTenant(t, r, "7")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if svc.deleteCalls != 1 {
+		t.Fatalf("DeleteTenant called %d times, want 1", svc.deleteCalls)
+	}
+}
+
+func TestDeleteTenantAllowsCrossTenantSuperuser(t *testing.T) {
+	svc := &tenantDeleteTenantService{}
+	h := &TenantHandler{
+		service: svc,
+		userService: &tenantDeleteUserService{user: &types.User{
+			ID:                  "super-user",
+			CanAccessAllTenants: true,
+		}},
+		// memberService stays nil: catalog managers bypass the membership gate
+		// entirely, so it must not be dereferenced.
+	}
+	r := newTenantDeleteRouter(h)
+	w := doDeleteTenant(t, r, "7")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if svc.deleteCalls != 1 {
+		t.Fatalf("DeleteTenant called %d times, want 1", svc.deleteCalls)
+	}
+}


### PR DESCRIPTION
## Description

Prevents a hard account deadlock: a user who deletes their **last remaining workspace** gets logged out, and on the next login they land on the tenantless onboarding screen with no way back — because self-service workspace creation may be disabled and no invitation is pending.

Root cause chain (already partially addressed upstream by #2037 tenantless provisioning, #2589 stale-home cleanup, #1718 membership purge):

1. `DELETE /tenants/{id}` unconditionally deletes the workspace, purging the caller's membership rows.
2. The user's `users.tenant_id` home pointer is left dangling at a soft-deleted tenant.
3. On re-login the account has no active membership and no usable workspace, so the SPA dead-ends on onboarding.

This PR closes the two remaining gaps with defense in depth:

- **Guard** (`internal/handler/tenant.go`, `internal/errors/errors.go`): reject the delete with a typed `403` (error code `2006`) when the caller has no *other* active membership. Exempted: cross-tenant superusers and platform API keys (catalog managers), and deployments wired without a member service keep prior behavior.
- **Pointer cleanup** (`internal/application/repository/tenant.go`): within the same delete transaction, `NULL` out `users.tenant_id` for members whose home tenant is being deleted, so login never resolves to a soft-deleted tenant. Written as SQL `NULL`, not `0`, because the column is nullable and FK-checked in PostgreSQL (mirrors `userRepository.UpdateUser`).

The existing self-heal paths (middleware `resolveFirstMembershipTarget`, user-service `homeOrFirstMembershipTenant`) already recover a stranded account the moment they accept an invitation or are added to another workspace, so no data migration is required — the guard simply stops new stranded states from being created.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A (no upstream issue tracks this exact deadlock; related prior work: #2037, #2589, #1718, #1706)

## Testing

Scoped tests added and passing:

```
go test ./internal/handler/ -run 'TestDeleteTenant' -count=1      # ok
go test ./internal/application/repository/ -run 'TestDeleteTenant' -count=1  # ok
```

- `internal/handler/tenant_delete_guard_test.go` — 3 cases: last-workspace delete rejected with `"code":2006` and `DeleteTenant` not invoked; delete allowed when another membership remains; cross-tenant superuser bypasses the gate (nil member service is not dereferenced).
- `internal/application/repository/tenant_test.go` — added `TestDeleteTenant_ClearsHomeTenantPointer` asserting the home pointer is stored as SQL `NULL` (and hydrated back as `0`), plus extended the shared fixture to migrate `types.User`.

One unrelated baseline failure exists in the full `./internal/handler` package run: `TestDeploymentCapabilityKeysMatchFrontend` fails because it parses `frontend/src/config/deploymentCapabilities.ts` line-by-line and my Windows checkout has `core.autocrlf=true` (CRLF terminators), leaving a trailing `\r` in each parsed key. It is unrelated to this change and fails identically on `upstream/main` in this environment; scoped tests for the changed packages all pass.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted (`gofmt`)
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (`golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

> Lint and full-repo checks require the full toolchain (`golangci-lint`, and infra-dependent integration tests) which are not available in this environment; scoped Go tests are the substitute, per the Contributing "Validation" section. Swagger annotations for `DeleteTenant` already cover the endpoint; the new `403` path does not change the route signature.

## Screenshots / Recordings

No user-visible UI change (backend guard only; the SPA already surfaces the `403` message through its existing delete error toast).
