### PR TITLE
feat(scripts): add native Windows launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,24 @@ docker compose pull     # Pull the latest images
 docker compose up -d    # Start core services
 ```
 
+On Windows, no WSL is required. Start Docker Desktop, then use the native launcher from PowerShell or `cmd.exe`:
+
+```powershell
+# Start optional local Ollama, pull images, and start Docker services
+.\scripts\start_all.cmd
+
+# Start only Docker services and return without following logs
+.\scripts\start_all.cmd Docker -NoLogs
+
+# Diagnose Docker Desktop, Compose, .env, platform, and Ollama
+.\scripts\start_all.cmd Check
+```
+
+The `.cmd` wrapper applies `ExecutionPolicy Bypass` only to its child process; it does not change the machine policy. Run `.\scripts\start_all.cmd Help` for all actions.
+
 Once started, visit **http://localhost** to get started.
 
-> To use a local Ollama model, run `ollama serve > /dev/null 2>&1 &` first.
+> On Linux/macOS, run `ollama serve > /dev/null 2>&1 &` before using a local Ollama model. The Windows launcher performs this check for you.
 
 ### 🔄 Upgrading
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -210,9 +210,24 @@ docker compose pull     # 拉取最新镜像
 docker compose up -d    # 启动核心服务
 ```
 
+Windows 用户无需安装 WSL。启动 Docker Desktop 后，可在 PowerShell 或 `cmd.exe` 中运行原生启动器：
+
+```powershell
+# 默认检查/启动本机 Ollama（可选），随后拉取并启动 Docker 服务
+.\scripts\start_all.cmd
+
+# 只启动 Docker 服务并在启动完成后返回，不持续跟随日志
+.\scripts\start_all.cmd Docker -NoLogs
+
+# 检查 Docker Desktop、Compose、.env、系统架构和 Ollama
+.\scripts\start_all.cmd Check
+```
+
+执行策略限制只影响直接运行 `.ps1`；`.cmd` 包装器仅对当前进程使用 `ExecutionPolicy Bypass`，不会修改系统执行策略。完整参数见 `.\scripts\start_all.cmd Help`。
+
 启动成功后访问 **http://localhost** 即可使用。
 
-> 如需使用本地 Ollama 模型，请先运行 `ollama serve > /dev/null 2>&1 &`
+> Linux/macOS 如需使用本地 Ollama 模型，请先运行 `ollama serve > /dev/null 2>&1 &`；Windows 启动器会自动检查并按需启动。
 
 ### 🔄 版本升级
 

--- a/scripts/start_all.cmd
+++ b/scripts/start_all.cmd
@@ -1,0 +1,11 @@
+@echo off
+setlocal
+
+where powershell.exe >nul 2>nul
+if errorlevel 1 (
+  echo [ERROR] Windows PowerShell 5.1 or later is required.
+  exit /b 1
+)
+
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0start_all.ps1" %*
+exit /b %ERRORLEVEL%

