### PR TITLE
fix(chat): correct Ollama non-streaming token usage accounting

### DIFF
--- a/internal/models/chat/ollama.go
+++ b/internal/models/chat/ollama.go
@@ -149,9 +149,12 @@ func (c *OllamaChat) Chat(ctx context.Context, messages []Message, opts *ChatOpt
 		toolCalls = c.toolCallTo(resp.Message.ToolCalls)
 
 		// 获取token计数
+		// Ollama 原生 API 语义：PromptEvalCount = 提示词 token，EvalCount = 生成 token
+		// （与下方流式路径一致；此前误将 EvalCount 当总数减去 prompt，导致
+		// CompletionTokens 为负、TotalTokens 等于生成数。）
 		if resp.EvalCount > 0 {
 			promptTokens = resp.PromptEvalCount
-			completionTokens = resp.EvalCount - promptTokens
+			completionTokens = resp.EvalCount
 		}
 
 		return nil


### PR DESCRIPTION
Ollama's native API reports `PromptEvalCount` (prompt tokens) and `EvalCount` (generated tokens). The non-streaming path subtracted prompt tokens from `EvalCount` as if it were the total, producing negative `CompletionTokens` whenever the answer is shorter than the prompt (e.g. `completion_tokens=-387, total_tokens=383` for a 770-token prompt), which corrupts token accounting in observability backends.

This aligns the non-streaming path with the streaming path, which already maps the fields correctly.