### PR TITLE
feat(dev): add containerized Delve debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build run test clean docker-build-app docker-build-docreader docker-build-frontend docker-build-all docker-run migrate-up migrate-down docker-restart docker-stop start-all stop-all start-ollama stop-ollama build-images build-images-app build-images-docreader build-images-frontend clean-images check-env list-containers pull-images show-platform dev-start dev-stop dev-restart dev-logs dev-status dev-app dev-frontend docs install-swagger build-lite run-lite package-lite anydoc-lib build-anydoc
+.PHONY: help build run test clean docker-build-app docker-build-docreader docker-build-frontend docker-build-all docker-run migrate-up migrate-down docker-restart docker-stop start-all stop-all start-ollama stop-ollama build-images build-images-app build-images-docreader build-images-frontend clean-images check-env list-containers pull-images show-platform dev-start dev-stop dev-restart dev-logs dev-status dev-app dev-debug dev-frontend docs install-swagger build-lite run-lite package-lite anydoc-lib build-anydoc
 
 # Show help
 help:
@@ -59,6 +59,7 @@ help:
 	@echo "  dev-status        查看开发环境状态"
 	@echo "  dev-app           启动后端应用（本地运行，需先运行 dev-start）"
 	@echo "                    已 make anydoc-lib 时自动链接 anydoc 引擎"
+	@echo "  dev-debug         在容器内启动 Delve 远程调试（默认 127.0.0.1:40000）"
 	@echo "  dev-frontend      启动前端（本地运行，需先运行 dev-start）"
 	@echo ""
 	@echo "Lite 模式（零外部依赖）:"
@@ -343,6 +344,9 @@ dev-status:
 
 dev-app:
 	./scripts/dev.sh app
