### PR TITLE
fix(agent): 工具失败走 tool_result 而非 error 事件

### DIFF
--- a/frontend/src/composables/useChatStreamHandler.ts
+++ b/frontend/src/composables/useChatStreamHandler.ts
@@ -731,10 +731,27 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
       }
       case 'tool_result':
       case 'error': {
+        // An error event is now exclusively a flow-interrupting failure (model
+        // stream / pipeline error); tool failures arrive as tool_result with
+        // success=false. Handle fatal errors first, before attempting
+        // pending-tool-call matching (which can never match a flow error and
+        // would only emit a spurious warning).
+        if (responseType === 'error') {
+          const errorMsg = String(data.content || t('chat.processError'))
+          message.content = errorMsg
+          message.is_completed = true
+          isReplying.value = false
+          loading.value = false
+          fullContent.value = ''
+          currentAssistantMessageId.value = ''
+          reportError(errorMsg)
+          console.error('[Chat Error]', errorMsg)
+          break
+        }
         if (dataPayload) {
           const toolCallId = dataPayload.tool_call_id as string | undefined
           const toolName = dataPayload.tool_name as string | undefined
-          const success = responseType !== 'error' && dataPayload.success !== false
+          const success = dataPayload.success !== false
           log('[Tool Result]', {
             tool_call_id: toolCallId,
             tool_name: toolName,
@@ -763,6 +780,8 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
             // Keep stdout/markdown on failure. The error field is often just
             // "exited with code 1" plus a retry hint; the streams live on
             // output / tool_data and are what the terminal card should show.
+            // The error event branch is handled earlier as a fatal error, so
+            // tool_result output is the only path that reaches this line.
             toolCallEvent.output = dataPayload.output || data.content
             toolCallEvent.error = !success ? dataPayload.error || data.content : undefined
             const duration =
@@ -775,27 +794,6 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
           } else {
             console.warn('[Tool Result] No pending tool call found for', toolCallId || toolName)
           }
-          if (responseType === 'error' && !toolName) {
-            const errorMsg = String(data.content || t('chat.processError'))
-            message.content = errorMsg
-            message.is_completed = true
-            isReplying.value = false
-            loading.value = false
-            fullContent.value = ''
-            currentAssistantMessageId.value = ''
-            reportError(errorMsg)
-            console.error('[Chat Error]', errorMsg)
-          }
-        } else if (responseType === 'error') {
-          const errorMsg = String(data.content || t('chat.processError'))
-          message.content = errorMsg
-          message.is_completed = true
-          isReplying.value = false
-          loading.value = false
-          fullContent.value = ''
-          currentAssistantMessageId.value = ''
-          reportError(errorMsg)
-          console.error('[Chat Error]', errorMsg)
         }
         break
       }

--- a/internal/handler/session/agent_stream_handler.go
+++ b/internal/handler/session/agent_stream_handler.go
@@ -241,14 +241,15 @@ func (h *AgentStreamHandler) handleToolResult(ctx context.Context, evt event.Eve
 	}
 	h.mu.Unlock()
 
-	// Send SSE response (both success and failure)
+	// Tool results — success or failure — always use the tool_result event
+	// type; the success flag in metadata distinguishes them. Reserve the
+	// error event type for flow-interrupting failures (model stream /
+	// pipeline errors), so the frontend can treat any error event as fatal
+	// without inspecting tool_name.
 	responseType := types.ResponseTypeToolResult
 	content := agenttools.StreamContentForToolResult(data.ToolName, data.Success, data.Error, data.Data)
-	if !data.Success {
-		responseType = types.ResponseTypeError
-		if content == "" && data.Error != "" {
-			content = data.Error
-		}
+	if !data.Success && content == "" && data.Error != "" {
+		content = data.Error
 	}
 
 	// Build metadata including tool result data for rich frontend rendering


### PR DESCRIPTION
## Description

`AgentStreamHandler.handleToolResult` 在 `!success` 时把 SSE 事件类型从 `tool_result` 改成 `error`，导致工具失败与模型流/pipeline 真错误共用 `error` 通道，前端只能靠 `tool_name` 有无隐式区分。

修复：
1. **后端**（`internal/handler/session/agent_stream_handler.go`）：工具失败始终发 `tool_result`（`success=false` 区分成败），`error` 事件留给流程中断错误。
2. **前端**（`useChatStreamHandler.ts`）：`error` 事件短路到致命处理（不再走无意义的 pending 工具卡匹配）；`success` 判定从 `responseType !== 'error' && ...` 收敛为 `dataPayload.success !== false`（与后端改动配套）。
3. 失败工具卡仍优先显示 `output`（stdout/stderr），该逻辑由 upstream `f79052fe` 已实现，本 PR 沿用其写法以避免重复。

## Type of Change

- [x] 🐛 Bug fix

## Related Issue

Fixes #

## Testing

- 后端：`go test ./internal/handler/session/` 全包 PASS（含 `TestNormalizeTemporaryAttachmentIDs` 等 14 项）
- 前端：`node --test src/composables/useChatStreamHandler.test.mjs` PASS（upstream 的 `failed tool results keep stdout/output` 断言通过）
- `git diff --check upstream/main...HEAD` 通过（无空白错误）
- 合并时发现与 upstream `f79052fe` 在 `useChatStreamHandler.ts` 的 output 行冲突，已收敛为 upstream 写法（三元版会破坏 upstream 测试断言）

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

前端事件类型收敛属行为变更，建议在 chat 中触发一次工具失败肉眼确认：工具卡显示完整 output 而非短 `Error` 标签，且无 spurious warning。