### PR TITLE
fix(skill): 解析 stringified JSON 数组形式的 args

### DIFF
--- a/internal/agent/tools/skill_execute.go
+++ b/internal/agent/tools/skill_execute.go
@@ -108,9 +108,18 @@ func (i *ExecuteSkillScriptInput) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("args must be a string or an array of strings: %w", err)
 	}
 
-	// A string is interpreted as a conventional space-separated command line.
-	// The tool schema continues to advertise []string, so well-formed calls are
-	// unaffected; this is only a compatibility fallback for model output.
+	// Some providers emit the array as a stringified JSON payload
+	// (e.g. "[\"--project-name\",\"X\"]"). Treat that as an array first so the
+	// model's intent is preserved; strings.Fields would otherwise split the
+	// brackets/quotes into garbage tokens and the script would see nonsense argv.
+	if err := json.Unmarshal([]byte(argsString), &i.Args); err == nil {
+		return nil
+	}
+
+	// A plain string is interpreted as a conventional space-separated command
+	// line. The tool schema continues to advertise []string, so well-formed
+	// calls are unaffected; this is only a compatibility fallback for model
+	// output.
 	i.Args = strings.Fields(argsString)
 	return nil
 }

--- a/internal/agent/tools/skill_execute_test.go
+++ b/internal/agent/tools/skill_execute_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,4 +33,56 @@ func TestExecuteSkillScriptDescriptionAcceptsWorkspacePaths(t *testing.T) {
 	assert.Contains(t, executeSkillScriptTool.Description(), "/workspace/input")
 	assert.Contains(t, executeSkillScriptTool.Description(), "install_deps.py")
 	assert.Contains(t, executeSkillScriptTool.Description(), ".skill-packages")
+}
+
+// TestExecuteSkillScriptInputUnmarshalJSON covers the model-emitted shapes the
+// UnmarshalJSON fallback must tolerate. The provider does not always honor the
+// []string schema: it sometimes emits a stringified JSON array or a single
+// command-line string. Each must round-trip to the intended argv.
+func TestExecuteSkillScriptInputUnmarshalJSON(t *testing.T) {
+	t.Run("real array", func(t *testing.T) {
+		var in ExecuteSkillScriptInput
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"skill_name": "s", "script_path": "p",
+			"args": ["--project-name", "X", "--creator", "admin"]
+		}`), &in))
+		require.Equal(t, []string{"--project-name", "X", "--creator", "admin"}, in.Args)
+	})
+
+	t.Run("stringified json array", func(t *testing.T) {
+		// Some providers emit args as a JSON string whose content is itself a
+		// JSON array. strings.Fields would mangle the brackets/quotes into
+		// one garbage token; the array must be recovered instead.
+		var in ExecuteSkillScriptInput
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"skill_name": "s", "script_path": "p",
+			"args": "[\"--project-name\", \"X\", \"--creator\", \"admin\"]"
+		}`), &in))
+		require.Equal(t, []string{"--project-name", "X", "--creator", "admin"}, in.Args)
+	})
+
+	t.Run("single command line string", func(t *testing.T) {
+		var in ExecuteSkillScriptInput
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"skill_name": "s", "script_path": "p",
+			"args": "ls --workspace /workspace/output"
+		}`), &in))
+		require.Equal(t, []string{"ls", "--workspace", "/workspace/output"}, in.Args)
+	})
+
+	t.Run("absent args", func(t *testing.T) {
+		var in ExecuteSkillScriptInput
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"skill_name": "s", "script_path": "p"
+		}`), &in))
+		require.Empty(t, in.Args)
+	})
+
+	t.Run("null args", func(t *testing.T) {
+		var in ExecuteSkillScriptInput
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"skill_name": "s", "script_path": "p", "args": null
+		}`), &in))
+		require.Empty(t, in.Args)
+	})
 }


### PR DESCRIPTION
## Description

部分模型供应商把 `execute_skill_script` 的 `args`（schema 声明为 `[]string`）emit 成一个 JSON 字符串，内容本身是一个 JSON 数组（如 `"[\"--project-name\",\"X\"]"`）。原 `UnmarshalJSON` 兜底用 `strings.Fields` 拆分这种字符串，会把方括号/引号拆成垃圾 token，脚本 `argv` 全是乱码，`argparse` 永远报参数缺失，模型无论如何调整格式都失败。

修复：先把字符串内容当 JSON 数组解析，成功即用；否则再退回 `strings.Fields`。

> 注：`fix(modelcontext): 失败工具结果保留 Output 诊断信息`（b2d8e735）已被 upstream `f79052fe` 完全覆盖，未纳入本 PR；本分支仅保留 args 解析这一处独立修复。

## Type of Change

- [x] 🐛 Bug fix

## Related Issue

Fixes #

## Testing

- `go test ./internal/agent/tools/ -run 'TestSkillScript|TestExecuteSkillScript'`
  - 结果：3 个上游测试 + `TestExecuteSkillScriptInputUnmarshalJSON`（5 个子测试）全部 PASS
- `git diff --check upstream/main...HEAD` 通过（无空白错误）
- cherry-pick 时与 upstream `f79052fe` 新建的 `skill_execute_test.go` 冲突，已手工合并两版测试（保留双方测试函数）

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A（纯后端逻辑，无 UI 变更）