+
+dev-debug:
+	./scripts/dev.sh debug
 
 dev-frontend:
 	./scripts/dev.sh frontend

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,0 +1,67 @@
+# Overlay for docker-compose.dev.yml. Start it through `make dev-debug` or:
+# docker compose -f docker-compose.dev.yml -f docker-compose.debug.yml up --build app-debug
+services:
+  app-debug:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.debug
+      args:
+        GOPRIVATE_ARG: ${GOPRIVATE:-}
+        GOPROXY_ARG: ${GOPROXY:-https://proxy.golang.org,direct}
+        GOSUMDB_ARG: ${GOSUMDB:-off}
+        DELVE_VERSION: ${DELVE_VERSION:-v1.27.1}
+    container_name: WeKnora-app-debug
+    working_dir: /workspace
+    env_file:
+      - ${WEKNORA_DEBUG_ENV_FILE:-.env}
+    environment:
+      # Host-facing ports may be customized, but container service addresses
+      # are stable on the development Compose network.
+      APP_PORT: "8080"
+      GIN_MODE: debug
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      REDIS_ADDR: redis:6379
+      DOCREADER_ADDR: docreader:50051
+      DOCREADER_TRANSPORT: grpc
+      LOCAL_STORAGE_BASE_DIR: /data/files
+      MINIO_ENDPOINT: minio:9000
+      QDRANT_HOST: qdrant
+      QDRANT_PORT: "6334"
+      MILVUS_ADDRESS: milvus:19530
+      NEO4J_URI: bolt://neo4j:7687
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
+      GOLANG_PROTOBUF_REGISTRATION_CONFLICT: warn
+    ports:
+      - "${DEBUG_APP_BIND:-127.0.0.1}:${APP_PORT:-8080}:8080"
+      # Delve has no transport authentication. Keep the host binding on
+      # loopback unless the development machine is otherwise isolated.
+      - "${DELVE_BIND:-127.0.0.1}:${DELVE_PORT:-40000}:40000"
+    volumes:
+      - .:/workspace
+      - debug-go-mod-cache:/go/pkg/mod
+      - debug-go-build-cache:/root/.cache/go-build
+      - debug-data-files:/data/files
+      - docreader-tmp-dev:/tmp/docreader:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      docreader:
+        condition: service_healthy
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined
+    init: true
+    networks:
+      - WeKnora-network-dev
+    restart: "no"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+volumes:
+  debug-go-mod-cache:
+  debug-go-build-cache:
+  debug-data-files:

--- a/docker/Dockerfile.debug
+++ b/docker/Dockerfile.debug
@@ -1,0 +1,40 @@
+# Native Go development image with Delve. This image is intentionally separate
+# from Dockerfile.app: it bind-mounts the source tree and waits for an IDE to
+# attach instead of producing a release artifact.
+FROM golang:1.26-bookworm
+
+WORKDIR /workspace
+
+ARG GOPRIVATE_ARG
+ARG GOPROXY_ARG=https://proxy.golang.org,direct
+ARG GOSUMDB_ARG=off
+ARG DELVE_VERSION=v1.27.1
+
+ENV CGO_ENABLED=1 \
+    CGO_CFLAGS="-Wno-deprecated-declarations -Wno-gnu-folding-constant" \
+    GOPRIVATE=${GOPRIVATE_ARG} \
+    GOPROXY=${GOPROXY_ARG} \
+    GOSUMDB=${GOSUMDB_ARG} \
+    GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        git \
+        libsqlite3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# go.mod replaces anydoc with a local module, so its manifest must be present
+# before downloading dependencies. Source code itself is mounted by Compose.
+COPY go.mod go.sum ./
+COPY third_party/anydoc-go/go.mod third_party/anydoc-go/go.mod
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download && \
+    go install github.com/go-delve/delve/cmd/dlv@${DELVE_VERSION}
+
+EXPOSE 8080 40000
+
+# Keep the debug binary outside the bind-mounted repository. Delve waits at
+# program entry until a remote client attaches and continues execution.
+CMD ["dlv", "debug", "./cmd/server", "--headless=true", "--listen=:40000", "--api-version=2", "--accept-multiclient", "--output=/tmp/weknora-debug"]

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -61,6 +61,7 @@ show_help() {
     echo "  logs       查看服务日志"
     echo "  status     查看服务状态"
     echo "  app        启动后端应用（本地运行）"
+    echo "  debug      在容器内启动 Delve，等待 IDE 远程调试连接"
     echo "  frontend   启动前端开发服务器（本地运行）"
     echo "  help       显示此帮助信息"
     echo ""
@@ -82,6 +83,7 @@ show_help() {
     echo "  $0 start --full             # 启动所有服务"
     echo "  make dev-start DEV_ARGS=--odl-hybrid   # 同上（Makefile 传参）"
     echo "  $0 app                      # 在另一个终端启动后端"
+    echo "  $0 debug                    # 容器内调试后端，Delve 默认监听 127.0.0.1:40000"
     echo "  $0 frontend                 # 在另一个终端启动前端"
 }
 
@@ -533,6 +535,35 @@ start_app() {
     fi
 }
 
+# 在容器中启动 Delve 远程调试。基础设施与 app-debug 使用同一个 Compose
+# project/network；Delve 只映射到宿主机 loopback，避免暴露无认证的调试端口。
+start_debug() {
+    log_info "启动容器化 Delve 远程调试..."
+
+    if ! check_docker; then
+        return 1
+    fi
+
+    cd "$PROJECT_ROOT"
+
+    local debug_env_file="${WEKNORA_DEBUG_ENV_FILE:-.env}"
+    if [ ! -f "$debug_env_file" ]; then
+        log_error "调试环境文件不存在: $debug_env_file"
+        log_info "请先运行: cp .env.example .env"
+        return 1
+    fi
+
+    log_info "Delve 地址: ${DELVE_BIND:-127.0.0.1}:${DELVE_PORT:-40000}"
+    log_info "源码路径映射: $PROJECT_ROOT -> /workspace"
+    log_info "Delve 会在程序入口等待；请在 IDE 连接后继续执行"
+
+    WEKNORA_DEBUG_ENV_FILE="$debug_env_file" \
+        "$DOCKER_COMPOSE_BIN" $DOCKER_COMPOSE_SUBCMD \
+        -f docker-compose.dev.yml \
+        -f docker-compose.debug.yml \
+        up --build app-debug
+}
+
 # 启动前端（本地）
 start_frontend() {
     log_info "启动前端开发服务器..."
@@ -584,6 +615,9 @@ case "$CMD" in
         ;;
     app)
         start_app
+        ;;
+    debug)
+        start_debug
         ;;
     frontend)
         start_frontend

