### PR TITLE
feat(dev): add native Windows development workflow

### DIFF
--- a/air.windows.toml
+++ b/air.windows.toml
@@ -1,0 +1,44 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main.exe"
+  cmd = "go build -o ./tmp/main.exe ./cmd/server"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata", "frontend", "migrations", "node_modules", "docs", "logs", "data", "WeKnora-Chrome-Extension", "Formula", "dataset", "docreader", "docker", "llm_debug", "web", "mcp-server", "misc", "scripts", "dist", "client", "helm", "website-docs"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html", "yaml"]
+  include_file = []
+  kill_delay = "2s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = true
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = true
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/docs/开发指南.md
+++ b/docs/开发指南.md
@@ -4,6 +4,8 @@
 
 如果你需要频繁修改 `app` 或 `frontend` 代码，**不需要每次都重新构建 Docker 镜像**，可以使用本地开发模式。
 
+Linux、macOS 与 WSL 使用下面的 Make/Bash 命令。Windows 原生开发请使用 `scripts/dev.ps1`；它会在启动前检查 Go、CGO、DuckDB 兼容的 UCRT GCC 与 `sqlite3.h`，完整依赖和 GoLand 配置见[开发指南的 Windows 原生开发章节](../website-docs/06-development/01-dev-guide.md#21-windows-原生开发)。
+
 ### 方式一：使用 Make 命令（推荐）
 
 #### 1. 启动基础设施服务
@@ -66,6 +68,22 @@ make dev-stop
 
 # 停止所有服务
 ./scripts/dev.sh stop
+```
+
+### 方式三：Windows 原生 PowerShell
+
+Windows 11 x64 已验证使用 Go 1.26、DuckDB 同款 GCC 14.2 POSIX/SEH/UCRT 与 MSYS2 UCRT64 SQLite 头文件。GCC 16 与当前 DuckDB Windows 预编译静态库存在 TLS 链接不兼容，脚本会提前拒绝该组合。
+
+```powershell
+Copy-Item .env.example .env
+$env:WEKNORA_GCC_BIN = 'C:\Tools\duckdb-gcc-14.2\mingw64\bin'
+$env:WEKNORA_SQLITE_INCLUDE = 'C:\msys64\ucrt64\include'
+
+.\scripts\dev.ps1 check
+.\scripts\dev.ps1 start
+# 在新终端分别运行：
+.\scripts\dev.ps1 app
+.\scripts\dev.ps1 frontend
 ```
 
 ## 访问地址

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -1,0 +1,698 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [ValidateSet('check', 'start', 'stop', 'restart', 'logs', 'status', 'app', 'frontend', 'help')]
+    [string]$Command = 'help',
+
+    [string]$GccBin = $env:WEKNORA_GCC_BIN,
+    [string]$SqliteInclude = $env:WEKNORA_SQLITE_INCLUDE,
+
+    [switch]$Minio,
+    [switch]$Qdrant,
+    [switch]$OpenSearch,
+    [switch]$Milvus,
+    [switch]$Neo4j,
+    [switch]$Searxng,
+    [switch]$Dex,
+    [switch]$OdlHybrid,
+    [switch]$Full,
+    [switch]$NoLangfuse,
+    [switch]$NoAir
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+$script:ScriptDirectory = Split-Path -Parent $PSCommandPath
+$script:ProjectRoot = Split-Path -Parent $script:ScriptDirectory
+$script:ComposeExecutable = $null
+$script:ComposePrefix = @()
+$script:ResolvedGcc = $null
+$script:ResolvedGxx = $null
+$script:ResolvedSqliteInclude = $null
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "[INFO] $Message" -ForegroundColor Cyan
+}
+
+function Write-Success {
+    param([string]$Message)
+    Write-Host "[OK]   $Message" -ForegroundColor Green
+}
+
+function Write-WarningMessage {
+    param([string]$Message)
+    Write-Host "[WARN] $Message" -ForegroundColor Yellow
+}
+
+function Write-ErrorMessage {
+    param([string]$Message)
+    Write-Host "[FAIL] $Message" -ForegroundColor Red
+}
+
+function Invoke-CapturedCommand {
+    param(
+        [string]$FilePath,
+        [string[]]$ArgumentList = @()
+    )
+
+    # Windows PowerShell 5.1 wraps native stderr as ErrorRecord objects. With
+    # ErrorActionPreference=Stop, otherwise-successful tools such as `gcc -v`
+    # can terminate the whole script. Capture both streams without promoting
+    # native stderr to a terminating PowerShell error.
+    $previousErrorActionPreference = $ErrorActionPreference
+    $output = @()
+    $exitCode = 1
+    try {
+        $ErrorActionPreference = 'Continue'
+        $output = & $FilePath @ArgumentList 2>&1
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    return @{
+        ExitCode = $exitCode
+        Output = (($output | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine)
+    }
+}
+
+function Import-DotEnvFile {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return
+    }
+
+    foreach ($rawLine in [IO.File]::ReadAllLines($Path)) {
+        $line = $rawLine.Trim()
+        if ([string]::IsNullOrWhiteSpace($line) -or $line.StartsWith('#')) {
+            continue
+        }
+        if ($line.StartsWith('export ')) {
+            $line = $line.Substring(7).TrimStart()
+        }
+
+        $separator = $line.IndexOf('=')
+        if ($separator -lt 1) {
+            Write-WarningMessage "Ignoring malformed environment entry in $Path"
+            continue
+        }
+
+        $name = $line.Substring(0, $separator).Trim()
+        if ($name -notmatch '^[A-Za-z_][A-Za-z0-9_]*$') {
+            Write-WarningMessage "Ignoring invalid environment variable '$name' in $Path"
+            continue
+        }
+
+        $value = $line.Substring($separator + 1).Trim()
+        if ($value.Length -ge 2) {
+            $first = $value[0]
+            $last = $value[$value.Length - 1]
+            if (($first -eq '"' -and $last -eq '"') -or ($first -eq "'" -and $last -eq "'")) {
+                $value = $value.Substring(1, $value.Length - 2)
+            }
+        }
+
+        [Environment]::SetEnvironmentVariable($name, $value, 'Process')
+    }
+}
+
+function Import-ProjectEnvironment {
+    param([switch]$Required)
+
+    $envPath = Join-Path $script:ProjectRoot '.env'
+    $localEnvPath = Join-Path $script:ProjectRoot '.env.local'
+    if (-not (Test-Path -LiteralPath $envPath -PathType Leaf)) {
+        if ($Required) {
+            Write-ErrorMessage '.env is missing. Run: Copy-Item .env.example .env'
+            return $false
+        }
+    }
+    else {
+        Import-DotEnvFile -Path $envPath
+    }
+
+    if (Test-Path -LiteralPath $localEnvPath -PathType Leaf) {
+        Write-Info 'Loading .env.local overrides'
+        Import-DotEnvFile -Path $localEnvPath
+    }
+    return $true
+}
+
+function Resolve-GccExecutable {
+    param([string]$Hint)
+
+    $candidates = New-Object System.Collections.Generic.List[string]
+    if (-not [string]::IsNullOrWhiteSpace($Hint)) {
+        if (Test-Path -LiteralPath $Hint -PathType Container) {
+            $candidates.Add((Join-Path $Hint 'gcc.exe'))
+        }
+        else {
+            $candidates.Add($Hint)
+        }
+    }
+
+    $gccCommand = Get-Command gcc.exe -ErrorAction SilentlyContinue
+    if ($null -ne $gccCommand) {
+        $candidates.Add($gccCommand.Source)
+    }
+    $candidates.Add('C:\msys64\ucrt64\bin\gcc.exe')
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+    }
+    return $null
+}
+
+function Resolve-SqliteIncludeDirectory {
+    param(
+        [string]$Hint,
+        [string]$CompilerDirectory
+    )
+
+    $candidates = New-Object System.Collections.Generic.List[string]
+    if (-not [string]::IsNullOrWhiteSpace($Hint)) {
+        if ((Test-Path -LiteralPath $Hint -PathType Leaf) -and
+            ([IO.Path]::GetFileName($Hint) -ieq 'sqlite3.h')) {
+            $candidates.Add((Split-Path -Parent $Hint))
+        }
+        else {
+            $candidates.Add($Hint)
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($CompilerDirectory)) {
+        $candidates.Add((Join-Path (Split-Path -Parent $CompilerDirectory) 'include'))
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:MSYSTEM_PREFIX)) {
+        $candidates.Add((Join-Path $env:MSYSTEM_PREFIX 'include'))
+    }
+    $candidates.Add('C:\msys64\ucrt64\include')
+
+    foreach ($candidate in $candidates) {
+        $header = Join-Path $candidate 'sqlite3.h'
+        if (Test-Path -LiteralPath $header -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+    }
+    return $null
+}
+
+function Test-PlatformAndGo {
+    $ok = $true
+    if ([Environment]::OSVersion.Platform -ne [PlatformID]::Win32NT) {
+        Write-ErrorMessage 'This script supports native Windows only. Use scripts/dev.sh on Unix or WSL.'
+        $ok = $false
+    }
+    else {
+        Write-Success "Windows detected (PowerShell $($PSVersionTable.PSVersion))"
+    }
+
+    $goCommand = Get-Command go.exe -ErrorAction SilentlyContinue
+    if ($null -eq $goCommand) {
+        Write-ErrorMessage 'Go is not installed or go.exe is not on PATH.'
+        return $false
+    }
+
+    $versionResult = Invoke-CapturedCommand -FilePath $goCommand.Source -ArgumentList @('version')
+    $versionMatch = [regex]::Match($versionResult.Output, 'go version go([0-9]+(?:\.[0-9]+){1,2})')
+    if (-not $versionMatch.Success) {
+        Write-ErrorMessage "Unable to parse Go version: $($versionResult.Output)"
+        $ok = $false
+    }
+    else {
+        $installedVersion = [version]$versionMatch.Groups[1].Value
+        $requiredLine = Select-String -LiteralPath (Join-Path $script:ProjectRoot 'go.mod') -Pattern '^go\s+([0-9.]+)' | Select-Object -First 1
+        if ($null -eq $requiredLine -or $requiredLine.Matches.Count -eq 0) {
+            Write-ErrorMessage 'Unable to read the required Go version from go.mod.'
+            $ok = $false
+        }
+        else {
+            $requiredVersion = [version]$requiredLine.Matches[0].Groups[1].Value
+            if ($installedVersion -lt $requiredVersion) {
+                Write-ErrorMessage "Go $installedVersion is too old; WeKnora requires Go $requiredVersion or newer."
+                $ok = $false
+            }
+            else {
+                Write-Success "Go $installedVersion (required: $requiredVersion)"
+            }
+        }
+    }
+
+    $goEnvResult = Invoke-CapturedCommand -FilePath $goCommand.Source -ArgumentList @('env', 'GOOS', 'GOARCH')
+    $goEnvValues = @($goEnvResult.Output -split '\r?\n' | ForEach-Object { $_.Trim() })
+    if ($goEnvResult.ExitCode -ne 0 -or
+        $goEnvValues -notcontains 'windows' -or $goEnvValues -notcontains 'amd64') {
+        Write-ErrorMessage 'The DuckDB prebuilt library requires native windows/amd64 Go. Windows ARM64 is not supported.'
+        $ok = $false
+    }
+    else {
+        Write-Success 'Go target is windows/amd64'
+    }
+    return $ok
+}
+
+function Test-WindowsToolchain {
+    $ok = $true
+    $gcc = Resolve-GccExecutable -Hint $GccBin
+    if ([string]::IsNullOrWhiteSpace($gcc)) {
+        Write-ErrorMessage 'gcc.exe was not found. Set WEKNORA_GCC_BIN or pass -GccBin.'
+        return $false
+    }
+
+    $compilerDirectory = Split-Path -Parent $gcc
+    $gxx = Join-Path $compilerDirectory 'g++.exe'
+    if (-not (Test-Path -LiteralPath $gxx -PathType Leaf)) {
+        Write-ErrorMessage "g++.exe is missing next to $gcc"
+        return $false
+    }
+
+    $targetResult = Invoke-CapturedCommand -FilePath $gcc -ArgumentList @('-dumpmachine')
+    if ($targetResult.ExitCode -ne 0 -or $targetResult.Output.Trim() -ne 'x86_64-w64-mingw32') {
+        Write-ErrorMessage "GCC target must be x86_64-w64-mingw32; found '$($targetResult.Output.Trim())'."
+        $ok = $false
+    }
+
+    $versionResult = Invoke-CapturedCommand -FilePath $gcc -ArgumentList @('-dumpfullversion', '-dumpversion')
+    $versionMatch = [regex]::Match($versionResult.Output, '[0-9]+\.[0-9]+(?:\.[0-9]+)?')
+    if (-not $versionMatch.Success) {
+        Write-ErrorMessage "Unable to parse GCC version: $($versionResult.Output)"
+        $ok = $false
+    }
+    else {
+        $gccVersion = [version]$versionMatch.Value
+        if ($gccVersion.Major -ge 16) {
+            Write-ErrorMessage "GCC $gccVersion uses native TLS and cannot link DuckDB's GCC 14.2 prebuilt static library."
+            Write-ErrorMessage 'Use the DuckDB-compatible GCC 14.2 UCRT toolchain documented in the development guide, or use WSL2.'
+            $ok = $false
+        }
+        elseif ($gccVersion.Major -eq 14 -and $gccVersion.Minor -eq 2) {
+            Write-Success "GCC $gccVersion matches the DuckDB Windows build toolchain"
+        }
+        else {
+            Write-WarningMessage "GCC $gccVersion is below the known GCC 16 incompatibility, but only GCC 14.2 is validated."
+        }
+    }
+
+    $detailsResult = Invoke-CapturedCommand -FilePath $gcc -ArgumentList @('-v')
+    if ($detailsResult.Output -notmatch '(?i)ucrt') {
+        Write-ErrorMessage 'The compiler is not an UCRT toolchain. DuckDB Windows artifacts require the UCRT variant.'
+        $ok = $false
+    }
+    else {
+        Write-Success 'UCRT compiler runtime detected'
+    }
+
+    $sqliteDirectory = Resolve-SqliteIncludeDirectory -Hint $SqliteInclude -CompilerDirectory $compilerDirectory
+    if ([string]::IsNullOrWhiteSpace($sqliteDirectory)) {
+        Write-ErrorMessage 'sqlite3.h was not found. Install mingw-w64-ucrt-x86_64-sqlite3 and set WEKNORA_SQLITE_INCLUDE.'
+        $ok = $false
+    }
+    else {
+        Write-Success "SQLite header: $(Join-Path $sqliteDirectory 'sqlite3.h')"
+    }
+
+    if ($ok) {
+        $script:ResolvedGcc = $gcc
+        $script:ResolvedGxx = $gxx
+        $script:ResolvedSqliteInclude = $sqliteDirectory
+    }
+    return $ok
+}
+
+function Set-WindowsCgoEnvironment {
+    $compilerDirectory = Split-Path -Parent $script:ResolvedGcc
+    $env:Path = "$compilerDirectory;$env:Path"
+    $env:CGO_ENABLED = '1'
+    $env:CC = $script:ResolvedGcc
+    $env:CXX = $script:ResolvedGxx
+
+    # -idirafter supplies sqlite3.h without shadowing the selected compiler's
+    # own UCRT system headers with headers from a second toolchain.
+    $includePath = $script:ResolvedSqliteInclude.Replace('\', '/')
+    $cgoFlags = @()
+    if (-not [string]::IsNullOrWhiteSpace($env:CGO_CFLAGS)) {
+        $cgoFlags += $env:CGO_CFLAGS.Trim()
+    }
+    $cgoFlags += '-Wno-deprecated-declarations'
+    $cgoFlags += "-idirafter `"$includePath`""
+    $env:CGO_CFLAGS = $cgoFlags -join ' '
+
+    if ([string]::IsNullOrWhiteSpace($env:GOLANG_PROTOBUF_REGISTRATION_CONFLICT)) {
+        $env:GOLANG_PROTOBUF_REGISTRATION_CONFLICT = 'warn'
+    }
+
+    Write-Info "CC=$($env:CC)"
+    Write-Info "CGO_CFLAGS=$($env:CGO_CFLAGS)"
+}
+
+function Find-DockerCompose {
+    $script:ComposeExecutable = $null
+    $script:ComposePrefix = @()
+
+    $dockerCommand = Get-Command docker.exe -ErrorAction SilentlyContinue
+    if ($null -ne $dockerCommand) {
+        $composeResult = Invoke-CapturedCommand -FilePath $dockerCommand.Source -ArgumentList @('compose', 'version')
+        if ($composeResult.ExitCode -eq 0) {
+            $script:ComposeExecutable = $dockerCommand.Source
+            $script:ComposePrefix = @('compose')
+            return $true
+        }
+    }
+
+    $legacyCommand = Get-Command docker-compose.exe -ErrorAction SilentlyContinue
+    if ($null -ne $legacyCommand) {
+        $legacyResult = Invoke-CapturedCommand -FilePath $legacyCommand.Source -ArgumentList @('version')
+        if ($legacyResult.ExitCode -eq 0) {
+            $script:ComposeExecutable = $legacyCommand.Source
+            return $true
+        }
+    }
+    return $false
+}
+
+function Test-DockerEngine {
+    if (-not (Find-DockerCompose)) {
+        Write-ErrorMessage 'Docker Compose was not found.'
+        return $false
+    }
+
+    $dockerCommand = Get-Command docker.exe -ErrorAction SilentlyContinue
+    if ($null -eq $dockerCommand) {
+        Write-ErrorMessage 'docker.exe was not found.'
+        return $false
+    }
+    $infoResult = Invoke-CapturedCommand -FilePath $dockerCommand.Source -ArgumentList @('info')
+    if ($infoResult.ExitCode -ne 0) {
+        Write-ErrorMessage 'Docker Desktop is installed but its engine is not running.'
+        return $false
+    }
+    return $true
+}
+
+function Invoke-Compose {
+    param([string[]]$ComposeArguments)
+
+    $allArguments = @($script:ComposePrefix) + @('-f', (Join-Path $script:ProjectRoot 'docker-compose.dev.yml')) + $ComposeArguments
+    & $script:ComposeExecutable @allArguments | Out-Host
+    return [int]$LASTEXITCODE
+}
+
+function Get-ProfileArguments {
+    $profiles = New-Object System.Collections.Generic.List[string]
+    if ($Full) {
+        if ($NoLangfuse) {
+            Write-WarningMessage '-NoLangfuse is ignored when -Full is used because the full profile includes Langfuse.'
+        }
+        $profiles.Add('full')
+    }
+    else {
+        if (-not $NoLangfuse) { $profiles.Add('langfuse') }
+        if ($Minio) { $profiles.Add('minio') }
+        if ($Qdrant) { $profiles.Add('qdrant') }
+        if ($OpenSearch) { $profiles.Add('opensearch') }
+        if ($Milvus) { $profiles.Add('milvus') }
+        if ($Neo4j) { $profiles.Add('neo4j') }
+        if ($Searxng) { $profiles.Add('searxng') }
+        if ($Dex) { $profiles.Add('dex') }
+    }
+    if ($OdlHybrid) { $profiles.Add('odl-hybrid') }
+
+    $arguments = @()
+    foreach ($profile in $profiles) {
+        $arguments += @('--profile', $profile)
+    }
+    return $arguments
+}
+
+function Start-Infrastructure {
+    if (-not (Import-ProjectEnvironment -Required)) { return 1 }
+    if (-not [string]::IsNullOrWhiteSpace($env:DEV_REMOTE_HOST)) {
+        Write-WarningMessage "DEV_REMOTE_HOST=$($env:DEV_REMOTE_HOST); local Docker infrastructure was not started."
+        return 0
+    }
+    if (-not (Test-DockerEngine)) { return 1 }
+
+    $profileArguments = @(Get-ProfileArguments)
+    Write-Info 'Starting development infrastructure'
+    $exitCode = Invoke-Compose -ComposeArguments ($profileArguments + @('up', '-d'))
+    if ($exitCode -ne 0) { return $exitCode }
+
+    if ($OdlHybrid) {
+        Write-Info 'Building and starting odl-hybrid'
+        $exitCode = Invoke-Compose -ComposeArguments ($profileArguments + @('up', '-d', '--build', 'odl-hybrid'))
+        if ($exitCode -ne 0) { return $exitCode }
+    }
+
+    Write-Success 'Development infrastructure is running'
+    Write-Info 'Start the backend and frontend in separate terminals:'
+    Write-Host '  .\scripts\dev.ps1 app'
+    Write-Host '  .\scripts\dev.ps1 frontend'
+    return 0
+}
+
+function Stop-Infrastructure {
+    if (-not (Find-DockerCompose)) {
+        Write-ErrorMessage 'Docker Compose was not found.'
+        return 1
+    }
+    return (Invoke-Compose -ComposeArguments @('down'))
+}
+
+function Show-InfrastructureLogs {
+    if (-not (Find-DockerCompose)) {
+        Write-ErrorMessage 'Docker Compose was not found.'
+        return 1
+    }
+    return (Invoke-Compose -ComposeArguments @('logs', '-f'))
+}
+
+function Show-InfrastructureStatus {
+    if (-not (Find-DockerCompose)) {
+        Write-ErrorMessage 'Docker Compose was not found.'
+        return 1
+    }
+    return (Invoke-Compose -ComposeArguments @('ps'))
+}
+
+function Set-LocalDevelopmentAddresses {
+    if (-not [string]::IsNullOrWhiteSpace($env:DEV_REMOTE_HOST)) {
+        $remoteHost = $env:DEV_REMOTE_HOST
+        Write-Info "Using remote infrastructure at $remoteHost"
+        if ([string]::IsNullOrWhiteSpace($env:DB_HOST)) { $env:DB_HOST = $remoteHost }
+        if ([string]::IsNullOrWhiteSpace($env:REDIS_ADDR)) { $env:REDIS_ADDR = "${remoteHost}:6379" }
+        if ([string]::IsNullOrWhiteSpace($env:DOCREADER_ADDR)) { $env:DOCREADER_ADDR = "${remoteHost}:50051" }
+        if ([string]::IsNullOrWhiteSpace($env:MINIO_ENDPOINT)) { $env:MINIO_ENDPOINT = "${remoteHost}:9000" }
+        if ([string]::IsNullOrWhiteSpace($env:MILVUS_ADDRESS)) { $env:MILVUS_ADDRESS = "${remoteHost}:19530" }
+        if ([string]::IsNullOrWhiteSpace($env:NEO4J_URI)) { $env:NEO4J_URI = "bolt://${remoteHost}:7687" }
+        if ([string]::IsNullOrWhiteSpace($env:QDRANT_HOST)) { $env:QDRANT_HOST = $remoteHost }
+        if ([string]::IsNullOrWhiteSpace($env:LANGFUSE_HOST) -or $env:LANGFUSE_HOST -eq 'http://langfuse-web:3000') {
+            $env:LANGFUSE_HOST = "http://${remoteHost}:3000"
+        }
+    }
+    else {
+        $env:DB_HOST = '127.0.0.1'
+        $env:REDIS_ADDR = '127.0.0.1:6379'
+        $env:DOCREADER_ADDR = '127.0.0.1:50051'
+        $env:MINIO_ENDPOINT = '127.0.0.1:9000'
+        $env:MILVUS_ADDRESS = '127.0.0.1:19530'
+        $env:NEO4J_URI = 'bolt://127.0.0.1:7687'
+        $env:QDRANT_HOST = '127.0.0.1'
+    }
+
+    if ([string]::IsNullOrWhiteSpace($env:DOCREADER_TRANSPORT)) {
+        $env:DOCREADER_TRANSPORT = 'grpc'
+    }
+    if ([string]::IsNullOrWhiteSpace($env:LOCAL_STORAGE_BASE_DIR) -or $env:LOCAL_STORAGE_BASE_DIR -eq '/data/files') {
+        $env:LOCAL_STORAGE_BASE_DIR = Join-Path $script:ProjectRoot '.local-data\files'
+    }
+    New-Item -ItemType Directory -Path $env:LOCAL_STORAGE_BASE_DIR -Force | Out-Null
+}
+
+function Get-DevelopmentLdflags {
+    $version = $env:VERSION
+    if ([string]::IsNullOrWhiteSpace($version)) {
+        $result = Invoke-CapturedCommand -FilePath 'git.exe' -ArgumentList @('describe', '--tags', '--abbrev=0')
+        $version = if ($result.ExitCode -eq 0 -and -not [string]::IsNullOrWhiteSpace($result.Output)) { $result.Output.Trim() } else { 'unknown' }
+    }
+
+    $commit = $env:COMMIT_ID
+    if ([string]::IsNullOrWhiteSpace($commit)) {
+        $result = Invoke-CapturedCommand -FilePath 'git.exe' -ArgumentList @('rev-parse', '--short', 'HEAD')
+        $commit = if ($result.ExitCode -eq 0) { $result.Output.Trim() } else { 'unknown' }
+    }
+
+    $goResult = Invoke-CapturedCommand -FilePath 'go.exe' -ArgumentList @('version')
+    $goVersionMatch = [regex]::Match($goResult.Output, 'go version (go[^\s]+)')
+    $goVersion = if ($goVersionMatch.Success) { $goVersionMatch.Groups[1].Value } else { 'unknown' }
+    $buildTime = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')
+    $handlerPackage = 'github.com/Tencent/WeKnora/internal/handler'
+
+    return @(
+        "-X ${handlerPackage}.Version=$version",
+        "-X ${handlerPackage}.Edition=standard",
+        "-X ${handlerPackage}.CommitID=$commit",
+        "-X ${handlerPackage}.BuildTime=$buildTime",
+        "-X ${handlerPackage}.GoVersion=$goVersion",
+        '-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn'
+    ) -join ' '
+}
+
+function Start-Backend {
+    Set-Location $script:ProjectRoot
+    if (-not (Import-ProjectEnvironment -Required)) { return 1 }
+    if (-not (Test-PlatformAndGo)) { return 1 }
+    if (-not (Test-WindowsToolchain)) { return 1 }
+    if ([string]::IsNullOrWhiteSpace($env:DB_DRIVER)) {
+        Write-ErrorMessage 'DB_DRIVER is not set in .env.'
+        return 1
+    }
+
+    Set-LocalDevelopmentAddresses
+    Set-WindowsCgoEnvironment
+    Write-Info "Database: $($env:DB_HOST):$($env:DB_PORT)"
+    Write-Info "Local storage: $($env:LOCAL_STORAGE_BASE_DIR)"
+
+    $airCommand = Get-Command air.exe -ErrorAction SilentlyContinue
+    if (-not $NoAir -and $null -ne $airCommand) {
+        Write-Success 'Air detected; starting Windows hot reload mode'
+        & $airCommand.Source '-c' (Join-Path $script:ProjectRoot 'air.windows.toml') | Out-Host
+        return [int]$LASTEXITCODE
+    }
+
+    if (-not $NoAir) {
+        Write-WarningMessage 'Air is not installed; starting without hot reload.'
+        Write-Info 'Optional install: go install github.com/air-verse/air@latest'
+    }
+
+    $goArguments = @('run')
+    if (-not [string]::IsNullOrWhiteSpace($env:GO_BUILD_TAGS)) {
+        $goArguments += @('-tags', $env:GO_BUILD_TAGS)
+    }
+    $goArguments += @('-ldflags', (Get-DevelopmentLdflags), './cmd/server')
+    & 'go.exe' @goArguments | Out-Host
+    return [int]$LASTEXITCODE
+}
+
+function Start-Frontend {
+    if (-not (Import-ProjectEnvironment)) { return 1 }
+    $npmCommand = Get-Command npm.cmd -ErrorAction SilentlyContinue
+    if ($null -eq $npmCommand) {
+        Write-ErrorMessage 'npm.cmd was not found. Install Node.js 22 or newer.'
+        return 1
+    }
+
+    $frontendDirectory = Join-Path $script:ProjectRoot 'frontend'
+    Set-Location $frontendDirectory
+    if (-not (Test-Path -LiteralPath (Join-Path $frontendDirectory 'node_modules') -PathType Container)) {
+        Write-WarningMessage 'frontend/node_modules is missing; running npm install.'
+        & $npmCommand.Source 'install' | Out-Host
+        if ($LASTEXITCODE -ne 0) { return [int]$LASTEXITCODE }
+    }
+
+    $proxyTarget = $env:VITE_DEV_PROXY_TARGET
+    if ([string]::IsNullOrWhiteSpace($proxyTarget)) { $proxyTarget = $env:FRONTEND_BACKEND_URL }
+    if ([string]::IsNullOrWhiteSpace($proxyTarget)) { $proxyTarget = 'http://localhost:8080' }
+    Write-Info 'Starting Vite at http://localhost:5173'
+    Write-Info "API proxy target: $proxyTarget"
+    & $npmCommand.Source 'run' 'dev' | Out-Host
+    return [int]$LASTEXITCODE
+}
+
+function Show-OptionalReadiness {
+    $npmCommand = Get-Command npm.cmd -ErrorAction SilentlyContinue
+    if ($null -eq $npmCommand) {
+        Write-WarningMessage 'Node.js/npm is missing; the frontend command will not run.'
+    }
+    else {
+        $npmResult = Invoke-CapturedCommand -FilePath $npmCommand.Source -ArgumentList @('--version')
+        Write-Success "npm $($npmResult.Output.Trim())"
+    }
+
+    if (Find-DockerCompose) {
+        $dockerCommand = Get-Command docker.exe -ErrorAction SilentlyContinue
+        if ($null -eq $dockerCommand) {
+            Write-WarningMessage 'Docker Compose is installed, but docker.exe is unavailable; run start to verify the engine.'
+            return
+        }
+        $dockerResult = Invoke-CapturedCommand -FilePath $dockerCommand.Source -ArgumentList @('info')
+        if ($dockerResult.ExitCode -eq 0) {
+            Write-Success 'Docker Desktop engine is running'
+        }
+        else {
+            Write-WarningMessage 'Docker Compose is installed, but Docker Desktop is not running.'
+        }
+    }
+    else {
+        Write-WarningMessage 'Docker Compose is missing; infrastructure commands will not run.'
+    }
+}
+
+function Invoke-Preflight {
+    $ok = $true
+    Set-Location $script:ProjectRoot
+    if (-not (Import-ProjectEnvironment -Required)) { $ok = $false }
+    if (-not (Test-PlatformAndGo)) { $ok = $false }
+    if (-not (Test-WindowsToolchain)) { $ok = $false }
+    if ($ok) {
+        Set-WindowsCgoEnvironment
+        Write-Success 'Windows backend preflight passed'
+    }
+    Show-OptionalReadiness
+    if ($ok) { return 0 }
+    return 1
+}
+
+function Show-Help {
+    Write-Host @'
+WeKnora native Windows development helper
+
+Usage:
+  .\scripts\dev.ps1 check [-GccBin <dir>] [-SqliteInclude <dir>]
+  .\scripts\dev.ps1 start [-Minio] [-Qdrant] [-OpenSearch] [-Milvus]
+                          [-Neo4j] [-Searxng] [-Dex] [-OdlHybrid]
+                          [-Full] [-NoLangfuse]
+  .\scripts\dev.ps1 app [-GccBin <dir>] [-SqliteInclude <dir>] [-NoAir]
+  .\scripts\dev.ps1 frontend
+  .\scripts\dev.ps1 status | logs | stop | restart
+
+Persistent toolchain settings:
+  WEKNORA_GCC_BIN        Directory containing the DuckDB-compatible gcc.exe/g++.exe
+  WEKNORA_SQLITE_INCLUDE Directory containing sqlite3.h
+
+Run `check` before `app`. See website-docs/06-development/01-dev-guide.md
+for the validated GCC 14.2 UCRT setup and the GCC 16 incompatibility note.
+'@
+}
+
+try {
+    $exitCode = switch ($Command) {
+        'check' { Invoke-Preflight }
+        'start' { Start-Infrastructure }
+        'stop' { Stop-Infrastructure }
+        'restart' {
+            $stopCode = Stop-Infrastructure
+            if ($stopCode -ne 0) { $stopCode } else { Start-Infrastructure }
+        }
+        'logs' { Show-InfrastructureLogs }
+        'status' { Show-InfrastructureStatus }
+        'app' { Start-Backend }
+        'frontend' { Start-Frontend }
+        default { Show-Help; 0 }
+    }
+}
+catch {
+    Write-ErrorMessage $_.Exception.Message
+    $exitCode = 1
+}
+finally {
+    Set-Location $script:ProjectRoot
+}
+
+exit [int]$exitCode

