### PR TITLE
fix(docreader): warm the OpenDataLoader JVM at service startup

### DIFF
--- a/docreader/config.py
+++ b/docreader/config.py
@@ -61,6 +61,7 @@ class DocReaderConfig:
     odl_hybrid_mode: str
     odl_hybrid_fallback: bool
     odl_markdown_with_html: bool
+    odl_warmup: bool
     pdf_render_max_workers: int
     pdf_render_parallelism: int
     pdf_render_dpi: int
@@ -98,6 +99,7 @@ def load_config() -> DocReaderConfig:
     odl_markdown_with_html = _get_bool(
         ["DOCREADER_ODL_MARKDOWN_WITH_HTML"], False
     )
+    odl_warmup = _get_bool(["DOCREADER_ODL_WARMUP"], True)
     pdf_render_max_workers = _get_int(["DOCREADER_PDF_RENDER_MAX_WORKERS"], 1)
     # Intra-document render parallelism: how many worker processes render the
     # scanned pages of a SINGLE PDF in parallel. pdfium is not thread-safe, so
@@ -140,6 +142,7 @@ def load_config() -> DocReaderConfig:
         odl_hybrid_mode=odl_hybrid_mode,
         odl_hybrid_fallback=odl_hybrid_fallback,
         odl_markdown_with_html=odl_markdown_with_html,
+        odl_warmup=odl_warmup,
         pdf_render_max_workers=pdf_render_max_workers,
         pdf_render_parallelism=pdf_render_parallelism,
         pdf_render_dpi=pdf_render_dpi,

--- a/docreader/main.py
+++ b/docreader/main.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import sys
+import threading
 import traceback
 import uuid
 from concurrent import futures
@@ -288,6 +289,37 @@ class DocReaderServicer(docreader_pb2_grpc.DocReaderServicer):
         return ListEnginesResponse(engines=engines)
 
 
+def _start_opendataloader_warmup() -> None:
+    """Kick off a best-effort OpenDataLoader engine warmup in the background.
+
+    The first ``opendataloader_pdf.convert()`` in this process initializes
+    the JVM and loads the parsing libraries, which can take 20s+ on a cold
+    container and used to time out the first knowledge-base import (issue
+    #1802). Running one tiny conversion right after the server is up moves
+    that cost off the first request. Set ``DOCREADER_ODL_WARMUP=false`` to
+    opt out; warmup failures only log and never affect serving.
+    """
+    if not CONFIG.odl_warmup:
+        logger.info("OpenDataLoader engine warmup disabled (DOCREADER_ODL_WARMUP)")
+        return
+
+    def _run() -> None:
+        try:
+            from docreader.parser.opendataloader_parser import warmup_engine
+
+            ok, msg = warmup_engine()
+        except Exception as e:  # noqa: BLE001 - warmup is best-effort
+            logger.warning("OpenDataLoader engine warmup crashed: %s: %s",
+                           type(e).__name__, e)
+            return
+        if ok:
+            logger.info("OpenDataLoader engine warmed up (%s)", msg)
+        else:
+            logger.warning("OpenDataLoader engine warmup skipped: %s", msg)
+
+    threading.Thread(target=_run, name="opendataloader-warmup", daemon=True).start()
+
+
 def main():
     config.print_config()
 
@@ -326,6 +358,8 @@ def main():
 
     logger.info("Server started on port %d", CONFIG.grpc_port)
     logger.info("Server is ready to accept connections")
+
+    _start_opendataloader_warmup()
 
     try:
         server.wait_for_termination()