--- a/website-docs/06-development/04-remote-debug.md
+++ b/website-docs/06-development/04-remote-debug.md
@@ -1,0 +1,69 @@
+# Go 后端容器远程调试
+
+WeKnora 提供独立的 `docker-compose.debug.yml`，用于在容器内以 Delve 启动 Go 后端，并从宿主机的 GoLand 等 IDE 连接断点。PostgreSQL、Redis 与 DocReader 仍复用 `docker-compose.dev.yml`，源码通过 bind mount 实时映射，不需要每次构建发布镜像。
+
+## 1. 启动调试服务
+
+先准备普通开发环境变量并确认 Docker 可用：
+
+```bash
+cp .env.example .env
+make dev-debug
+```
+
+该命令会完成以下动作：
+
+1. 构建 `docker/Dockerfile.debug`，安装固定版本的 [Delve v1.27.1](https://github.com/go-delve/delve/releases/tag/v1.27.1)；
+2. 启动 PostgreSQL、Redis、DocReader 与 `app-debug`；
+3. 把仓库根目录映射到容器 `/workspace`，并为 Go module/build cache 使用独立数据卷；
+4. 在容器内执行 `dlv debug ./cmd/server`，等待 IDE 连接后再继续程序。
+
+默认调试地址为 `127.0.0.1:40000`，HTTP API 仍映射到 `127.0.0.1:8080`。如端口冲突，可在命令前覆盖宿主机端口：
+
+```bash
+DELVE_PORT=2345 APP_PORT=18080 make dev-debug
+```
+
+也可以不经过 Makefile，直接运行：
+
+```bash
+docker compose \
+  -f docker-compose.dev.yml \
+  -f docker-compose.debug.yml \
+  up --build app-debug
+```
+
+按 `Ctrl+C` 停止本次前台调试；需要清理整个开发 Compose project 时运行 `make dev-stop`。
+
+## 2. 连接 IDE
+
+以 GoLand 为例，新建 **Go Remote** 配置：
+
+- Host：`127.0.0.1`
+- Port：`40000`（或自定义的 `DELVE_PORT`）
+- 本地项目根目录映射到远程 `/workspace`
+
+启动 `make dev-debug`，等待终端出现 Delve 监听信息后运行该配置。连接成功时进程仍停在入口；在 IDE 中继续执行即可命中断点。Delve 使用 headless API v2 并允许同一开发会话重新连接，具体命令语义见 [Delve `debug` 官方说明](https://github.com/go-delve/delve/blob/master/Documentation/usage/dlv_debug.md)。
+
+## 3. 配置与可选服务
+
+`app-debug` 默认读取仓库根目录的 `.env`。如需隔离调试配置，可指定另一个完整环境文件：
+
+```bash
+WEKNORA_DEBUG_ENV_FILE=.env.debug make dev-debug
+```
+
+向量库、MinIO、Neo4j 等仍由开发 Compose profile 管理。先按需运行例如 `make dev-start DEV_ARGS=--qdrant`，再启动调试服务；`app-debug` 与这些容器共享 `WeKnora-network-dev`。
+
+调试镜像默认不链接可选的 anydoc Rust 静态库，适合排查 Go 后端主链路。需要调试 anydoc FFI 时，应在宿主机按[开发指南](./01-dev-guide.md)构建静态库并使用本地 `make dev-app` 调试。
+
+## 4. 安全与故障排查
+
+Delve 远程协议不提供传输认证，因此 Compose 默认把端口限制在宿主机 loopback。不要在不可信网络中把 `DELVE_BIND` 改成 `0.0.0.0`。调试容器额外启用 `SYS_PTRACE` 与 `seccomp:unconfined`，只应用于本地 `app-debug` 服务，不应作为生产部署配置。
+
+常见问题：
+
+- **断点显示未绑定**：确认源码路径映射为“本地仓库根目录 → `/workspace`”，并等待首次 CGO 编译完成。
+- **端口已占用**：设置新的 `DELVE_PORT` 或 `APP_PORT` 后重试。
+- **依赖配置未生效**：确认 `WEKNORA_DEBUG_ENV_FILE` 指向完整文件；服务名地址会在容器内固定为 `postgres`、`redis` 与 `docreader`。
+- **构建依赖下载失败**：通过 `GOPROXY` 覆盖 Go module 代理；必要时设置 `DELVE_VERSION` 使用经验证的其他 Delve 版本。

--- a/website-docs/README.md
+++ b/website-docs/README.md
@@ -139,6 +139,7 @@ npm run preview  # 预览构建产物
 | [开发指南](06-development/01-dev-guide.md) | 环境要求、Makefile 全目标、开发模式、四条测试线、CI 与代码规范、调试技巧 |
 | [数据库与迁移](06-development/02-database-schema.md) | 40+ 张表结构与 ER 图、golang-migrate 双路径（versioned / sqlite）、新增迁移步骤、故障排查 |
 | [扩展点指南](06-development/03-extension-points.md) | 9 大扩展点：解析器/分块策略/检索引擎/模型 Provider/搜索引擎/数据源连接器/IM 适配器/Agent 工具/存储后端 |
+| [Go 后端容器远程调试](06-development/04-remote-debug.md) | 使用 Docker Compose 与 Delve 在容器内启动后端，并从 GoLand 连接断点 |
 
 ## 系统组件速览
 


### PR DESCRIPTION
## Description

Add an opt-in Docker Compose workflow for remote Go backend debugging with Delve.

- Add a dedicated Go 1.26 debug image with Delve v1.27.1 and the CGO dependencies required by WeKnora.
- Add a Compose overlay that bind-mounts the source tree, reuses the development infrastructure network, and waits for an IDE on Delve API v2.
- Bind both the debug and app ports to loopback by default; scope `SYS_PTRACE` and `seccomp:unconfined` to the debug-only service.
- Add `make dev-debug` / `scripts/dev.sh debug` with environment-file validation and actionable connection details.
- Add a Chinese setup, GoLand path-mapping, configuration, security, and troubleshooting guide.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [x] 🔧 Configuration / Build / CI

## Related Issue

Closes #599

## Testing

- `docker compose --env-file .env.example -f docker-compose.dev.yml -f docker-compose.debug.yml config --quiet`: passed.
- Parsed Compose model verified the debug image, `127.0.0.1` bindings, custom port overrides, source mount, `SYS_PTRACE`, seccomp option, shared development network, and dependency conditions.
- Git Bash `bash -n scripts/dev.sh`: passed.
- Isolated fake-Docker integration verified `scripts/dev.sh debug` runs exactly `docker compose -f docker-compose.dev.yml -f docker-compose.debug.yml up --build app-debug` after the preflight checks.
- `npm --prefix website-docs run check`: passed (146 links, 61 Mermaid graphs).
- `npm --prefix website-docs run build`: passed.
- `git diff --check origin/main...HEAD`: passed.

Docker Desktop was installed but its engine was not running on the validation host, so the debug image was not built or launched locally. The Compose model and command wiring were validated without mutating real containers.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed components pass
- [x] Diff-scoped lint passes where applicable (no Go source diff)
- [x] Full-repository checks were run, or unrelated/environment-dependent limitations are documented above
- [x] Self-reviewed the code
- [ ] Added/updated automated tests covering the change
- [x] Updated related documentation
- [x] Breaking changes are clearly called out (none)

## Screenshots / Recordings

Not applicable; this change adds command-line development tooling and documentation.