### PR TITLE
fix(storage): strip storage-backend scope in local provider path normalization

### DIFF
--- a/internal/application/service/file/local.go
+++ b/internal/application/service/file/local.go
@@ -282,15 +282,51 @@ func (s *localFileService) GetFileURL(ctx context.Context, filePath string) (str
 	return normalized, nil
 }
 
+// storageScopePrefixes matches the storage://<backend-id>/ scope wrapper that
+// backend-scoped file services prepend to every persisted path
+// (types.BuildStorageBackendPath). On chains assembled without the scoped
+// wrapper (e.g. the process-wide default file service used by KB deletion),
+// these scoped paths reach the raw local provider, where they used to fall
+// through to the relative-path branch, get joined under baseDir, and produce a
+// nonexistent path — silently leaking the physical file on delete. Path
+// normalization (filepath.Clean) may also collapse "storage://" into
+// "storage:/", so both forms are accepted.
+const storageScheme = "storage:"
+
+// trimStorageScope strips a leading "storage://<backend-id>/" (or the cleaned
+// "storage:/<backend-id>/") scope wrapper and returns the inner provider path.
+// Paths without the wrapper are returned unchanged.
+func trimStorageScope(path string) string {
+	if !strings.HasPrefix(path, storageScheme) {
+		return path
+	}
+	rest := strings.TrimPrefix(path, storageScheme)
+	// Tolerate "storage://", "storage:/" and even a bare "storage:" prefix —
+	// filepath.Clean collapses "//" to "/", so cleaned paths arrive single-slashed.
+	rest = strings.TrimLeft(rest, "/")
+	// Skip the backend-id segment; the remainder is the provider path.
+	if i := strings.Index(rest, "/"); i >= 0 {
+		return rest[i+1:]
+	}
+	return ""
+}
+
 // normalizePathForBase keeps backward compatibility for legacy file paths:
+// - storage-backend scope: "storage://<backend-id>/local://tenant/.." → baseDir/tenant/..
 // - provider scheme: "local://tenant/.." → baseDir/tenant/..
 // - absolute path: "/data/files/tenant/.."
 // - path under base dir: "tenant/.."
 // - legacy relative with base prefix: "data/files/tenant/.."
 func (s *localFileService) normalizePathForBase(filePath string) string {
-	// Handle provider:// format: local://{relPath}
-	if strings.HasPrefix(filePath, localScheme) {
-		relPath := strings.TrimPrefix(filePath, localScheme)
+	// Strip a storage-backend scope wrapper first: some chains (KB deletion
+	// uses the process-wide default file service) hand scoped paths straight
+	// to this provider, and the scoped prefix is not a filesystem component.
+	filePath = trimStorageScope(strings.TrimSpace(filePath))
+
+	// Handle provider scheme: local://{relPath}. Also tolerate the cleaned
+	// "local:/" single-slash form for the same reason as trimStorageScope.
+	if strings.HasPrefix(filePath, "local:") {
+		relPath := strings.TrimLeft(strings.TrimPrefix(filePath, "local:"), "/")
 		return filepath.Join(s.baseDir, filepath.FromSlash(relPath))
 	}
 

--- a/internal/application/service/file/local_test.go
+++ b/internal/application/service/file/local_test.go
@@ -3,6 +3,7 @@ package file
 import (
 	"context"
 	"net/url"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,4 +40,47 @@ func TestLocalGetFileURL_NoExternalURL(t *testing.T) {
 	got, err := svc.GetFileURL(context.Background(), "local://1/abc/img.png")
 	require.NoError(t, err)
 	assert.Equal(t, "local://1/abc/img.png", got)
+}
+
+// TestNormalizePathForBase_StripsStorageBackendScope verifies that paths
+// carrying the storage://<backend-id>/ scope wrapper (written by
+// backend-scoped chains, e.g. "storage://uuid/local://10000/doc/file.md")
+// resolve to the same file as their unscoped provider path. Scoped paths
+// reach the raw provider on chains without the scoped wrapper — notably KB
+// deletion — and previously fell into the relative-path branch, producing a
+// nonexistent path under baseDir and silently leaking physical files.
+func TestNormalizePathForBase_StripsStorageBackendScope(t *testing.T) {
+	svc := NewLocalFileService("/data/files", "").(*localFileService)
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			"scoped provider path",
+			"storage://3ac51020-0fe9-4eb6-a58e-e3f8eaee9d04/local://10000/doc1/file.md",
+			"/data/files/10000/doc1/file.md",
+		},
+		{
+			"scoped path after filepath.Clean collapsed double slashes",
+			"storage:/3ac51020-0fe9-4eb6-a58e-e3f8eaee9d04/local:/10000/doc1/file.md",
+			"/data/files/10000/doc1/file.md",
+		},
+		{
+			"plain provider path unaffected",
+			"local://10000/doc1/file.md",
+			"/data/files/10000/doc1/file.md",
+		},
+		{
+			"plain relative path unaffected",
+			"10000/doc1/file.md",
+			"/data/files/10000/doc1/file.md",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, filepath.ToSlash(svc.normalizePathForBase(tc.in)))
+		})
+	}
 }


### PR DESCRIPTION
### Problem

Deleting a knowledge base (or an individual document) with `STORAGE_TYPE=local` never removes the physical files: every `os.Remove` targets `/data/files/storage:/<backend-uuid>/local:/...` (a nonexistent path) and fails with ENOENT, silently leaking files on every KB/document delete.

### Root cause

Write paths run on a `BackendScopedFileService`, so every persisted physical path in the resource catalog carries a `storage://<backend-id>/` scope prefix. KB deletion, however, runs on the process-wide default file service **without** the scoped wrapper: the scoped path reaches the raw `localFileService`, `normalizePathForBase` does not recognize the prefix, falls through to the relative-path branch, and `filepath.Clean` collapses `storage://` into `storage:/` while joining it under `baseDir` — a nonexistent path, so every `os.Remove` fails with ENOENT.

### Fix

`normalizePathForBase` now strips the `storage://<backend-id>/` scope wrapper up front (accepting both the canonical double-slash form and the `filepath.Clean`-collapsed single-slash form, and likewise tolerating a collapsed `local:/` provider scheme). Unscoped paths behave exactly as before.

### Verification

- New unit test `TestNormalizePathForBase_StripsStorageBackendScope` covers scoped (both slash forms) and unscoped inputs; the existing suite — including path-traversal rejection — passes unchanged.
- End-to-end on a live deployment: deleting a document removes its file under `data/files/<tenant>/<knowledge-id>/` with no warnings (file count drops by exactly one; previously the file survived and every delete logged `Failed to delete file`).