### PR TITLE
fix(agent): serve starter questions and channel lists for shared agents

### DIFF
--- a/internal/application/service/agent_share_read.go
+++ b/internal/application/service/agent_share_read.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/logger"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+// resolveAgentForSharedRead resolves agentID for callerTenantID through an
+// organization share and returns the agent as seen by the source tenant. It
+// exists for read paths (e.g. starter questions, embed channel listing) that
+// must work for tenants an agent has been shared with, while mutating paths
+// keep enforcing ownership.
+//
+// Every miss — no share, dangling share, or agent gone from the source
+// tenant — collapses to ErrAgentNotFound: callers only reach this helper
+// after their own-tenant lookup already missed, so surfacing share-internals
+// as distinct errors would leak existence information without helping the
+// caller. Read paths are best-effort; a transient share-repo failure reads
+// as "not shared with you".
+func resolveAgentForSharedRead(
+	ctx context.Context,
+	shareRepo interfaces.AgentShareRepository,
+	fetchAgent func(ctx context.Context, agentID string, tenantID uint64) (*types.CustomAgent, error),
+	callerTenantID uint64,
+	agentID string,
+) (*types.CustomAgent, error) {
+	if shareRepo == nil || fetchAgent == nil || callerTenantID == 0 || agentID == "" {
+		return nil, ErrAgentNotFound
+	}
+	share, err := shareRepo.GetShareByAgentIDForTenant(ctx, callerTenantID, agentID, callerTenantID)
+	if err != nil {
+		if err != repository.ErrAgentShareNotFound {
+			logger.Warnf(ctx, "[shared-agent-read] share lookup failed for agent %s: %v", agentID, err)
+		}
+		return nil, ErrAgentNotFound
+	}
+	if share == nil || share.SourceTenantID == 0 || share.SourceTenantID == callerTenantID {
+		return nil, ErrAgentNotFound
+	}
+	agent, err := fetchAgent(ctx, agentID, share.SourceTenantID)
+	if err != nil {
+		return nil, ErrAgentNotFound
+	}
+	if agent == nil {
+		return nil, ErrAgentNotFound
+	}
+	agent.EnsureDefaults()
+	return agent, nil
+}

--- a/internal/application/service/custom_agent.go
+++ b/internal/application/service/custom_agent.go
@@ -42,6 +42,9 @@ type customAgentService struct {
 	wikiPageRepo   interfaces.WikiPageRepository
 	tagRepo        interfaces.KnowledgeTagRepository
 	knowledgeRepo  interfaces.KnowledgeRepository
+	// agentShareRepo is optional (nil in unit tests that don't exercise
+	// sharing): it lets read paths resolve organization-shared agents.
+	agentShareRepo interfaces.AgentShareRepository
 }
 
 // NewCustomAgentService creates a new custom agent service
