### PR TITLE
feat(knowledge): show batch upload progress

### DIFF
--- a/frontend/src/components/UploadConfirmHost.vue
+++ b/frontend/src/components/UploadConfirmHost.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import UploadConfirmDialog from '@/views/knowledge/components/UploadConfirmDialog.vue'
+import UploadProgressDialog from '@/views/knowledge/components/UploadProgressDialog.vue'
 import { useUploadConfirmStore } from '@/stores/uploadConfirm'
 
 const uploadConfirmStore = useUploadConfirmStore()
@@ -30,4 +31,5 @@ const handleCancel = () => {
     @confirm="handleConfirm"
     @cancel="handleCancel"
   />
+  <UploadProgressDialog />
 </template>

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -706,7 +706,22 @@ export default {
     confirmReparse: 'Confirm and reparse',
     reparseSource: 'Document to reparse',
     reparseHint: 'Reuses the last parse settings; adjust them here',
-    manualCharCount: '{count} characters'
+    manualCharCount: '{count} characters',
+    progress: {
+      title: 'Uploading files',
+      completed: 'Upload complete',
+      completedWithErrors: 'Upload completed with errors',
+      runningSummary: '{completed} of {total} files completed',
+      completedSummary: '{success} succeeded, {failed} failed',
+      overall: 'Overall progress',
+      pending: 'Waiting',
+      uploading: 'Uploading {progress}%',
+      success: 'Uploaded',
+      failed: 'Failed',
+      keepOpen: 'Keep this window open until the upload finishes.',
+      done: 'Done',
+      unknownFile: 'Unknown file'
+    }
   },
   knowledgeStages: {
     title: 'Processing pipeline',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -6012,6 +6012,21 @@ export default {
     reparseSource: '재파싱할 문서',
     reparseHint: '이전 파싱 설정을 사용하며 여기서 조정할 수 있습니다',
     manualCharCount: '{count}자',
+    progress: {
+      title: '파일 업로드 중',
+      completed: '업로드 완료',
+      completedWithErrors: '일부 파일 업로드 실패',
+      runningSummary: '{total}개 중 {completed}개 완료',
+      completedSummary: '성공 {success}개, 실패 {failed}개',
+      overall: '전체 진행률',
+      pending: '대기 중',
+      uploading: '업로드 중 {progress}%',
+      success: '업로드됨',
+      failed: '실패',
+      keepOpen: '업로드가 완료될 때까지 이 창을 열어 두세요.',
+      done: '완료',
+      unknownFile: '알 수 없는 파일'
+    },
     pdfForceScanned: {
       label: '스캔 PDF로 파싱',
       description: '웹 인쇄, 스캔본, 이미지 위주 PDF에 적합합니다. 모든 페이지를 이미지로 렌더링한 뒤 OCR/VLM으로 처리합니다. 처리 시간과 모델 호출 비용이 늘어날 수 있습니다.'

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -6012,6 +6012,21 @@ export default {
     reparseSource: 'Документ для повторной обработки',
     reparseHint: 'Используются настройки прошлой обработки; их можно изменить здесь',
     manualCharCount: '{count} символов',
+    progress: {
+      title: 'Загрузка файлов',
+      completed: 'Загрузка завершена',
+      completedWithErrors: 'Загрузка завершена с ошибками',
+      runningSummary: 'Завершено: {completed} из {total}',
+      completedSummary: 'Успешно: {success}, с ошибкой: {failed}',
+      overall: 'Общий прогресс',
+      pending: 'В очереди',
+      uploading: 'Загружается: {progress}%',
+      success: 'Загружен',
+      failed: 'Ошибка',
+      keepOpen: 'Не закрывайте это окно до завершения загрузки.',
+      done: 'Готово',
+      unknownFile: 'Неизвестный файл'
+    },
     pdfForceScanned: {
       label: 'Разбор PDF как сканированного документа',
       description: 'Подходит для PDF с веб-печати, сканов и документов с большим числом изображений. Каждая страница будет отрендерена в изображение и обработана через OCR/VLM. Может увеличить время обработки и расходы на модели.'

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -6014,6 +6014,21 @@ export default {
     reparseSource: '待重新解析文档',
     reparseHint: '将沿用上次解析的配置，可在此调整',
     manualCharCount: '{count} 个字符',
+    progress: {
+      title: '正在上传文件',
+      completed: '上传完成',
+      completedWithErrors: '上传完成，部分文件失败',
+      runningSummary: '已完成 {completed}/{total} 个文件',
+      completedSummary: '成功 {success} 个，失败 {failed} 个',
+      overall: '总进度',
+      pending: '等待上传',
+      uploading: '上传中 {progress}%',
+      success: '上传成功',
+      failed: '上传失败',
+      keepOpen: '请保持此窗口打开，直到上传完成。',
+      done: '完成',
+      unknownFile: '未知文件'
+    },
     pdfForceScanned: {
       label: '按扫描件解析 PDF',
       description: '适用于网页打印、扫描件、图片型 PDF。开启后会逐页 OCR，解析更完整但耗时和模型调用更多。'

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -1607,6 +1607,61 @@ const AUDIO_EXTENSIONS = ['mp3', 'wav', 'm4a', 'flac', 'ogg'];
 
 const uploadConfirmStore = useUploadConfirmStore();
 
+type KnowledgeUploadEventName =
+  | 'knowledgeFileUploadStart'
+  | 'knowledgeFileUploadProgress'
+  | 'knowledgeFileUploadComplete';
+
+type KnowledgeUploadStatus = 'pending' | 'uploading' | 'success' | 'error';
+
+interface KnowledgeUploadEventDetail {
+  uploadId: string;
+  kbId: string;
+  fileName: string;
+  fileSize: number;
+  progress: number;
+  status: KnowledgeUploadStatus;
+  error?: string;
+}
+
+let uploadBatchSequence = 0;
+
+const dispatchKnowledgeUploadEvent = (
+  name: KnowledgeUploadEventName,
+  detail: KnowledgeUploadEventDetail,
+) => {
+  window.dispatchEvent(new CustomEvent(name, { detail }));
+};
+
+const getUploadProgressPercentage = (progressEvent: {
+  loaded?: number;
+  total?: number;
+  progress?: number;
+}) => {
+  let ratio: number | undefined;
+  if (typeof progressEvent.progress === 'number') {
+    ratio = progressEvent.progress;
+  } else if (
+    typeof progressEvent.loaded === 'number'
+    && typeof progressEvent.total === 'number'
+    && progressEvent.total > 0
+  ) {
+    ratio = progressEvent.loaded / progressEvent.total;
+  }
+  if (ratio === undefined || !Number.isFinite(ratio)) return null;
+  const percentage = ratio <= 1 ? ratio * 100 : ratio;
+  return Math.min(100, Math.max(0, Math.round(percentage)));
+};
+
+const getUploadErrorMessage = (error: any) => {
+  const payload = error?.response?.data || error;
+  const code = payload?.code || payload?.error?.code;
+  if (code === 'duplicate_file') {
+    return t('knowledgeBase.fileExists');
+  }
+  return payload?.error?.message || payload?.message || t('knowledgeBase.uploadFailed');
+};
+
 const getFolderUploadFileName = (file: File, targetFolder: string) =>
   buildUploadFileName(file, targetFolder);
 
@@ -1665,7 +1720,32 @@ const executeUploadBatch = async (
   const totalCount = files.length;
   const hasFolderPaths = files.some(isFolderUpload);
 
-  for (const file of files) {
+  uploadBatchSequence += 1;
+  const uploadBatchId = `${targetKbId}-${Date.now()}-${uploadBatchSequence}`;
+  const uploadTasks = files.map((file, index) => ({
+    uploadId: `${uploadBatchId}-${index}`,
+    fileName: (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name,
+    fileSize: file.size,
+  }));
+
+  uploadTasks.forEach(task => {
+    dispatchKnowledgeUploadEvent('knowledgeFileUploadStart', {
+      ...task,
+      kbId: targetKbId,
+      progress: 0,
+      status: 'pending',
+    });
+  });
+
+  for (const [index, file] of files.entries()) {
+    const uploadTask = uploadTasks[index];
+    let lastProgress = 0;
+    dispatchKnowledgeUploadEvent('knowledgeFileUploadStart', {
+      ...uploadTask,
+      kbId: targetKbId,
+      progress: 0,
+      status: 'uploading',
+    });
     try {
       const uploadData: {
         file: File
@@ -1680,32 +1760,51 @@ const executeUploadBatch = async (
         uploadData.process_config = options.processConfig;
       }
 
-      const responseData: any = await uploadKnowledgeFile(targetKbId, uploadData);
+      const responseData: any = await uploadKnowledgeFile(targetKbId, uploadData, progressEvent => {
+        const progress = getUploadProgressPercentage(progressEvent);
+        if (progress === null || progress === lastProgress) return;
+        lastProgress = progress;
+        dispatchKnowledgeUploadEvent('knowledgeFileUploadProgress', {
+          ...uploadTask,
+          kbId: targetKbId,
+          progress,
+          status: 'uploading',
+        });
+      });
       const isSuccess = responseData?.success || responseData?.code === 200 || responseData?.status === 'success' || (!responseData?.error && responseData);
       if (isSuccess) {
         successCount++;
+        dispatchKnowledgeUploadEvent('knowledgeFileUploadComplete', {
+          ...uploadTask,
+          kbId: targetKbId,
+          progress: 100,
+          status: 'success',
+        });
       } else {
         failCount++;
+        const errorMessage = getUploadErrorMessage(responseData);
+        dispatchKnowledgeUploadEvent('knowledgeFileUploadComplete', {
+          ...uploadTask,
+          kbId: targetKbId,
+          progress: 100,
+          status: 'error',
+          error: errorMessage,
+        });
         if (totalCount === 1) {
-          let errorMessage = t('knowledgeBase.uploadFailed');
-          if (responseData?.error?.message) {
-            errorMessage = responseData.error.message;
-          } else if (responseData?.message) {
-            errorMessage = responseData.message;
-          }
-          if (responseData?.code === 'duplicate_file' || responseData?.error?.code === 'duplicate_file') {
-            errorMessage = t('knowledgeBase.fileExists');
-          }
           MessagePlugin.error(errorMessage);
         }
       }
     } catch (error: any) {
       failCount++;
+      const errorMessage = getUploadErrorMessage(error);
+      dispatchKnowledgeUploadEvent('knowledgeFileUploadComplete', {
+        ...uploadTask,
+        kbId: targetKbId,
+        progress: 100,
+        status: 'error',
+        error: errorMessage,
+      });
       if (totalCount === 1) {
-        let errorMessage = error?.error?.message || error?.message || t('knowledgeBase.uploadFailed');
-        if (error?.code === 'duplicate_file') {
-          errorMessage = t('knowledgeBase.fileExists');
-        }
         MessagePlugin.error(errorMessage);
       }
     }

--- a/frontend/src/views/knowledge/components/UploadConfirmDialog.test.ts
+++ b/frontend/src/views/knowledge/components/UploadConfirmDialog.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 import { readFileSync } from 'node:fs'
 
 const dialog = readFileSync(new URL('./UploadConfirmDialog.vue', import.meta.url), 'utf8')
+const progressDialog = readFileSync(new URL('./UploadProgressDialog.vue', import.meta.url), 'utf8')
 const host = readFileSync(new URL('../../../components/UploadConfirmHost.vue', import.meta.url), 'utf8')
 const knowledgeBase = readFileSync(new URL('../KnowledgeBase.vue', import.meta.url), 'utf8')
 const platform = readFileSync(new URL('../../platform/index.vue', import.meta.url), 'utf8')
@@ -77,4 +78,22 @@ test('uses section navigation with inline chunking controls and advanced options
   assert.match(dialog, /statusFull/)
   assert.match(dialog, /data-section="multimodal"/)
   assert.doesNotMatch(dialog, /<KBChunkingSettings/)
+})
+
+test('shows byte progress for every file in a confirmed upload batch', () => {
+  assert.match(host, /UploadProgressDialog/)
+  assert.match(progressDialog, /<t-progress/)
+  assert.match(progressDialog, /knowledgeFileUploadStart/)
+  assert.match(progressDialog, /knowledgeFileUploadProgress/)
+  assert.match(progressDialog, /knowledgeFileUploadComplete/)
+  assert.match(progressDialog, /v-for="task in tasks"/)
+  assert.match(progressDialog, /v-if="!isActive"/)
+
+  const queuedBeforeUpload = knowledgeBase.indexOf('uploadTasks.forEach')
+  const uploadLoop = knowledgeBase.indexOf('for (const [index, file] of files.entries())')
+  assert.ok(queuedBeforeUpload >= 0 && uploadLoop > queuedBeforeUpload, 'the modal should list the full batch before upload starts')
+  assert.match(knowledgeBase, /uploadKnowledgeFile\(targetKbId, uploadData, progressEvent =>/)
+  assert.match(knowledgeBase, /getUploadProgressPercentage\(progressEvent\)/)
+  assert.match(knowledgeBase, /dispatchKnowledgeUploadEvent\('knowledgeFileUploadProgress'/)
+  assert.match(knowledgeBase, /dispatchKnowledgeUploadEvent\('knowledgeFileUploadComplete'/)
 })

--- a/frontend/src/views/knowledge/components/UploadProgressDialog.vue
+++ b/frontend/src/views/knowledge/components/UploadProgressDialog.vue
@@ -1,0 +1,448 @@
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div v-if="visible" class="upload-progress-overlay">
+        <section
+          class="upload-progress-modal"
+          role="dialog"
+          aria-modal="true"
+          :aria-label="progressTitle"
+        >
+          <button
+            v-if="!isActive"
+            class="close-btn"
+            type="button"
+            :aria-label="t('general.close')"
+            @click="handleClose"
+          >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path d="M15 5L5 15M5 5L15 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+            </svg>
+          </button>
+
+          <header class="progress-header">
+            <div
+              class="header-icon"
+              :class="{
+                'header-icon--done': !isActive && failedCount === 0,
+                'header-icon--error': !isActive && failedCount > 0,
+              }"
+            >
+              <t-icon :name="isActive ? 'upload' : failedCount > 0 ? 'error-circle-filled' : 'check-circle-filled'" />
+            </div>
+            <div>
+              <h2>{{ progressTitle }}</h2>
+              <p aria-live="polite">{{ progressSummary }}</p>
+            </div>
+          </header>
+
+          <div class="overall-progress">
+            <div class="overall-row">
+              <span>{{ t('uploadConfirm.progress.overall') }}</span>
+              <strong>{{ overallProgress }}%</strong>
+            </div>
+            <t-progress :percentage="overallProgress" :label="false" size="small" />
+          </div>
+
+          <ul class="progress-list">
+            <li
+              v-for="task in tasks"
+              :key="task.uploadId"
+              class="progress-item"
+              :class="`progress-item--${task.status}`"
+            >
+              <div class="file-icon">
+                <t-icon :name="getFileIcon(task.fileName)" />
+              </div>
+              <div class="file-progress">
+                <div class="file-row">
+                  <div class="file-details">
+                    <span class="file-name" :title="task.fileName">{{ task.fileName }}</span>
+                    <span v-if="formatFileSize(task.fileSize)" class="file-size">
+                      {{ formatFileSize(task.fileSize) }}
+                    </span>
+                  </div>
+                  <span class="file-status">{{ getStatusText(task) }}</span>
+                </div>
+                <t-progress :percentage="task.progress" :label="false" size="small" />
+                <p v-if="task.status === 'error' && task.error" class="file-error" :title="task.error">
+                  {{ task.error }}
+                </p>
+              </div>
+            </li>
+          </ul>
+
+          <footer class="progress-footer">
+            <span v-if="isActive" class="keep-open-hint">
+              {{ t('uploadConfirm.progress.keepOpen') }}
+            </span>
+            <t-button v-else theme="primary" @click="handleClose">
+              {{ t('uploadConfirm.progress.done') }}
+            </t-button>
+          </footer>
+        </section>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { formatFileSize, getFileIcon } from '@/utils/files'
+
+type UploadProgressStatus = 'pending' | 'uploading' | 'success' | 'error'
+
+interface UploadProgressTask {
+  uploadId: string
+  fileName: string
+  fileSize?: number
+  progress: number
+  status: UploadProgressStatus
+  error?: string
+}
+
+interface UploadProgressEventDetail {
+  uploadId: string
+  fileName?: string
+  fileSize?: number
+  progress?: number
+  status?: UploadProgressStatus
+  error?: string
+}
+
+const { t } = useI18n()
+const visible = ref(false)
+const tasks = ref<UploadProgressTask[]>([])
+
+const clampProgress = (value: number) => Math.min(100, Math.max(0, Math.round(value)))
+
+const completedCount = computed(() =>
+  tasks.value.filter(task => task.status === 'success' || task.status === 'error').length,
+)
+const successCount = computed(() => tasks.value.filter(task => task.status === 'success').length)
+const failedCount = computed(() => tasks.value.filter(task => task.status === 'error').length)
+const isActive = computed(() => completedCount.value < tasks.value.length)
+const overallProgress = computed(() => {
+  if (tasks.value.length === 0) return 0
+  const total = tasks.value.reduce((sum, task) => sum + task.progress, 0)
+  return clampProgress(total / tasks.value.length)
+})
+
+const progressTitle = computed(() => {
+  if (isActive.value) return t('uploadConfirm.progress.title')
+  return failedCount.value > 0
+    ? t('uploadConfirm.progress.completedWithErrors')
+    : t('uploadConfirm.progress.completed')
+})
+
+const progressSummary = computed(() => {
+  if (isActive.value) {
+    return t('uploadConfirm.progress.runningSummary', {
+      completed: completedCount.value,
+      total: tasks.value.length,
+    })
+  }
+  return t('uploadConfirm.progress.completedSummary', {
+    success: successCount.value,
+    failed: failedCount.value,
+  })
+})
+
+const findTaskIndex = (uploadId: string) =>
+  tasks.value.findIndex(task => task.uploadId === uploadId)
+
+const upsertTask = (detail: UploadProgressEventDetail, defaultStatus: UploadProgressStatus) => {
+  if (!detail.uploadId) return
+  const index = findTaskIndex(detail.uploadId)
+  const existing = index >= 0 ? tasks.value[index] : undefined
+  const task: UploadProgressTask = {
+    uploadId: detail.uploadId,
+    fileName: detail.fileName || existing?.fileName || t('uploadConfirm.progress.unknownFile'),
+    fileSize: detail.fileSize ?? existing?.fileSize,
+    progress: typeof detail.progress === 'number'
+      ? clampProgress(detail.progress)
+      : existing?.progress || 0,
+    status: detail.status || existing?.status || defaultStatus,
+    error: detail.error ?? existing?.error,
+  }
+  if (index >= 0) {
+    const nextTasks = [...tasks.value]
+    nextTasks[index] = task
+    tasks.value = nextTasks
+  } else {
+    tasks.value = [...tasks.value, task]
+  }
+}
+
+const handleUploadStart = (event: Event) => {
+  const detail = (event as CustomEvent<UploadProgressEventDetail>).detail
+  if (!detail?.uploadId) return
+  if (!visible.value && !isActive.value) {
+    tasks.value = []
+  }
+  visible.value = true
+  upsertTask(detail, 'pending')
+}
+
+const handleUploadProgress = (event: Event) => {
+  const detail = (event as CustomEvent<UploadProgressEventDetail>).detail
+  if (!detail?.uploadId || typeof detail.progress !== 'number') return
+  upsertTask({ ...detail, status: 'uploading' }, 'uploading')
+}
+
+const handleUploadComplete = (event: Event) => {
+  const detail = (event as CustomEvent<UploadProgressEventDetail>).detail
+  if (!detail?.uploadId) return
+  upsertTask({
+    ...detail,
+    progress: typeof detail.progress === 'number' ? detail.progress : 100,
+    status: detail.status === 'error' ? 'error' : 'success',
+  }, 'success')
+}
+
+const getStatusText = (task: UploadProgressTask) => {
+  if (task.status === 'pending') return t('uploadConfirm.progress.pending')
+  if (task.status === 'uploading') {
+    return t('uploadConfirm.progress.uploading', { progress: task.progress })
+  }
+  if (task.status === 'error') return t('uploadConfirm.progress.failed')
+  return t('uploadConfirm.progress.success')
+}
+
+const handleClose = () => {
+  if (isActive.value) return
+  visible.value = false
+  tasks.value = []
+}
+
+onMounted(() => {
+  window.addEventListener('knowledgeFileUploadStart', handleUploadStart as EventListener)
+  window.addEventListener('knowledgeFileUploadProgress', handleUploadProgress as EventListener)
+  window.addEventListener('knowledgeFileUploadComplete', handleUploadComplete as EventListener)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('knowledgeFileUploadStart', handleUploadStart as EventListener)
+  window.removeEventListener('knowledgeFileUploadProgress', handleUploadProgress as EventListener)
+  window.removeEventListener('knowledgeFileUploadComplete', handleUploadComplete as EventListener)
+})
+</script>
+
+<style scoped lang="less">
+.upload-progress-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 3000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+.upload-progress-modal {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: min(640px, 92vw);
+  max-height: min(720px, 86vh);
+  overflow: hidden;
+  border-radius: 12px;
+  background: var(--td-bg-color-container);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.16);
+}
+
+.close-btn {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 0;
+  border-radius: 6px;
+  background: var(--td-bg-color-secondarycontainer);
+  color: var(--td-text-color-secondary);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--td-text-color-primary);
+  }
+}
+
+.progress-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 24px 56px 16px 24px;
+
+  h2 {
+    margin: 0 0 4px;
+    color: var(--td-text-color-primary);
+    font-size: 20px;
+    line-height: 28px;
+  }
+
+  p {
+    margin: 0;
+    color: var(--td-text-color-secondary);
+    font-size: 14px;
+  }
+}
+
+.header-icon {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--td-brand-color-light);
+  color: var(--td-brand-color);
+  font-size: 22px;
+
+  &--done {
+    background: var(--td-success-color-light);
+    color: var(--td-success-color);
+  }
+
+  &--error {
+    background: var(--td-error-color-light);
+    color: var(--td-error-color);
+  }
+}
+
+.overall-progress {
+  padding: 0 24px 18px;
+  border-bottom: 1px solid var(--td-component-stroke);
+}
+
+.overall-row,
+.file-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.overall-row {
+  margin-bottom: 8px;
+  color: var(--td-text-color-secondary);
+  font-size: 13px;
+
+  strong {
+    color: var(--td-text-color-primary);
+  }
+}
+
+.progress-list {
+  flex: 1;
+  min-height: 0;
+  margin: 0;
+  padding: 8px 24px;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.progress-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--td-component-stroke);
+
+  &:last-child {
+    border-bottom: 0;
+  }
+
+  &--error .file-status,
+  &--error .file-error {
+    color: var(--td-error-color);
+  }
+
+  &--success .file-status {
+    color: var(--td-success-color);
+  }
+}
+
+.file-icon {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  background: var(--td-bg-color-secondarycontainer);
+  color: var(--td-brand-color);
+  font-size: 18px;
+}
+
+.file-progress {
+  min-width: 0;
+  flex: 1;
+}
+
+.file-row {
+  margin-bottom: 7px;
+}
+
+.file-details {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.file-name {
+  overflow: hidden;
+  color: var(--td-text-color-primary);
+  font-size: 14px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-size,
+.file-status {
+  flex: 0 0 auto;
+  color: var(--td-text-color-placeholder);
+  font-size: 12px;
+}
+
+.file-error {
+  margin: 5px 0 0;
+  overflow: hidden;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.progress-footer {
+  display: flex;
+  min-height: 64px;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 12px 24px;
+  border-top: 1px solid var(--td-component-stroke);
+}
+
+.keep-open-hint {
+  color: var(--td-text-color-secondary);
+  font-size: 13px;
+}
+
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+</style>


### PR DESCRIPTION
## Description

Add a global batch-upload progress modal after the existing upload confirmation flow.

- Lists the full confirmed batch before the first request starts.
- Reports real byte progress from Axios `onUploadProgress` for each file and for the whole batch.
- Shows pending, uploading, success, and error states with per-file error messages.
- Keeps the modal open while uploads are active and preserves the final result until the user closes it.
- Emits the existing knowledge upload lifecycle events, which also activates the progress summary already present on the knowledge base list page.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #1165

## Testing

- `tsx --test src/views/knowledge/components/UploadConfirmDialog.test.ts` (8/8 passed)
- `npm run type-check`
- `npm run check-i18n` (11/11 passed)
- `npm run build`
- Rendered the real component in a local Vite harness and visually checked both an active three-file batch and a completed mixed result (2 successful, 1 failed).

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (not applicable; no documented API changed)
- [x] Breaking changes are clearly called out above (none)

## Screenshots / Recordings

The active and mixed-result states were rendered and inspected locally with the real component. The temporary captures were intentionally not committed to the source diff.