--- a/website-docs/06-development/01-dev-guide.md
+++ b/website-docs/06-development/01-dev-guide.md
@@ -33,7 +33,7 @@ pip install uv          # docreader 使用 uv sync 安装依赖
 
 ## 2. 快速开始：开发模式（推荐）
 
-开发模式的核心思想：**基础设施跑在 Docker 里，`app` 与 `frontend` 跑在本地**，改代码即时重启，无需反复构建镜像。入口是 `scripts/dev.sh`（Makefile 的 `dev-*` 目标是它的包装）。
+开发模式的核心思想：**基础设施跑在 Docker 里，`app` 与 `frontend` 跑在本地**，改代码即时重启，无需反复构建镜像。Linux、macOS 与 WSL 使用 `scripts/dev.sh`（Makefile 的 `dev-*` 目标是它的包装）；Windows 原生 PowerShell 使用 `scripts/dev.ps1`。
 
 ```bash
 # 1. 准备环境变量：dev.sh 会加载 .env（必须存在），再用 .env.local 覆盖（可选）
@@ -56,9 +56,59 @@ make dev-stop     # 停止
 make dev-restart  # 重启
 ```
 
-前端 dev server 监听 `5173`（`frontend/vite.config.ts` 中 `server.port: 5173`），并把 `/api` 与 `/files` 代理到本地后端（`DEV_PROXY_TARGET`）。`vite preview`（端口 `4173`）用生产构建产物起服务，是最接近 release 镜像的验证环境。
+前端 dev server 监听 `5173`（`frontend/vite.config.ts` 中 `server.port: 5173`），并把 `/api` 与 `/files` 代理到本地后端（`VITE_DEV_PROXY_TARGET`）。`vite preview`（端口 `4173`）用生产构建产物起服务，是最接近 release 镜像的验证环境。
 