--- a/docreader/parser/opendataloader_parser.py
+++ b/docreader/parser/opendataloader_parser.py
@@ -306,6 +306,68 @@ def _run_convert(
     opendataloader_pdf.convert(**kwargs)
 
 
+def _minimal_warmup_pdf() -> bytes:
+    """Build a tiny but valid one-page PDF to feed the warmup convert.
+
+    Xref offsets are computed so the file is spec-valid; a blank page is
+    enough because the only goal is to trigger JVM + library initialization.
+    """
+    objects = [
+        b"<</Type/Catalog/Pages 2 0 R>>",
+        b"<</Type/Pages/Kids[3 0 R]/Count 1>>",
+        b"<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]>>",
+    ]
+    out = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for i, body in enumerate(objects, start=1):
+        offsets.append(len(out))
+        out += f"{i} 0 obj".encode("ascii") + body + b"endobj\n"
+    xref_pos = len(out)
+    out += f"xref\n0 {len(objects) + 1}\n".encode("ascii")
+    out += b"0000000000 65535 f \n"
+    for off in offsets:
+        out += f"{off:010d} 00000 n \n".encode("ascii")
+    out += (
+        f"trailer<</Size {len(objects) + 1}/Root 1 0 R>>\n"
+        f"startxref\n{xref_pos}\n%%EOF"
+    ).encode("ascii")
+    return bytes(out)
+
+
+def warmup_engine(
+    overrides: Optional[Mapping[str, Any]] = None,
+) -> Tuple[bool, str]:
+    """Warm the OpenDataLoader engine right after the service starts.
+
+    The first ``convert()`` in this process pays JVM startup plus library
+    initialization (20s+ on a cold container), which used to time out the
+    first knowledge-base import. Running one tiny conversion at boot moves
+    that cost off the request path. Best-effort by design: every failure is
+    reported as ``(False, reason)`` and must never affect serving.
+    """
+    import time
+
+    ok, msg = opendataloader_available(overrides, quick=True)
+    if not ok:
+        return False, msg
+
+    started = time.monotonic()
+    try:
+        max_workers = CONFIG.odl_max_workers
+        with parser_worker_limit("opendataloader", max_workers):
+            with tempfile.TemporaryDirectory(prefix="weknora-odl-warmup-") as tmp_dir:
+                pdf_path = os.path.join(tmp_dir, "warmup.pdf")
+                with open(pdf_path, "wb") as f:
+                    f.write(_minimal_warmup_pdf())
+                image_dir = os.path.join(tmp_dir, "images")
+                os.makedirs(image_dir, exist_ok=True)
+                _run_convert(pdf_path, tmp_dir, image_dir, overrides=overrides)
+    except Exception as e:  # noqa: BLE001 - warmup must never propagate
+        return False, f"{type(e).__name__}: {e}"
+    elapsed = time.monotonic() - started
+    return True, f"convert finished in {elapsed:.1f}s"
+
+
 class OpenDataLoaderParser(BaseParser):
     """Parse PDFs with OpenDataLoader (layout-aware markdown + external images)."""
 

--- a/docreader/tests/test_opendataloader_parser.py
+++ b/docreader/tests/test_opendataloader_parser.py
@@ -10,11 +10,13 @@ from docreader.parser.opendataloader_parser import (
     OpenDataLoaderParser,
     _collect_images_under_output,
     _find_markdown_file,
+    _minimal_warmup_pdf,
     _normalize_odl_image_url,
     _ping_hybrid,
     _run_convert,
     _rewrite_markdown_image_refs,
     opendataloader_available,
+    warmup_engine,
 )
 
 
@@ -127,6 +129,77 @@ class OpenDataLoaderParserTest(unittest.TestCase):
             ok, msg = opendataloader_available()
         self.assertFalse(ok)
         self.assertIn("Java", msg)
+
+
+class OpenDataLoaderWarmupTest(unittest.TestCase):
+    def test_minimal_warmup_pdf_is_spec_shaped(self):
+        pdf = _minimal_warmup_pdf()
+        self.assertTrue(pdf.startswith(b"%PDF-1.4\n"))
+        self.assertTrue(pdf.rstrip().endswith(b"%%EOF"))
+        self.assertIn(b"xref", pdf)
+        self.assertIn(b"startxref", pdf)
+        self.assertIn(b"/Root 1 0 R", pdf)
+
+    def test_minimal_warmup_pdf_parses_with_pypdf(self):
+        from io import BytesIO
+
+        from pypdf import PdfReader
+
+        reader = PdfReader(BytesIO(_minimal_warmup_pdf()))
+        self.assertEqual(1, len(reader.pages))
+
+    @mock.patch(
+        "docreader.parser.opendataloader_parser.opendataloader_available",
+        return_value=(False, "需要 Java 11+"),
+    )
+    def test_warmup_skips_when_engine_unavailable(self, mock_avail):
+        with mock.patch(
+            "docreader.parser.opendataloader_parser._run_convert"
+        ) as mock_convert:
+            ok, msg = warmup_engine()
+
+        self.assertFalse(ok)
+        self.assertIn("Java", msg)
+        mock_convert.assert_not_called()
+
+    @mock.patch(
+        "docreader.parser.opendataloader_parser.opendataloader_available",
+        return_value=(True, ""),
+    )
+    @mock.patch("docreader.parser.opendataloader_parser._run_convert")
+    def test_warmup_runs_tiny_convert_and_reports_elapsed(
+        self, mock_convert, _mock_avail
+    ):
+        seen = {}
+
+        def fake_convert(pdf_path, output_dir, image_dir, overrides=None):
+            with open(pdf_path, "rb") as f:
+                seen["pdf"] = f.read()
+
+        mock_convert.side_effect = fake_convert
+
+        ok, msg = warmup_engine()
+
+        self.assertTrue(ok)
+        self.assertIn("convert finished", msg)
+        self.assertEqual(1, mock_convert.call_count)
+        self.assertTrue(mock_convert.call_args[0][0].endswith("warmup.pdf"))
+        self.assertTrue(seen["pdf"].startswith(b"%PDF-1.4"))
+
+    @mock.patch(
+        "docreader.parser.opendataloader_parser.opendataloader_available",
+        return_value=(True, ""),
+    )
+    @mock.patch(
+        "docreader.parser.opendataloader_parser._run_convert",
+        side_effect=RuntimeError("JVM exploded"),
+    )
+    def test_warmup_swallows_convert_failures(self, _mock_convert, _mock_avail):
+        ok, msg = warmup_engine()
+
+        self.assertFalse(ok)
+        self.assertIn("RuntimeError", msg)
+        self.assertIn("JVM exploded", msg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fixes #1802

The docreader `opendataloader` PDF parser pays full JVM startup plus library initialization on the first `opendataloader_pdf.convert()` of each process — 25-30s on a cold container (`docreader/parser/opendataloader_parser.py:276`, `import opendataloader_pdf` happens inside `_run_convert`, and the JVM is initialized on first use). The first knowledge-base import after startup therefore exceeds the parse timeout and fails; users must retry.

This PR moves that one-time cost off the request path: right after the gRPC server starts listening, docreader runs one tiny spec-valid PDF through the normal convert path in a daemon thread. By the time the first real document arrives, the JVM and libraries are already initialized.

### Change

- New `warmup_engine()` in `docreader/parser/opendataloader_parser.py`: best-effort engine warmup that goes through the same `opendataloader_available(quick=True)` probe, `parser_worker_limit("opendataloader", ...)` slot, and `_run_convert()` path as a real parse, using an in-memory generated one-page PDF (`_minimal_warmup_pdf()`, xref offsets computed so the file is spec-valid). Every failure is returned as `(False, reason)` — warmup never raises into serving.
- `docreader/main.py`: `_start_opendataloader_warmup()` spawns the warmup as a daemon thread after `server.start()`, so startup is never blocked; failures only log.
- New `DOCREADER_ODL_WARMUP` config (default `true`), so deployments that don't want the boot-time conversion can set `DOCREADER_ODL_WARMUP=false`.

### Type of Change

- [x] 🐛 Bug fix

### Related Issue

- Fixes #1802

### Testing

- New tests in `docreader/tests/test_opendataloader_parser.py`:
  - `test_minimal_warmup_pdf_is_spec_shaped` / `test_minimal_warmup_pdf_parses_with_pypdf` — the warmup PDF is a real one-page PDF (parsed with pypdf)
  - `test_warmup_skips_when_engine_unavailable` — no convert call when java/package missing
  - `test_warmup_runs_tiny_convert_and_reports_elapsed` — exactly one convert against `warmup.pdf`, elapsed reported
  - `test_warmup_swallows_convert_failures` — convert exceptions surface as `(False, reason)`
- `pytest tests/test_opendataloader_parser.py` — 14 passed (9 pre-existing + 5 new)
- `pytest tests/` (full docreader suite) — 170 passed / 13 skipped / 14 failed; the same 14 failures (`test_excel_parser.py`, `test_mhtml_parser.py`) occur identically on a clean `origin/main` baseline (165 passed there) — pre-existing and unrelated to this change; this branch adds the 5 passing warmup tests on top.
- Graceful degradation verified live on a host without Java: `warmup_engine()` returns `(False, "需要 Java 11+（JRE）...")` in <0.1s instead of raising; the JVM-positive path runs in the standard docreader image where `openjdk-17-jre-headless` and `opendataloader-pdf` are installed.
- No Go code touched.

### Checklist

- [x] Changed source files are formatted
- [x] Targeted tests for the changed components pass
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Breaking changes: none (new config defaults to enabled; set `DOCREADER_ODL_WARMUP=false` to opt out)
