### PR TITLE
fix(knowledge): show basic fields first in editor

### DIFF
--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.test.ts
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readFileSync } from 'node:fs'
+
+const source = readFileSync(new URL('./KnowledgeBaseEditorModal.vue', import.meta.url), 'utf8')
+
+test('新建知识库先展示名称和描述，再展示类型与索引设置', () => {
+  const basicStart = source.indexOf("currentSection === 'basic'")
+  const modelsStart = source.indexOf("currentSection === 'models'", basicStart)
+  assert.ok(basicStart >= 0 && modelsStart > basicStart, '找不到知识库基本信息区')
+
+  const basicSection = source.slice(basicStart, modelsStart)
+  const name = basicSection.indexOf('v-model="formData.name"')
+  const description = basicSection.indexOf('v-model="formData.description"')
+  const type = basicSection.indexOf('v-model="formData.type"')
+  const indexing = basicSection.indexOf('data-guide="kb-create-indexing"')
+
+  assert.ok(name >= 0, '基本信息区应包含知识库名称')
+  assert.ok(description > name, '知识库描述应紧随名称展示')
+  assert.ok(type > description, '知识库类型应在名称和描述之后展示')
+  assert.ok(indexing > type, '索引设置应在知识库类型之后展示')
+})

--- a/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseEditorModal.vue
@@ -59,6 +59,24 @@
                         </div>
                       </div>
 
+                      <div class="form-item" data-guide="kb-create-name">
+                        <label class="form-label required">{{ $t('knowledgeEditor.basic.nameLabel') }}</label>
+                        <t-input
+                          v-model="formData.name"
+                          :placeholder="$t('knowledgeEditor.basic.namePlaceholder')"
+                          :maxlength="50"
+                        />
+                      </div>
+                      <div class="form-item">
+                        <label class="form-label">{{ $t('knowledgeEditor.basic.descriptionLabel') }}</label>
+                        <t-textarea
+                          v-model="formData.description"
+                          :placeholder="$t('knowledgeEditor.basic.descriptionPlaceholder')"
+                          :maxlength="200"
+                          :autosize="{ minRows: 3, maxRows: 6 }"
+                        />
+                      </div>
+
                       <div class="form-item">
                         <label class="form-label required">{{ $t('knowledgeEditor.basic.typeLabel') }}</label>
                         <t-radio-group
@@ -154,24 +172,6 @@
                           :placeholder="$t('knowledgeEditor.wiki.extractionInstructionsPlaceholder')"
                           :maxlength="4000"
                           :autosize="{ minRows: 3, maxRows: 8 }"
-                        />
-                      </div>
-
-                      <div class="form-item" data-guide="kb-create-name">
-                        <label class="form-label required">{{ $t('knowledgeEditor.basic.nameLabel') }}</label>
-                        <t-input 
-                          v-model="formData.name" 
-                          :placeholder="$t('knowledgeEditor.basic.namePlaceholder')"
-                          :maxlength="50"
-                        />
-                      </div>
-                      <div class="form-item">
-                        <label class="form-label">{{ $t('knowledgeEditor.basic.descriptionLabel') }}</label>
-                        <t-textarea
-                          v-model="formData.description"
-                          :placeholder="$t('knowledgeEditor.basic.descriptionPlaceholder')"
-                          :maxlength="200"
-                          :autosize="{ minRows: 3, maxRows: 6 }"
                         />
                       </div>
 


### PR DESCRIPTION
## Description

Move the knowledge base name and description fields to the top of the Basic Information section. Wiki knowledge base creation now shows these required identity fields on the first screen, before type and indexing options.

A focused regression test locks the intended field order.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2959

## Testing

- `tsx --test src/views/knowledge/KnowledgeBaseEditorModal.test.ts`
- `npm run type-check`
- `npm run check-i18n` (11/11 checks passed)
- `npm run build`

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (not applicable; no documented behavior changed)
- [x] Breaking changes are clearly called out above (none)

## Screenshots / Recordings

The implementation matches the expected first-page layout proposed in #2959:

![Expected knowledge base editor layout](https://github.com/user-attachments/assets/75dc22ce-a561-4c15-b00d-95e26d2690ab)