-### 2.1 docker-compose.dev.yml 服务清单
+### 2.1 Windows 原生开发
+
+Windows 原生开发同样采用“Docker Desktop 跑基础设施、Windows 跑 Go/Vite”的结构。后端即使使用 PostgreSQL，构建时仍会编译 DuckDB 与 sqlite-vec，因此必须启用 CGO，并同时提供兼容的 UCRT GCC、`g++.exe` 与 `sqlite3.h`。
+
+当前已验证的组合为 **Windows 11 x64 + Go 1.26 + GCC 14.2 POSIX/SEH/UCRT + UCRT64 SQLite 头文件**。请使用 [DuckDB Windows 构建采用的 GCC 14.2 工具链](https://github.com/niXman/mingw-builds-binaries/releases/download/14.2.0-rt_v12-rev0/x86_64-14.2.0-release-posix-seh-ucrt-rt_v12-rev0.7z)，并从 MSYS2 UCRT64 安装 SQLite 开发包：
+
+```bash
+# 在 MSYS2 UCRT64 终端执行；默认头文件位于 C:\msys64\ucrt64\include\sqlite3.h
+pacman -S --needed mingw-w64-ucrt-x86_64-sqlite3
+```
+
+> 不要使用当前 MSYS2 UCRT64 的 GCC 16 来链接 DuckDB 预编译库。GCC 16 切换为 native TLS 后，旧工具链构建的静态库会缺少 `__emutls_v._ZSt11__once_call` 与 `__emutls_v._ZSt15__once_callable`。`dev.ps1 check` 会在编译前明确报告此问题。背景见 [MSYS2 GCC 16 native TLS 说明](https://www.msys2.org/news/#2026-05-11-native-thread-local-storage-tls-with-gcc-16) 与 [DuckDB Windows 工具链记录](https://github.com/duckdb/duckdb-r/issues/2234)。
+
+在 PowerShell 5.1 或更高版本中配置并启动：
+
+```powershell
+Copy-Item .env.example .env
+
+# 指向下载后包含 gcc.exe / g++.exe 的目录，以及包含 sqlite3.h 的目录。
+$env:WEKNORA_GCC_BIN = 'C:\Tools\duckdb-gcc-14.2\mingw64\bin'
+$env:WEKNORA_SQLITE_INCLUDE = 'C:\msys64\ucrt64\include'
+
+# 必做：检查 Windows/amd64、Go、CGO 工具链、UCRT 和 SQLite 头文件。
+.\scripts\dev.ps1 check
+
+# 启动 Docker Desktop 基础设施；可追加 -Qdrant、-Minio、-Neo4j 等开关。
+.\scripts\dev.ps1 start
+
+# 分别在两个新终端中执行。安装 Air 后，后端会使用 air.windows.toml 热重载。
+.\scripts\dev.ps1 app
+.\scripts\dev.ps1 frontend
+```
+
+也可用 `-GccBin` 与 `-SqliteInclude` 参数代替环境变量。基础设施管理命令为 `start`、`stop`、`restart`、`logs`、`status`；`app -NoAir` 可强制使用普通 `go run`。脚本只读取 `.env`/`.env.local` 的键值，不会把文件内容当作 PowerShell 代码执行。
+
+GoLand 断点调试可创建以 `./cmd/server` 为目标、仓库根目录为工作目录的 Go Build 配置，并设置以下环境：
+
+```text
+CGO_ENABLED=1
+CC=C:\Tools\duckdb-gcc-14.2\mingw64\bin\gcc.exe
+CXX=C:\Tools\duckdb-gcc-14.2\mingw64\bin\g++.exe
+CGO_CFLAGS=-Wno-deprecated-declarations -idirafter "C:/msys64/ucrt64/include"
+GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn
+DB_HOST=127.0.0.1
+REDIS_ADDR=127.0.0.1:6379
+DOCREADER_ADDR=127.0.0.1:50051
+```
+
+同时加载 `.env` 中其余配置，并先运行 `.\scripts\dev.ps1 start`。当前 DuckDB Go 预编译绑定只覆盖 `windows/amd64`；Windows ARM64 或不希望维护 Windows CGO 工具链时，请使用 WSL2，在 WSL 内按本节开头的 `dev.sh`/Makefile 流程开发。更多背景可参考 [DuckDB Go Windows 说明](https://github.com/duckdb/duckdb-go#Windows)、[MSYS2 UCRT64 环境说明](https://www.msys2.org/docs/environments/) 与 [Go cgo 文档](https://go.dev/wiki/cgo)。
+
+### 2.2 docker-compose.dev.yml 服务清单
 
 `docker-compose.dev.yml` 只包含依赖服务，不含 `app`/`frontend`。默认启动与 profile 可选服务如下（profile 通过 `dev.sh start` 的参数开启）：
 
@@ -81,7 +131,7 @@ make dev-restart  # 重启
 
 `dev.sh start` 的可选参数：`--minio`、`--qdrant`、`--neo4j`、`--dex`、`--langfuse`（默认开）、`--no-langfuse`、`--odl-hybrid`、`--full`（全部可选服务，不含 odl-hybrid）。通过 Makefile 传参：`make dev-start DEV_ARGS=--odl-hybrid`。
 
-### 2.2 本地单独跑 docreader
+### 2.3 本地单独跑 docreader
 
 `dev-start` 默认把 docreader 跑在容器里；如需本地调试 Python 代码：
 
@@ -93,7 +143,7 @@ uv run -m docreader.main      # 启动 gRPC 服务（与 Dockerfile CMD 一致�
 
 docreader 的大量调优参数（PDF 渲染 DPI、扫描件判定、SSRF 白名单、gRPC TLS 等）以 `DOCREADER_*` 环境变量注入，完整清单见 `docker-compose.dev.yml` 的 `docreader.environment` 段。
 
-### 2.3 Lite 模式（零外部依赖）
+### 2.4 Lite 模式（零外部依赖）
 
 Lite 模式把 SQLite（+sqlite-vec）与内存队列编译进单个二进制，适合快速体验与桌面端：
 
@@ -157,7 +207,8 @@ make package-mac-app  # 打 macOS .app（scripts/package-mac-app.sh）
 | `dev-start` / `dev-stop` / `dev-restart` / `dev-logs` / `dev-status` | `scripts/dev.sh start/stop/restart/logs/status`（支持 `DEV_ARGS` 传 profile 参数） |
 | `dev-app` | 本地 `go run ./cmd/server`（带版本 ldflags） |
 | `dev-frontend` | 本地 `npm run dev` |
-| `build-lite` / `run-lite` / `package-lite` / `package-mac-app` | Lite 模式构建/运行/打包（见 2.3） |
+| Windows 原生命令 | 使用 `scripts/dev.ps1 check/start/app/frontend`，不经过 Makefile（见 2.1） |
+| `build-lite` / `run-lite` / `package-lite` / `package-mac-app` | Lite 模式构建/运行/打包（见 2.4） |
 | `download_spatial` | `go run cmd/download/duckdb/duckdb.go` 下载 DuckDB spatial 扩展（数据分析工具用） |
 
 ## 4. 测试体系


### PR DESCRIPTION
## Description

Add a native Windows development workflow for the supported “Docker infrastructure + local Go/Vite” setup.

- Add `scripts/dev.ps1` with `check`, infrastructure lifecycle, backend, frontend, logs, and status commands for PowerShell 5.1+.
- Validate Go, windows/amd64, CGO, UCRT GCC, `g++.exe`, and `sqlite3.h` before starting the backend.
- Reject GCC 16 with an actionable explanation for the current DuckDB prebuilt-library TLS incompatibility; document the verified GCC 14.2 UCRT toolchain.
- Add `air.windows.toml` for native backend hot reload.
- Parse `.env` and `.env.local` as data rather than executing PowerShell expressions.
- Document PowerShell usage, GoLand configuration, Docker profiles, and the WSL fallback.

This is scoped to developer mode (`docker-compose.dev.yml`, local backend/frontend), separate from the all-in-Docker installation launcher.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [x] 🔧 Configuration / Build / CI

## Related Issue

Closes #2095

## Testing

- Windows PowerShell 5.1 and PowerShell 7.6 AST parsing, help, and positive preflight: passed.
- Exact DuckDB-compatible GCC 14.2 UCRT toolchain plus MSYS2 UCRT64 `sqlite3.h`: passed in both PowerShell versions.
- GCC 16, missing GCC, and missing `sqlite3.h` negative preflight cases: rejected with the expected actionable errors.
- `scripts/dev.ps1 app -NoAir`: completed the real Windows CGO compile/link and entered the server; startup then stopped at the expected database connection because local PostgreSQL was not running.
- Isolated fake Docker/Air/npm integration checks: verified compose profiles/lifecycle arguments, Air config selection, frontend command forwarding, and safe `.env` parsing.
- `go vet -p 1 ./...`: passed with the documented GCC 14.2 environment.
- `npm --prefix website-docs run check`: passed (144 links and 61 Mermaid graphs).
- `npm --prefix website-docs run build`: passed.
- `go test -p 1 ./...`: most packages passed. Existing Windows/environment-dependent failures remain in `internal/agent/skills` (path separators), `internal/application/service` (open SQLite temp handle and no callable `python`), and `internal/handler` (Windows path parsing). `internal/datasource/connector/feishu/wiki` passed when the host-only `LOG_FORMAT=json` override was removed. No Go source files are changed by this PR.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (no Go source diff; full `go vet` passed)
- [x] Full-repository checks were run, or unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [x] Updated related documentation
- [x] Breaking changes are clearly called out (none)

## Screenshots / Recordings

Not applicable; this change adds command-line developer tooling and documentation.