### PR TITLE
fix(skill): @mention 不再收窄技能白名单

### DIFF
--- a/internal/application/service/session_agent_qa.go
+++ b/internal/application/service/session_agent_qa.go
@@ -436,8 +436,12 @@ func mergeResolvedTagKnowledgeIDs(
 	return uniqueNonEmptyStrings(merged)
 }
 
-// applyPerRequestSkillScope narrows the agent's skill whitelist to the @Skill
-// mentions for this turn and records the pinned set for the <must_use> hint.
+// applyPerRequestSkillScope records the @Skill mentions for this turn as the
+// pinned set that drives the <must_use> hint. It deliberately does NOT narrow
+// the allow-gate: an agent whose prompt requires a skill the user did not
+// @mention must still be able to read and execute it. Mentioning a skill only
+// prioritizes it, it never revokes access to the agent's configured set.
+//
 // It is a no-op when no skills were mentioned or skills are disabled.
 func applyPerRequestSkillScope(
 	ctx context.Context,
@@ -455,18 +459,11 @@ func applyPerRequestSkillScope(
 	if !agentConfig.SkillsEnabled {
 		return
 	}
-	switch skillsMode {
-	case "selected":
-		agentConfig.AllowedSkills = intersectPreservingRequestOrder(requested, agentConfig.AllowedSkills)
-		if len(agentConfig.AllowedSkills) == 0 {
-			agentConfig.SkillsEnabled = false
-		}
-	case "all":
-		agentConfig.AllowedSkills = dedupPreservingOrder(requested)
-	}
-	if agentConfig.SkillsEnabled && len(agentConfig.AllowedSkills) > 0 {
-		agentConfig.PinnedSkillNames = intersectPreservingRequestOrder(requested, agentConfig.AllowedSkills)
-	}
+	// PinnedSkillNames carries only mentioned skills that are currently
+	// allowed, so the <must_use> hint never directs the model at a skill it
+	// cannot load. An empty AllowedSkills means all skills are allowed,
+	// matching Manager.isSkillAllowed, so every mention is pinned in that case.
+	agentConfig.PinnedSkillNames = pinPreservingRequestOrder(requested, agentConfig.AllowedSkills)
 	logger.Infof(ctx, "Applied per-request @skill scope: requested=%v effective=%v pinned=%v",
 		requested, agentConfig.AllowedSkills, agentConfig.PinnedSkillNames)
 }
@@ -546,6 +543,33 @@ func intersectPreservingRequestOrder(requested []string, allowed []string) []str
 	seen := make(map[string]bool, len(requested))
 	for _, value := range requested {
 		if value == "" || seen[value] || !allowedSet[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	return result
+}
+
+// pinPreservingRequestOrder returns the requested skills that are allowed,
+// preserving request order. Unlike intersectPreservingRequestOrder, an empty
+// allowed list is treated as "all skills allowed" (matching
+// Manager.isSkillAllowed), so every requested skill is pinned.
+func pinPreservingRequestOrder(requested []string, allowed []string) []string {
+	allowedAll := len(allowed) == 0
+	allowedSet := make(map[string]bool, len(allowed))
+	for _, value := range allowed {
+		if value != "" {
+			allowedSet[value] = true
+		}
+	}
+	result := make([]string, 0, len(requested))
+	seen := make(map[string]bool, len(requested))
+	for _, value := range requested {
+		if value == "" || seen[value] {
+			continue
+		}
+		if !allowedAll && !allowedSet[value] {
 			continue
 		}
 		seen[value] = true

--- a/internal/application/service/session_agent_qa_scope_test.go
+++ b/internal/application/service/session_agent_qa_scope_test.go
@@ -78,18 +78,33 @@ func TestApplyPerRequestMCPScope_NoneIgnoresMentionAndDoesNotPin(t *testing.T) {
 	assert.Empty(t, cfg.PinnedMCPServiceIDs)
 }
 
-func TestApplyPerRequestSkillScope_SelectedEmptyIntersectionDisables(t *testing.T) {
+func TestApplyPerRequestSkillScope_SelectedPinsMentionedAndKeepsAllowed(t *testing.T) {
+	cfg := &types.AgentConfig{SkillsEnabled: true, AllowedSkills: []string{"a", "b"}}
+	applyPerRequestSkillScope(context.Background(), cfg, "selected", []string{"a"})
+	assert.True(t, cfg.SkillsEnabled)
+	// Allow-gate is not narrowed: a prompt-mandated skill the user did not
+	// @mention (b) must remain callable.
+	assert.Equal(t, []string{"a", "b"}, cfg.AllowedSkills)
+	assert.Equal(t, []string{"a"}, cfg.PinnedSkillNames)
+}
+
+func TestApplyPerRequestSkillScope_SelectedMentionOutsideAllowedIsNotPinned(t *testing.T) {
 	cfg := &types.AgentConfig{SkillsEnabled: true, AllowedSkills: []string{"a", "b"}}
 	applyPerRequestSkillScope(context.Background(), cfg, "selected", []string{"c"})
-	assert.False(t, cfg.SkillsEnabled)
+	// Skills stay enabled (no narrowing-to-empty disable); the out-of-scope
+	// mention is simply not pinned.
+	assert.True(t, cfg.SkillsEnabled)
+	assert.Equal(t, []string{"a", "b"}, cfg.AllowedSkills)
 	assert.Empty(t, cfg.PinnedSkillNames)
 }
 
-func TestApplyPerRequestSkillScope_AllPinsMentioned(t *testing.T) {
+func TestApplyPerRequestSkillScope_AllPinsMentionedWithoutNarrowingGate(t *testing.T) {
 	cfg := &types.AgentConfig{SkillsEnabled: true}
 	applyPerRequestSkillScope(context.Background(), cfg, "all", []string{"analysis", "analysis"})
 	assert.True(t, cfg.SkillsEnabled)
-	assert.Equal(t, []string{"analysis"}, cfg.AllowedSkills)
+	// "all" mode keeps AllowedSkills empty (= all allowed); it does not narrow
+	// to only the mentioned set, so other skills the agent needs stay callable.
+	assert.Empty(t, cfg.AllowedSkills)
 	assert.Equal(t, []string{"analysis"}, cfg.PinnedSkillNames)
 }
 


### PR DESCRIPTION
## Description

`useAgent` 收到 `@skill` / `@mcp` mention 时，`applyPerRequestSkillScope` 与 `applyPerRequestMCPScope` 会把技能白名单收窄到 mention 指向的技能，导致用户已授权的其他技能在当轮被静默禁用。修复后：mention 仅用于**置顶/钉住**目标技能，不再收窄白名单；`mode=none` 时则忽略 mention。

## Type of Change

- [x] 🐛 Bug fix

## Related Issue

Fixes #

## Testing

- `go test ./internal/application/service/ -run 'TestResolvePerRequestMCPScope|TestApplyPerRequestMCPScope|TestApplyPerRequestSkillScope|TestConfigureSkillsFromAgentDoesNotLoadHostPreloadedDir'`
  - 结果：12/12 PASS
- `git diff --check upstream/main...HEAD` 通过（无空白错误）

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A（纯后端逻辑，无 UI 变更）