@@ -53,6 +56,7 @@ func NewCustomAgentService(
 	wikiPageRepo interfaces.WikiPageRepository,
 	tagRepo interfaces.KnowledgeTagRepository,
 	knowledgeRepo interfaces.KnowledgeRepository,
+	agentShareRepo interfaces.AgentShareRepository,
 ) interfaces.CustomAgentService {
 	return &customAgentService{
 		repo:           repo,
@@ -62,6 +66,7 @@ func NewCustomAgentService(
 		wikiPageRepo:   wikiPageRepo,
 		tagRepo:        tagRepo,
 		knowledgeRepo:  knowledgeRepo,
+		agentShareRepo: agentShareRepo,
 	}
 }
 
@@ -537,9 +542,38 @@ func (s *customAgentService) getSuggestedQuestions(
 		return nil, ErrInvalidTenantID
 	}
 
-	// Get agent configuration
+	// Get agent configuration. The starter-questions endpoint must also work
+	// for organization-shared agents (issue #2957): when the caller's tenant
+	// has no own copy, fall back to the share and run the KB/tag resolution
+	// below under the source tenant.
 	agent, err := s.GetAgentByID(ctx, agentID)
-	if err != nil {
+	if err != nil && includeCurated {
+		if !errors.Is(err, ErrAgentNotFound) {
+			return nil, err
+		}
+		sharedAgent, shareErr := resolveAgentForSharedRead(
+			ctx, s.agentShareRepo, s.repo.GetAgentByID, tenantID, agentID,
+		)
+		if shareErr != nil {
+			return nil, err // preserve the original own-tenant lookup result
+		}
+		agent = sharedAgent
+		// A shared-agent consumer has no scope over the source tenant, so
+		// caller-supplied KB/knowledge/tag overrides are unsafe to honor:
+		// the owner-tenant switch below would widen them beyond the caller's
+		// own access. Only the agent's configuration selects suggestion
+		// sources — the same visibility chatting with the shared agent
+		// already grants.
+		kbIDs = nil
+		knowledgeIDs = nil
+		tagScopes = nil
+		scopeTagIDs = nil
+		// Run KB/tag/chunk resolution under the source tenant so the agent's
+		// configured knowledge bases resolve; mirrors how the embed widget
+		// queries suggestions for the agent's channels.
+		ctx = context.WithValue(ctx, types.TenantIDContextKey, agent.TenantID)
+		tenantID = agent.TenantID
+	} else if err != nil {
 		return nil, err
 	}
 

--- a/internal/application/service/custom_agent_shared_suggestion_test.go
+++ b/internal/application/service/custom_agent_shared_suggestion_test.go
@@ -1,0 +1,197 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/application/repository"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The suite covers the shared-agent read path for starter questions
+// (issue #2957): tenant 2 owns the agent and shares it with tenant 1;
+// tenant 1 has no own copy of the agent.
+
+// sharedSuggestionAgentRepo mimics the tenant-scoped custom agent
+// repository: GetAgentByID only resolves the agent under its own tenant.
+type sharedSuggestionAgentRepo struct {
+	interfaces.CustomAgentRepository
+	agent          *types.CustomAgent
+	lookupByTenant []uint64
+}
+
+func (r *sharedSuggestionAgentRepo) GetAgentByID(
+	_ context.Context, _ string, tenantID uint64,
+) (*types.CustomAgent, error) {
+	r.lookupByTenant = append(r.lookupByTenant, tenantID)
+	if r.agent != nil && r.agent.TenantID == tenantID {
+		return r.agent, nil
+	}
+	return nil, repository.ErrCustomAgentNotFound
+}
+
+// sharedSuggestionShareRepo returns the share that tenant 1 can access.
+type sharedSuggestionShareRepo struct {
+	interfaces.AgentShareRepository
+	share *types.AgentShare
+}
+
+func (r *sharedSuggestionShareRepo) GetShareByAgentIDForTenant(
+	_ context.Context, tenantID uint64, _ string, excludeTenantID uint64,
+) (*types.AgentShare, error) {
+	if r.share == nil ||
+		r.share.SourceTenantID == tenantID ||
+		r.share.SourceTenantID == excludeTenantID {
+		return nil, repository.ErrAgentShareNotFound
+	}
+	return r.share, nil
+}
+
+// sharedSuggestionChunkRepo records how the suggestion pipeline queries
+// chunks so tests can assert the effective tenant and KB scope.
+type sharedSuggestionChunkRepo struct {
+	interfaces.ChunkRepository
+	faqTenants []uint64
+	faqKBIDs   [][]string
+	docTenants []uint64
+	docKBIDs   [][]string
+}
+
+func (r *sharedSuggestionChunkRepo) ListRecommendedFAQChunks(
+	_ context.Context, tenantID uint64, kbIDs []string, _ []string, _ []string, _ int,
+) ([]*types.Chunk, error) {
+	r.faqTenants = append(r.faqTenants, tenantID)
+	r.faqKBIDs = append(r.faqKBIDs, kbIDs)
+	return nil, nil
+}
+
+func (r *sharedSuggestionChunkRepo) ListRecentDocumentChunksWithQuestions(
+	_ context.Context, tenantID uint64, kbIDs []string, _ []string, _ int,
+) ([]*types.Chunk, error) {
+	r.docTenants = append(r.docTenants, tenantID)
+	r.docKBIDs = append(r.docKBIDs, kbIDs)
+	return nil, nil
+}
+
+// sharedSuggestionKBService resolves KBs without a tenant filter, as the
+// real batch lookup does.
+type sharedSuggestionKBService struct {
+	interfaces.KnowledgeBaseService
+	kbs []*types.KnowledgeBase
+}
+
+func (s *sharedSuggestionKBService) GetKnowledgeBasesByIDsOnly(
+	_ context.Context, ids []string,
+) ([]*types.KnowledgeBase, error) {
+	byID := make(map[string]*types.KnowledgeBase, len(s.kbs))
+	for _, kb := range s.kbs {
+		byID[kb.ID] = kb
+	}
+	out := make([]*types.KnowledgeBase, 0, len(ids))
+	for _, id := range ids {
+		if kb, ok := byID[id]; ok {
+			out = append(out, kb)
+		}
+	}
+	return out, nil
+}
+
+func sharedAgentWithCuratedStarters() *types.CustomAgent {
+	return &types.CustomAgent{
+		ID:       "agent-shared",
+		TenantID: 2,
+		Config: types.CustomAgentConfig{
+			QuestionSuggestions: &types.QuestionSuggestionConfig{
+				Starters: types.StarterSuggestionConfig{
+					Enabled: true,
+					Mode:    types.SuggestionModeCurated,
+					Count:   3,
+					Items:   []string{"s1", "s2", "s3"},
+				},
+			},
+		},
+	}
+}
+
+// TestGetSuggestedQuestions_SharedAgentResolvesThroughShare is the
+// regression test for issue #2957: a tenant an agent was shared with must
+// get starter questions instead of a 404 agent-not-found.
+func TestGetSuggestedQuestions_SharedAgentResolvesThroughShare(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+	agent := sharedAgentWithCuratedStarters()
+	svc := &customAgentService{
+		repo:           &sharedSuggestionAgentRepo{agent: agent},
+		agentShareRepo: &sharedSuggestionShareRepo{share: &types.AgentShare{SourceTenantID: 2}},
+	}
+
+	got, err := svc.GetSuggestedQuestions(ctx, "agent-shared", nil, nil, nil, 0)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, "s1", got[0].Question)
+}
+
+// TestGetSuggestedQuestions_SharedAgentWithoutShareStaysNotFound keeps the
+// original behavior for agents that are not shared with the caller.
+func TestGetSuggestedQuestions_SharedAgentWithoutShareStaysNotFound(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+	svc := &customAgentService{
+		repo:           &sharedSuggestionAgentRepo{agent: sharedAgentWithCuratedStarters()},
+		agentShareRepo: &sharedSuggestionShareRepo{},
+	}
+
+	_, err := svc.GetSuggestedQuestions(ctx, "agent-shared", nil, nil, nil, 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAgentNotFound)
+}
+
+// TestGetSuggestedQuestions_NilShareRepoStaysNotFound pins the nil-safe
+// fallback for unit constructions without a share repository.
+func TestGetSuggestedQuestions_NilShareRepoStaysNotFound(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+	svc := &customAgentService{
+		repo: &sharedSuggestionAgentRepo{agent: sharedAgentWithCuratedStarters()},
+	}
+
+	_, err := svc.GetSuggestedQuestions(ctx, "agent-shared", nil, nil, nil, 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAgentNotFound)
+}
+
+// TestGetSuggestedQuestions_SharedAgentIgnoresCallerKBOverrides ensures a
+// shared-agent consumer cannot widen the suggestion scope: caller-supplied
+// KB targets are dropped and only the agent's own KB configuration is
+// queried, under the source tenant.
+func TestGetSuggestedQuestions_SharedAgentIgnoresCallerKBOverrides(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+	agent := sharedAgentWithCuratedStarters()
+	agent.Config.QuestionSuggestions = nil // force the KB pipeline
+	agent.Config.KBSelectionMode = "selected"
+	agent.Config.KnowledgeBases = []string{"kb-owner"}
+	chunks := &sharedSuggestionChunkRepo{}
+	svc := &customAgentService{
+		repo:           &sharedSuggestionAgentRepo{agent: agent},
+		agentShareRepo: &sharedSuggestionShareRepo{share: &types.AgentShare{SourceTenantID: 2}},
+		chunkRepo:      chunks,
+		kbService: &sharedSuggestionKBService{kbs: []*types.KnowledgeBase{
+			{ID: "kb-owner", TenantID: 2},
+		}},
+	}
+
+	got, err := svc.GetSuggestedQuestions(ctx, "agent-shared", []string{"kb-caller"}, nil, nil, 5)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+	// Every chunk query must run under the source tenant (2) with only the
+	// agent's configured KB — never the caller's kb-caller target.
+	for _, tenantID := range append(append([]uint64{}, chunks.faqTenants...), chunks.docTenants...) {
+		assert.Equal(t, uint64(2), tenantID)
+	}
+	for _, kbIDs := range append(append([][]string{}, chunks.faqKBIDs...), chunks.docKBIDs...) {
+		for _, id := range kbIDs {
+			assert.Equal(t, "kb-owner", id)
+		}
+	}
+	require.NotEmpty(t, chunks.faqTenants, "expected the pipeline to reach the chunk queries")
+}

--- a/internal/application/service/embed_channel.go
+++ b/internal/application/service/embed_channel.go
@@ -30,6 +30,9 @@ type embedChannelService struct {
 	agentService interfaces.CustomAgentService
 	chunkService interfaces.ChunkService
 	redis        *redis.Client
+	// agentShareRepo is optional (nil in unit tests): it lets read paths
+	// resolve organization-shared agents.
+	agentShareRepo interfaces.AgentShareRepository
 }
 
 func NewEmbedChannelService(
@@ -37,12 +40,14 @@ func NewEmbedChannelService(
 	agentService interfaces.CustomAgentService,
 	chunkService interfaces.ChunkService,
 	redisClient *redis.Client,
+	agentShareRepo interfaces.AgentShareRepository,
 ) interfaces.EmbedChannelService {
 	return &embedChannelService{
-		repo:         repo,
-		agentService: agentService,
-		chunkService: chunkService,
-		redis:        redisClient,
+		repo:           repo,
+		agentService:   agentService,
+		chunkService:   chunkService,
+		redis:          redisClient,
+		agentShareRepo: agentShareRepo,
 	}
 }
 
@@ -105,7 +110,18 @@ func (s *embedChannelService) ListByAgent(
 ) ([]*types.EmbedChannel, error) {
 	agentID = strings.TrimSpace(agentID)
 	if _, err := s.ensureAgentOwned(ctx, tenantID, agentID); err != nil {
-		return nil, err
+		// Read paths also serve organization-shared agents (issue #2957):
+		// when the agent is not owned by the caller's tenant, resolve it
+		// through the share and list the source tenant's channels. Publish
+		// tokens are never included in responses, and mutating paths keep
+		// going through ensureAgentOwned, so sharing stays read-only here.
+		sharedAgent, shareErr := resolveAgentForSharedRead(
+			ctx, s.agentShareRepo, s.agentService.GetAgentByIDAndTenant, tenantID, agentID,
+		)
+		if shareErr != nil {
+			return nil, err // preserve the ownership error for the handler
+		}
+		tenantID = sharedAgent.TenantID
 	}
 	return s.repo.ListByAgent(ctx, tenantID, agentID)
 }

--- a/internal/application/service/embed_channel_shared_list_test.go
+++ b/internal/application/service/embed_channel_shared_list_test.go
@@ -1,0 +1,136 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Covers the shared-agent read path of embed channel listing (issue #2957):
+// tenants an agent was shared with may list its channels; publish tokens
+// never appear in responses and mutations stay owner-only.
+
+// sharedEmbedAgentService stubs the agent service: the agent lives in
+// tenant 2, while the caller resolves agents under tenant 1.
+type sharedEmbedAgentService struct {
+	interfaces.CustomAgentService
+	agent *types.CustomAgent
+}
+
+func (s *sharedEmbedAgentService) GetAgentByID(
+	_ context.Context, _ string,
+) (*types.CustomAgent, error) {
+	// The caller's tenant (1) has no own copy of the agent; surface the
+	// same error the real service produces in that case.
+	if s.agent == nil {
+		return nil, ErrAgentNotFound
+	}
+	return s.agent, nil
+}
+
+func (s *sharedEmbedAgentService) GetAgentByIDAndTenant(
+	_ context.Context, _ string, tenantID uint64,
+) (*types.CustomAgent, error) {
+	if s.agent == nil || s.agent.TenantID != tenantID {
+		return nil, ErrAgentNotFound
+	}
+	return s.agent, nil
+}
+
+// sharedEmbedShareRepo yields the tenant-1-visible share for the agent.
+type sharedEmbedShareRepo struct {
+	interfaces.AgentShareRepository
+	share *types.AgentShare
+}
+
+func (r *sharedEmbedShareRepo) GetShareByAgentIDForTenant(
+	_ context.Context, tenantID uint64, _ string, excludeTenantID uint64,
+) (*types.AgentShare, error) {
+	if r.share == nil ||
+		r.share.SourceTenantID == tenantID ||
+		r.share.SourceTenantID == excludeTenantID {
+		return nil, ErrAgentNotFound
+	}
+	return r.share, nil
+}
+
+// sharedEmbedRepo records the tenant the channel listing ran under.
+type sharedEmbedRepo struct {
+	interfaces.EmbedChannelRepository
+	listedTenant uint64
+	listCalls    int
+}
+
+func (r *sharedEmbedRepo) ListByAgent(
+	_ context.Context, tenantID uint64, _ string,
+) ([]*types.EmbedChannel, error) {
+	r.listedTenant = tenantID
+	r.listCalls++
+	return nil, nil
+}
+
+func sharedAgentFixture() *types.CustomAgent {
+	return &types.CustomAgent{ID: "agent-shared", TenantID: 2}
+}
+
+func newSharedListService(
+	t *testing.T,
+	agent *types.CustomAgent,
+	shareRepo interfaces.AgentShareRepository,
+) (*embedChannelService, *sharedEmbedRepo) {
+	t.Helper()
+	repo := &sharedEmbedRepo{}
+	svc := &embedChannelService{
+		repo:           repo,
+		agentService:   &sharedEmbedAgentService{agent: agent},
+		agentShareRepo: shareRepo,
+	}
+	return svc, repo
+}
+
+func TestListByAgent_SharedAgentListsSourceTenantChannels(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+	svc, repo := newSharedListService(t, sharedAgentFixture(),
+		&sharedEmbedShareRepo{share: &types.AgentShare{SourceTenantID: 2}})
+
+	rows, err := svc.ListByAgent(ctx, 1, "agent-shared")
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+	assert.Equal(t, 1, repo.listCalls)
+	assert.Equal(t, uint64(2), repo.listedTenant, "channel listing must run under the source tenant")
+}
+
+func TestListByAgent_OwnedAgentKeepsCallerTenant(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+	agent := sharedAgentFixture()
+	agent.TenantID = 1
+	svc, repo := newSharedListService(t, agent,
+		&sharedEmbedShareRepo{share: &types.AgentShare{SourceTenantID: 2}})
+
+	_, err := svc.ListByAgent(ctx, 1, "agent-shared")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), repo.listedTenant)
+}
+
+func TestListByAgent_UnsharedAgentStaysNotFound(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+	svc, repo := newSharedListService(t, sharedAgentFixture(), &sharedEmbedShareRepo{})
+
+	_, err := svc.ListByAgent(ctx, 1, "agent-shared")
+	require.Error(t, err)
+	assert.Equal(t, 0, repo.listCalls, "no listing may run for agents the caller cannot see")
+}
+
+func TestListByAgent_NilShareRepoStaysNotFound(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+	svc, repo := newSharedListService(t, sharedAgentFixture(), nil)
+
+	_, err := svc.ListByAgent(ctx, 1, "agent-shared")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent not found", "unexpected error: %v", err)
+	assert.Equal(t, 0, repo.listCalls)
+}


### PR DESCRIPTION
## Description

Fixes #2957

When tenant A creates an agent and shares it with tenant B through an organization, tenant B can chat with the shared agent, but two read endpoints return 404 `Agent not found`:

- `GET /api/v1/agents/{id}/suggested-questions`
- `GET /api/v1/agents/{id}/embed-channels`

Code-level confirmation (today's main): both paths resolve the agent through the caller's own tenant only — `getSuggestedQuestions` uses `GetAgentByID` (`internal/application/service/custom_agent.go:546`) and `ListByAgent` enforces `ensureAgentOwned` (`internal/application/service/embed_channel.go:105`), which rejects any agent whose `TenantID` differs from the caller's. The chat path already resolves shared agents through the organization share (`GetSharedAgentForTenant`, used by `internal/handler/session/qa.go:538`), which is why chatting works while these endpoints 404.

This PR adds a shared-read fallback to both paths via a new `resolveAgentForSharedRead` helper (`internal/application/service/agent_share_read.go`), which maps the caller's tenant to the source tenant through `AgentShareRepository.GetShareByAgentIDForTenant`.

### Change

- New package-level helper `resolveAgentForSharedRead`: resolves an agent for a caller tenant through the organization share; every miss (no share, dangling share, agent gone from source tenant) collapses to `ErrAgentNotFound` so read paths never leak share internals.
- `getSuggestedQuestions` (starter-questions endpoint, `includeCurated=true` only): on own-tenant miss, resolves the agent through the share and runs the KB/tag/chunk resolution under the **source tenant** so the agent's configured knowledge bases resolve — mirroring how the embed widget already queries suggestions. Caller-supplied KB/knowledge/tag overrides are **ignored** in that mode: the tenant switch would otherwise widen those targets beyond the caller's own access. `GetKnowledgeSuggestedQuestions` (chat-time suggestions) keeps its current own-tenant semantics unchanged.
- `embedChannelService.ListByAgent`: on ownership miss, resolves through the share and lists the source tenant's channels. Listing stays read-only (mutations still go through `ensureAgentOwned`) and publish tokens remain unserialized (`json:"-"`).
- Both services accept an optional `AgentShareRepository` (wired automatically by the existing dig providers; nil-safe for existing unit constructions).

### Scope note

Chat-time knowledge suggestions for shared agents (`GetKnowledgeSuggestedQuestions` used by `message_suggestion.go`) currently degrade to "no suggestions" for shared agents. Aligning that path involves chat @mention target semantics, so it is intentionally left unchanged here and can follow as a separate change.

### Type of Change

- [x] 🐛 Bug fix

### Related Issue

- Fixes #2957

### Testing

- New tests (`internal/application/service`):
  - `TestGetSuggestedQuestions_SharedAgentResolvesThroughShare` — shared agent resolves instead of 404
  - `TestGetSuggestedQuestions_SharedAgentWithoutShareStaysNotFound` / `TestGetSuggestedQuestions_NilShareRepoStaysNotFound` — failure paths keep the original not-found behavior
  - `TestGetSuggestedQuestions_SharedAgentIgnoresCallerKBOverrides` — chunk queries run only under the source tenant and only against the agent's configured KBs (caller overrides dropped)
  - `TestListByAgent_SharedAgentListsSourceTenantChannels`, `TestListByAgent_OwnedAgentKeepsCallerTenant`, `TestListByAgent_UnsharedAgentStaysNotFound`, `TestListByAgent_NilShareRepoStaysNotFound` — listing tenant selection and failure paths
- `go test ./internal/application/service/ -run 'TestGetSuggestedQuestions|TestListByAgent' -count=1` — pass
- `go test ./internal/application/service/ -count=1` — one failure: `TestSkillPythonVerifier`; verified failing identically on a clean `origin/main` baseline (environment-dependent: it exercises an external python verifier), unrelated to this change. Everything else passes.
- `go vet ./internal/application/service/` — clean
- `gofmt -l` no output; `git diff --check` clean

### Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Breaking changes: none