--- a/scripts/start_all.ps1
+++ b/scripts/start_all.ps1
@@ -1,0 +1,609 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [ValidateSet("All", "Ollama", "Docker", "Stop", "Check", "Restart", "List", "Pull", "Help", "Version")]
+    [string]$Action = "All",
+
+    [Parameter(Position = 1)]
+    [string]$Service,
+
+    [switch]$NoPull,
+    [switch]$NoLogs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:Version = "1.0.0"
+$script:ScriptDirectory = Split-Path -Parent $PSCommandPath
+$script:ProjectRoot = Split-Path -Parent $script:ScriptDirectory
+$script:EnvPath = Join-Path $script:ProjectRoot ".env"
+$script:ComposeExecutable = $null
+$script:ComposePrefix = @()
+$script:DockerExecutable = $null
+
+function Write-Status {
+    param(
+        [ValidateSet("INFO", "WARN", "ERROR", "OK")]
+        [string]$Level,
+        [string]$Message
+    )
+
+    $color = switch ($Level) {
+        "INFO" { "Cyan" }
+        "WARN" { "Yellow" }
+        "ERROR" { "Red" }
+        "OK" { "Green" }
+    }
+    Write-Host "[$Level] $Message" -ForegroundColor $color
+}
+
+function Show-Usage {
+    Write-Host @'
+WeKnora Windows launcher
+
+Usage:
+  .\scripts\start_all.cmd [action] [service] [-NoPull] [-NoLogs]
+  .\scripts\start_all.ps1 [action] [service] [-NoPull] [-NoLogs]
+
+Actions:
+  All       Start Ollama when available, then start Docker services (default)
+  Ollama    Start only the local Ollama service
+  Docker    Start only Docker services
+  Stop      Stop local Ollama and Docker services
+  Check     Diagnose Docker, Compose, .env, platform, and Ollama
+  Restart   Rebuild and restart one Compose service (for example: Restart app)
+  List      List Compose containers
+  Pull      Pull core and sandbox images
+  Help      Show this help
+  Version   Show launcher version
+
+Options:
+  -NoPull   Reuse local images when starting Docker services
+  -NoLogs   Return after startup instead of following service logs
+
+Examples:
+  .\scripts\start_all.cmd
+  .\scripts\start_all.cmd Docker -NoLogs
+  .\scripts\start_all.cmd Check
+  .\scripts\start_all.cmd Restart app
+  .\scripts\start_all.cmd Stop
+'@
+}
+
+function Read-DotEnv {
+    $values = @{}
+    if (-not (Test-Path -LiteralPath $script:EnvPath -PathType Leaf)) {
+        return $values
+    }
+
+    foreach ($line in Get-Content -LiteralPath $script:EnvPath -Encoding UTF8) {
+        if ($line -notmatch '^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$') {
+            continue
+        }
+
+        $name = $Matches[1]
+        $value = $Matches[2].Trim()
+        if ($value.Length -ge 2) {
+            $first = $value.Substring(0, 1)
+            $last = $value.Substring($value.Length - 1, 1)
+            if (($first -eq '"' -and $last -eq '"') -or ($first -eq "'" -and $last -eq "'")) {
+                $value = $value.Substring(1, $value.Length - 2)
+            }
+        }
+        $values[$name] = $value
+    }
+
+    return $values
+}
+
+function Get-ConfiguredValue {
+    param(
+        [string]$Name,
+        [string]$Default = ""
+    )
+
+    $processValue = [Environment]::GetEnvironmentVariable($Name)
+    if (-not [string]::IsNullOrWhiteSpace($processValue)) {
+        return $processValue
+    }
+
+    $values = Read-DotEnv
+    if ($values.ContainsKey($Name) -and -not [string]::IsNullOrWhiteSpace([string]$values[$Name])) {
+        return [string]$values[$Name]
+    }
+    return $Default
+}
+
+function Test-TrueValue {
+    param([string]$Value)
+    return @("1", "true", "yes", "on") -contains $Value.Trim().ToLowerInvariant()
+}
+
+function Initialize-EnvironmentFile {
+    if (Test-Path -LiteralPath $script:EnvPath -PathType Leaf) {
+        Write-Status "INFO" ".env already exists."
+        return
+    }
+
+    $examplePath = Join-Path $script:ProjectRoot ".env.example"
+    if (-not (Test-Path -LiteralPath $examplePath -PathType Leaf)) {
+        throw ".env is missing and .env.example was not found."
+    }
+
+    Copy-Item -LiteralPath $examplePath -Destination $script:EnvPath
+    Write-Status "WARN" "Created .env from .env.example. Review passwords and secrets before production use."
+}
+
+function Invoke-QuietNative {
+    param(
+        [string]$FilePath,
+        [string[]]$Arguments
+    )
+
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = "SilentlyContinue"
+    try {
+        & $FilePath @Arguments *> $null
+        return $LASTEXITCODE
+    }
+    catch {
+        return 1
+    }
+    finally {
+        $ErrorActionPreference = $previousPreference
+    }
+}
+
+function Set-ComposeCommand {
+    $dockerCommand = Get-Command "docker" -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($null -eq $dockerCommand) {
+        throw "Docker CLI was not found. Install Docker Desktop and reopen the terminal."
+    }
+
+    $script:DockerExecutable = $dockerCommand.Source
+    if ((Invoke-QuietNative -FilePath $script:DockerExecutable -Arguments @("compose", "version")) -eq 0) {
+        $script:ComposeExecutable = $script:DockerExecutable
+        $script:ComposePrefix = @("compose")
+        return
+    }
+
+    $legacyCommand = Get-Command "docker-compose" -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($null -ne $legacyCommand) {
+        if ((Invoke-QuietNative -FilePath $legacyCommand.Source -Arguments @("version")) -eq 0) {
+            $script:ComposeExecutable = $legacyCommand.Source
+            $script:ComposePrefix = @()
+            return
+        }
+    }
+
+    throw "Docker Compose was not found. Install the Docker Compose v2 plugin."
+}
+
+function Invoke-Compose {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [switch]$AllowFailure,
+        [switch]$Capture
+    )
+
+    if ([string]::IsNullOrWhiteSpace([string]$script:ComposeExecutable)) {
+        Set-ComposeCommand
+    }
+
+    $nativeArguments = @($script:ComposePrefix) + @($Arguments)
+    Push-Location $script:ProjectRoot
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        if ($Capture) {
+            $output = @(& $script:ComposeExecutable @nativeArguments 2>&1)
+        }
+        else {
+            & $script:ComposeExecutable @nativeArguments
+            $output = @()
+        }
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $previousPreference
+        Pop-Location
+    }
+
+    if ($exitCode -ne 0 -and -not $AllowFailure) {
+        throw "Docker Compose failed with exit code ${exitCode}: $($Arguments -join ' ')"
+    }
+
+    if ($Capture) {
+        return [PSCustomObject]@{
+            ExitCode = $exitCode
+            Output = $output
+        }
+    }
+}
+
+function Test-DockerDaemon {
+    return (Invoke-QuietNative -FilePath $script:DockerExecutable -Arguments @("info")) -eq 0
+}
+
+function Initialize-Docker {
+    Set-ComposeCommand
+    if (-not (Test-DockerDaemon)) {
+        throw "Docker Desktop is not running. Start Docker Desktop and wait until the engine is ready."
+    }
+    Write-Status "OK" "Docker Desktop and Docker Compose are ready."
+}
+
+function Set-DockerPlatform {
+    $architecture = $env:PROCESSOR_ARCHITEW6432
+    if ([string]::IsNullOrWhiteSpace($architecture)) {
+        $architecture = $env:PROCESSOR_ARCHITECTURE
+    }
+
+    if ($architecture -match '^(ARM64|AARCH64)$') {
+        $platform = "linux/arm64"
+    }
+    elseif ($architecture -match '^(AMD64|x86_64|x64)$') {
+        $platform = "linux/amd64"
+    }
+    else {
+        $platform = "linux/amd64"
+        Write-Status "WARN" "Unknown Windows architecture '$architecture'; using $platform."
+    }
+
+    $env:PLATFORM = $platform
+    Write-Status "INFO" "Docker platform: $platform"
+    return $platform
+}
+
+function Get-OllamaSettings {
+    $baseUrl = Get-ConfiguredValue -Name "OLLAMA_BASE_URL" -Default "http://host.docker.internal:11434"
+    try {
+        $baseUri = [Uri]$baseUrl
+    }
+    catch {
+        throw "OLLAMA_BASE_URL is not a valid absolute URL: $baseUrl"
+    }
+
+    if (-not $baseUri.IsAbsoluteUri -or @("http", "https") -notcontains $baseUri.Scheme) {
+        throw "OLLAMA_BASE_URL must be an absolute HTTP(S) URL: $baseUrl"
+    }
+
+    $localHosts = @("localhost", "127.0.0.1", "::1", "host.docker.internal")
+    $isLocal = $localHosts -contains $baseUri.Host.ToLowerInvariant()
+    $probeUrl = $baseUrl.TrimEnd('/') + "/api/tags"
+
+    if ($baseUri.Host -eq "host.docker.internal") {
+        $probeBuilder = New-Object System.UriBuilder($probeUrl)
+        $probeBuilder.Host = "127.0.0.1"
+        $probeUrl = $probeBuilder.Uri.AbsoluteUri
+    }
+
+    return [PSCustomObject]@{
+        BaseUrl = $baseUrl
+        ProbeUrl = $probeUrl
+        IsLocal = $isLocal
+    }
+}
+
+function Test-OllamaEndpoint {
+    param([string]$Url)
+    try {
+        $null = Invoke-RestMethod -Uri $Url -Method Get -TimeoutSec 3 -ErrorAction Stop
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+function Start-OllamaService {
+    $settings = Get-OllamaSettings
+    Write-Status "INFO" "Checking Ollama at $($settings.BaseUrl)"
+
+    if (Test-OllamaEndpoint -Url $settings.ProbeUrl) {
+        Write-Status "OK" "Ollama is reachable."
+        return $true
+    }
+
+    if (-not $settings.IsLocal) {
+        Write-Status "WARN" "The configured remote Ollama endpoint is not reachable."
+        return $false
+    }
+
+    $ollamaCommand = Get-Command "ollama" -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($null -eq $ollamaCommand) {
+        Write-Status "WARN" "Ollama is not installed. Install it from https://ollama.com/download/windows or configure a remote endpoint."
+        return $false
+    }
+
+    Write-Status "INFO" "Starting Ollama in the background..."
+    Start-Process -FilePath $ollamaCommand.Source -ArgumentList @("serve") -WindowStyle Hidden | Out-Null
+
+    for ($attempt = 1; $attempt -le 30; $attempt++) {
+        Start-Sleep -Seconds 1
+        if (Test-OllamaEndpoint -Url $settings.ProbeUrl) {
+            Write-Status "OK" "Ollama started successfully."
+            return $true
+        }
+    }
+
+    Write-Status "WARN" "Ollama did not become ready within 30 seconds."
+    return $false
+}
+
+function Stop-OllamaService {
+    $settings = Get-OllamaSettings
+    if (-not $settings.IsLocal) {
+        Write-Status "INFO" "Remote Ollama is configured; nothing to stop locally."
+        return $true
+    }
+
+    $processes = @(Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.ProcessName -like "ollama*" })
+    if ($processes.Count -eq 0) {
+        Write-Status "INFO" "No local Ollama process is running."
+        return $true
+    }
+
+    $failed = $false
+    foreach ($process in $processes) {
+        try {
+            Stop-Process -Id $process.Id -ErrorAction Stop
+        }
+        catch {
+            $failed = $true
+            Write-Status "WARN" "Could not stop Ollama process $($process.Id): $($_.Exception.Message)"
+        }
+    }
+
+    if ($failed) {
+        return $false
+    }
+    Write-Status "OK" "Local Ollama processes stopped."
+    return $true
+}
+
+function Test-OllamaOptional {
+    $value = Get-ConfiguredValue -Name "OLLAMA_OPTIONAL" -Default "true"
+    return Test-TrueValue -Value $value
+}
+
+function Initialize-SandboxImage {
+    $version = Get-ConfiguredValue -Name "WEKNORA_VERSION" -Default "latest"
+    $image = "wechatopenai/weknora-sandbox:$version"
+    if ((Invoke-QuietNative -FilePath $script:DockerExecutable -Arguments @("image", "inspect", $image)) -eq 0) {
+        Write-Status "OK" "Sandbox image is ready: $image"
+        return
+    }
+
+    Write-Status "INFO" "Pulling optional Agent Skills sandbox image: $image"
+    try {
+        Invoke-Compose -Arguments @("--profile", "sandbox", "pull", "sandbox")
+    }
+    catch {
+        Write-Status "WARN" "Sandbox image pull failed; Agent Skills may be unavailable: $($_.Exception.Message)"
+    }
+}
+
+function Start-DockerServices {
+    Initialize-Docker
+    Initialize-EnvironmentFile
+    $null = Set-DockerPlatform
+
+    if ($NoPull) {
+        Write-Status "INFO" "Starting core services with locally available images..."
+        Invoke-Compose -Arguments @("up", "-d")
+    }
+    else {
+        Write-Status "INFO" "Pulling current images and starting core services..."
+        Invoke-Compose -Arguments @("up", "--pull", "always", "-d")
+    }
+
+    Write-Status "OK" "Docker services started."
+    Invoke-Compose -Arguments @("ps")
+    Initialize-SandboxImage
+}
+
+function Stop-DockerServices {
+    Initialize-Docker
+    Write-Status "INFO" "Stopping Compose services without deleting containers or volumes..."
+    Invoke-Compose -Arguments @("stop")
+    Write-Status "OK" "Docker services stopped."
+}
+
+function Show-DockerServices {
+    Initialize-Docker
+    Invoke-Compose -Arguments @("ps")
+}
+
+function Sync-DockerImages {
+    Initialize-Docker
+    Initialize-EnvironmentFile
+    $null = Set-DockerPlatform
+    Invoke-Compose -Arguments @("pull")
+    Initialize-SandboxImage
+    Write-Status "OK" "Docker images pulled."
+}
+
+function Restart-DockerService {
+    param([string]$Name)
+
+    if ([string]::IsNullOrWhiteSpace($Name)) {
+        throw "Restart requires a Compose service name, for example: Restart app"
+    }
+
+    Initialize-Docker
+    Initialize-EnvironmentFile
+    $null = Set-DockerPlatform
+
+    $result = Invoke-Compose -Arguments @("config", "--services") -Capture
+    $services = @($result.Output | ForEach-Object { ([string]$_).Trim() } | Where-Object { $_ })
+    if ($services -notcontains $Name) {
+        throw "Unknown Compose service '$Name'. Available services: $($services -join ', ')"
+    }
+
+    Write-Status "INFO" "Rebuilding Compose service '$Name'..."
+    Invoke-Compose -Arguments @("build", $Name)
+    Invoke-Compose -Arguments @("up", "-d", "--no-deps", $Name)
+    Write-Status "OK" "Compose service '$Name' restarted."
+}
+
+function Test-Environment {
+    Write-Status "INFO" "WeKnora Windows environment check"
+    $ready = $true
+    $dockerReady = $false
+
+    try {
+        Set-ComposeCommand
+        Write-Status "OK" "Docker CLI and Docker Compose were found."
+        $dockerReady = Test-DockerDaemon
+        if ($dockerReady) {
+            Write-Status "OK" "Docker Desktop engine is running."
+        }
+        else {
+            Write-Status "ERROR" "Docker Desktop engine is not running."
+            $ready = $false
+        }
+    }
+    catch {
+        Write-Status "ERROR" $_.Exception.Message
+        $ready = $false
+    }
+
+    $null = Set-DockerPlatform
+    if (Test-Path -LiteralPath $script:EnvPath -PathType Leaf) {
+        Write-Status "OK" ".env exists."
+        $values = Read-DotEnv
+        foreach ($requiredName in @("DB_DRIVER", "STORAGE_TYPE")) {
+            if (-not $values.ContainsKey($requiredName) -or [string]::IsNullOrWhiteSpace([string]$values[$requiredName])) {
+                Write-Status "WARN" ".env does not set $requiredName."
+            }
+        }
+
+        if ($null -ne $script:ComposeExecutable) {
+            try {
+                Invoke-Compose -Arguments @("config", "--quiet")
+                Write-Status "OK" "docker-compose.yml and .env are valid."
+            }
+            catch {
+                Write-Status "ERROR" $_.Exception.Message
+                $ready = $false
+            }
+        }
+    }
+    else {
+        Write-Status "WARN" ".env is missing; the start action will create it from .env.example."
+    }
+
+    try {
+        $settings = Get-OllamaSettings
+        if (Test-OllamaEndpoint -Url $settings.ProbeUrl) {
+            Write-Status "OK" "Ollama is reachable at $($settings.BaseUrl)."
+        }
+        elseif (Test-OllamaOptional) {
+            Write-Status "WARN" "Ollama is not reachable, but OLLAMA_OPTIONAL is enabled."
+        }
+        else {
+            Write-Status "ERROR" "Ollama is not reachable and OLLAMA_OPTIONAL is disabled."
+            $ready = $false
+        }
+    }
+    catch {
+        Write-Status "ERROR" $_.Exception.Message
+        $ready = $false
+    }
+
+    if ($dockerReady) {
+        $version = Get-ConfiguredValue -Name "WEKNORA_VERSION" -Default "latest"
+        $sandboxImage = "wechatopenai/weknora-sandbox:$version"
+        if ((Invoke-QuietNative -FilePath $script:DockerExecutable -Arguments @("image", "inspect", $sandboxImage)) -eq 0) {
+            Write-Status "OK" "Sandbox image is ready: $sandboxImage"
+        }
+        else {
+            Write-Status "WARN" "Sandbox image is missing: $sandboxImage"
+        }
+    }
+
+    return $ready
+}
+
+function Show-ServiceEndpoints {
+    $frontendPort = Get-ConfiguredValue -Name "FRONTEND_PORT" -Default "80"
+    $appPort = Get-ConfiguredValue -Name "APP_PORT" -Default "8080"
+    Write-Status "OK" "Frontend: http://localhost:$frontendPort"
+    Write-Status "OK" "API: http://localhost:$appPort"
+}
+
+function Show-ServiceLogs {
+    Write-Status "INFO" "Following service logs. Press Ctrl+C to leave logs; containers will keep running."
+    Invoke-Compose -Arguments @("logs", "--since", "10s", "--follow", "app", "docreader", "postgres") -AllowFailure
+}
+
+try {
+    switch ($Action.ToLowerInvariant()) {
+        "help" {
+            Show-Usage
+        }
+        "version" {
+            Write-Host "WeKnora Windows launcher v$($script:Version)"
+        }
+        "check" {
+            if (-not (Test-Environment)) {
+                exit 1
+            }
+        }
+        "list" {
+            Show-DockerServices
+        }
+        "pull" {
+            Sync-DockerImages
+        }
+        "restart" {
+            Restart-DockerService -Name $Service
+        }
+        "stop" {
+            $ollamaStopped = Stop-OllamaService
+            Stop-DockerServices
+            if (-not $ollamaStopped) {
+                throw "Docker services stopped, but one or more Ollama processes could not be stopped."
+            }
+        }
+        "ollama" {
+            Initialize-EnvironmentFile
+            if (-not (Start-OllamaService)) {
+                throw "Ollama could not be started."
+            }
+        }
+        "docker" {
+            Start-DockerServices
+            Show-ServiceEndpoints
+            if (-not $NoLogs) {
+                Show-ServiceLogs
+            }
+        }
+        "all" {
+            Initialize-EnvironmentFile
+            $ollamaReady = Start-OllamaService
+            if (-not $ollamaReady -and -not (Test-OllamaOptional)) {
+                throw "Ollama is required but could not be started."
+            }
+            if (-not $ollamaReady) {
+                Write-Status "WARN" "Continuing because OLLAMA_OPTIONAL is enabled."
+            }
+
+            Start-DockerServices
+            Show-ServiceEndpoints
+            if (-not $NoLogs) {
+                Show-ServiceLogs
+            }
+        }
+    }
+    exit 0
+}
+catch {
+    Write-Status "ERROR" $_.Exception.Message
+    exit 1
+}

--- a/website-docs/01-getting-started/02-installation.md
+++ b/website-docs/01-getting-started/02-installation.md
@@ -64,6 +64,29 @@ docker compose ps                 # 等所有服务变成 healthy/running
 
 > 注意：`docker-compose.yml` 的 app 服务使用 `env_file: [.env]`，`.env` 不存在会导致 compose 解析失败。`make docker-run` / `start_all.sh` 会自动 `cp .env.example .env` 或 `touch .env` 兜底。
 
+### Windows 原生一键启动
+
+Windows 无需安装 WSL。先启动 Docker Desktop，等待引擎就绪，再从 PowerShell 或 `cmd.exe` 运行：
+
+```powershell
+# 默认检查/启动本机 Ollama（不可用且 OLLAMA_OPTIONAL=true 时仅警告），再拉取并启动 Docker 服务
+.\scripts\start_all.cmd
+
+# 只启动 Docker 服务，并在启动完成后返回而不是持续跟随日志
+.\scripts\start_all.cmd Docker -NoLogs
+
+# 只使用已有镜像，不主动拉取
+.\scripts\start_all.cmd Docker -NoPull -NoLogs
+
+# 检查 Docker Desktop、Compose、.env、Windows 架构和 Ollama
+.\scripts\start_all.cmd Check
+
+# 停止 Ollama 与 Compose 服务；保留容器和数据卷
+.\scripts\start_all.cmd Stop
+```
+
+`.cmd` 会调用 Windows PowerShell 5.1+ 的 `scripts/start_all.ps1`。其中 `ExecutionPolicy Bypass` 只作用于这个子进程，不修改用户或系统执行策略；也可直接运行 `.\scripts\start_all.ps1 Help` 查看参数。支持的动作包括 `All`（默认）、`Ollama`、`Docker`、`Stop`、`Check`、`Restart <service>`、`List` 和 `Pull`。
+
 ### 版本升级
 
 若已有部署并下载了更新的 release：
@@ -165,6 +188,7 @@ make docker-build-frontend
 | 脚本 | 职责 |
 | --- | --- |
 | `scripts/start_all.sh` | 一键启动：参数 `-o`（仅 Ollama）、`-d`（仅 Docker）、`-a`（全部，默认）、`-s`（停止）、`-c`（检查环境）、`-l`（列容器）、`-p`(拉镜像)；自动探测 compose v1/v2、按 `uname -m` 设定 `PLATFORM`、后台预拉取 sandbox 镜像 |
+| `scripts/start_all.cmd` / `scripts/start_all.ps1` | Windows 原生启动入口：无需 WSL，支持启动/停止/检查/拉取/重启，自动识别 amd64/arm64、校验 Docker Desktop 与 Compose，并按需拉取 sandbox 镜像 |
 | `scripts/dev.sh` | 开发环境编排（见上文），子命令 `start/stop/restart/logs/status/app/frontend` |
 | `scripts/check-env.sh` | 校验 `.env` 必填变量（DB_*、STORAGE_TYPE、REDIS_ADDR、OLLAMA_BASE_URL 等）与 Go/npm/Docker/Air 工具链 |
 | `scripts/build_images.sh` | 构建镜像并注入版本（git tag / commit / build time），支持跨架构 |


### PR DESCRIPTION
## 背景

现有 `scripts/start_all.sh` 在 Windows 上会被系统当作 WSL Bash 脚本，未安装 WSL 时无法执行。本 PR 提供 Windows PowerShell 5.1+ 原生入口，用户启动 Docker Desktop 后即可直接运行，不再依赖 WSL。

Fixes #191

## 改动

- 新增 `scripts/start_all.ps1`，支持 `All`、`Ollama`、`Docker`、`Stop`、`Check`、`Restart`、`List` 与 `Pull`。
- 新增可从 PowerShell、`cmd.exe` 或资源管理器调用的 `scripts/start_all.cmd` 包装器；执行策略覆盖仅作用于当前子进程。
- 自动探测 Docker Compose v2/v1、Docker Desktop 引擎和 Windows amd64/arm64，并在缺少 `.env` 时从模板创建。
- 安全解析 `.env` 而不执行其内容，按 `OLLAMA_OPTIONAL` 处理本地/远程 Ollama，并以隐藏窗口启动本地服务。
- 停止操作保留容器和数据卷；启动后按需拉取 Agent Skills sandbox 镜像。
- 在中英文 README 与安装文档中补充 Windows 使用方法。

## 验证

- Windows PowerShell 5.1：AST 解析、approved verb 检查、Help/Version 入口通过。
- PowerShell 7.6：AST 解析、Help/Version 入口通过。
- `.cmd` 包装器：Help/Version 与参数转发通过。
- 真实 Docker CLI（Docker Desktop 未启动）：`Check` 正确识别 CLI/Compose、校验实际 Compose 配置、明确报告引擎未运行并返回 1。
- 伪 Docker 集成：验证默认拉取、`-NoPull`、`Check`、`Pull`、`Restart app`、未知服务拒绝及实际参数序列。
- `npm run check`：59 篇文档的 144 个内部链接无失效，61 个 Mermaid 图无失败。
- `npm run build`：VitePress 1.6.4 完整构建成功。
- `git diff --check`：通过。

本机 Docker Desktop 引擎未启动，因此未实际拉起 WeKnora 容器；Docker/Compose 命令编排通过隔离的伪可执行文件覆盖验证。
