### PR TITLE
fix(agent): recover tool arguments with a stray trailing fragment

### DIFF
--- a/internal/agent/tools/json_repair.go
+++ b/internal/agent/tools/json_repair.go
@@ -13,6 +13,7 @@ import (
 //   - Unquoted keys
 //   - Invalid backslash escapes inside strings (e.g. regex patterns like
 //     "C\+\+", "\d+", "\.log$") where the LLM forgot to double-escape.
+//   - Extra tokens after the top-level value (e.g. `{}""`, `{"a":1}{"a":1}`)
 //
 // Returns the repaired JSON string. If repair is not possible,
 // returns the original string unchanged (caller should handle parse errors).
@@ -35,6 +36,9 @@ func RepairJSON(s string) string {
 	// Fix invalid backslash escapes before anything else, because unbalanced
 	// strings confuse the comma/bracket trackers below.
 	s = fixInvalidEscapes(s)
+
+	// Drop anything after the first complete top-level value
+	s = trimAfterTopLevelValue(s)
 
 	// Fix trailing commas: ,} or ,]
 	s = fixTrailingCommas(s)
@@ -100,6 +104,51 @@ func fixInvalidEscapes(s string) string {
 		}
 	}
 	return out.String()
+}
+
+// trimAfterTopLevelValue cuts everything that follows the first balanced
+// top-level object/array. Streaming providers occasionally emit a stray
+// argument fragment after the arguments are already complete — a lone `""`
+// or a repeat of the whole payload — and the concatenated result (`{}""`)
+// fails to parse even though the leading value is perfectly good.
+// Input that never closes its top-level value is returned unchanged so that
+// balanceBrackets can still recover a truncated payload.
+func trimAfterTopLevelValue(s string) string {
+	depth := 0
+	inString := false
+	escaped := false
+
+	for i, r := range s {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inString {
+			switch r {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch r {
+		case '"':
+			inString = true
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+			if depth == 0 {
+				end := i + len(string(r))
+				if strings.TrimSpace(s[end:]) == "" {
+					return s
+				}
+				return s[:end]
+			}
+		}
+	}
+	return s
 }
 
 // fixTrailingCommas removes trailing commas before closing brackets/braces.

--- a/internal/agent/tools/json_repair_test.go
+++ b/internal/agent/tools/json_repair_test.go
@@ -116,6 +116,35 @@ func TestRepairJSON(t *testing.T) {
 		assert.Equal(t, once, twice)
 	})
 
+	t.Run("stray fragment after empty object", func(t *testing.T) {
+		// Streaming providers sometimes append a lone `""` fragment after the
+		// arguments are already complete.
+		result := RepairJSON(`{}""`)
+		assert.Equal(t, "{}", result)
+	})
+
+	t.Run("stray fragment after complete object", func(t *testing.T) {
+		result := RepairJSON(`{"path": "/workspace/output"}""`)
+		assert.True(t, json.Valid([]byte(result)), "result: %s", result)
+
+		var parsed struct {
+			Path string `json:"path"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(result), &parsed))
+		assert.Equal(t, "/workspace/output", parsed.Path)
+	})
+
+	t.Run("duplicated payload keeps first value", func(t *testing.T) {
+		result := RepairJSON(`{"a": 1}{"a": 1}`)
+		assert.Equal(t, `{"a": 1}`, result)
+	})
+
+	t.Run("brace inside string does not trigger trim", func(t *testing.T) {
+		input := `{"query": "}", "limit": 1}`
+		result := RepairJSON(input)
+		assert.Equal(t, input, result)
+	})
+
 	t.Run("valid escapes are preserved", func(t *testing.T) {
 		// Valid JSON escapes must pass through untouched.
 		input := `{"path": "C:\\Users\\x", "line": "a\nb", "quote": "say \"hi\""}`


### PR DESCRIPTION
## 问题

Agent 在执行零参数工具调用时偶发失败：

```
ERROR [Agent][Round-5][Tool list_sandbox_files] Failed to parse arguments (repair failed): invalid character '"' after top-level value
```

抓取上游 SSE 原始报文后确认，参数是分片发来的：先是 `{}`，随后上游又多发了一个内容为 `""` 的 arguments delta。按 OpenAI 流式规范拼接后得到 `{}""`，`json.Unmarshal` 失败；现有的 `RepairJSON` 只处理截断、尾逗号和非法转义，对「顶层值之后的多余内容」无能为力，于是整个工具调用直接报错，模型被迫改用其他方式绕行。

在本地 1475 份原始流报文中，32 份出现过 `"arguments":"{}"`，其中 21 份紧跟着就冒出这个 `""` 片段；参数非空时一次都没出现过，且跨越两个模型。属于上游 tool-call 流式解析器在零参数场景下的系统性缺陷，客户端需要兜住。

## 改动

`RepairJSON` 新增 `trimAfterTopLevelValue`：扫描时跟踪字符串状态与括号深度，一旦第一个顶层对象/数组闭合、其后仍有非空白内容，就丢弃后续部分。

- `{}""` → `{}`
- `{"a":1}{"a":1}` → `{"a":1}`（重复负载保留首个）
- 字符串内部的 `}` 不会误触发截断
- 顶层值未闭合的截断 JSON 保持原样，交由后续 `balanceBrackets` 恢复，不影响既有修复能力

## 测试

新增四个用例覆盖多余 `""`、完整对象后跟垃圾、重复负载、字符串内含括号；`go test ./internal/agent/tools/` 全部通过。