### PR TITLE
feat(agent): forward selected request metadata to MCP tools

### DIFF
--- a/client/agent.go
+++ b/client/agent.go
@@ -35,6 +35,7 @@ type AgentQARequest struct {
 	MentionedItems   []MentionedItem   `json:"mentioned_items,omitempty"`    // @mentioned knowledge bases and files
 	DisableTitle     bool              `json:"disable_title,omitempty"`      // Whether to disable auto title generation
 	MCPServiceIDs    []string          `json:"mcp_service_ids,omitempty"`    // Optional MCP service allow list (deprecated)
+	MCPMetadata      map[string]string `json:"mcp_metadata,omitempty"`       // Optional scalar metadata selected by the Agent's MCP request-meta allowlist
 	Images           []ImageAttachment `json:"images,omitempty"`             // Attached images for multimodal chat
 	Channel          string            `json:"channel,omitempty"`            // Source channel: "web", "api", "im", etc.
 }

--- a/client/agent.go
+++ b/client/agent.go
@@ -27,14 +27,14 @@ type MentionedItem struct {
 type AgentQARequest struct {
 	Query            string          `json:"query"`                        // Required query text
 	KnowledgeBaseIDs []string        `json:"knowledge_base_ids,omitempty"` // Optional KBs for this query
-	KnowledgeIDs     []string        `json:"knowledge_ids,omitempty"`      // Optional specific knowledge IDs for this query
+	KnowledgeIDs     []string        `json:"knowledge_ids,omitempty"`      // Optional knowledge IDs
 	AgentEnabled     bool            `json:"agent_enabled"`                // Whether to run in agent mode
 	AgentID          string          `json:"agent_id,omitempty"`           // Optional custom agent ID
 	WebSearchEnabled bool            `json:"web_search_enabled"`           // Whether to enable web search
 	SummaryModelID   string          `json:"summary_model_id,omitempty"`   // Optional summary model override
 	MentionedItems   []MentionedItem `json:"mentioned_items,omitempty"`    // @mentioned knowledge bases and files
 	DisableTitle     bool            `json:"disable_title,omitempty"`      // Whether to disable auto title generation
-	MCPServiceIDs    []string        `json:"mcp_service_ids,omitempty"`    // Optional MCP service allow list (deprecated)
+	MCPServiceIDs    []string        `json:"mcp_service_ids,omitempty"`    // Deprecated MCP service allow list
 	// Optional scalar metadata selected by the Agent's MCP request-meta allowlist.
 	MCPMetadata map[string]string `json:"mcp_metadata,omitempty"`
 	Images      []ImageAttachment `json:"images,omitempty"`  // Attached images for multimodal chat

--- a/client/agent.go
+++ b/client/agent.go
@@ -25,19 +25,20 @@ type MentionedItem struct {
 
 // AgentQARequest agent Q&A request payload.
 type AgentQARequest struct {
-	Query            string            `json:"query"`                        // Required query text
-	KnowledgeBaseIDs []string          `json:"knowledge_base_ids,omitempty"` // Optional KBs for this query
-	KnowledgeIDs     []string          `json:"knowledge_ids,omitempty"`      // Optional specific knowledge IDs for this query
-	AgentEnabled     bool              `json:"agent_enabled"`                // Whether to run in agent mode
-	AgentID          string            `json:"agent_id,omitempty"`           // Optional custom agent ID
-	WebSearchEnabled bool              `json:"web_search_enabled"`           // Whether to enable web search
-	SummaryModelID   string            `json:"summary_model_id,omitempty"`   // Optional summary model override
-	MentionedItems   []MentionedItem   `json:"mentioned_items,omitempty"`    // @mentioned knowledge bases and files
-	DisableTitle     bool              `json:"disable_title,omitempty"`      // Whether to disable auto title generation
-	MCPServiceIDs    []string          `json:"mcp_service_ids,omitempty"`    // Optional MCP service allow list (deprecated)
-	MCPMetadata      map[string]string `json:"mcp_metadata,omitempty"`       // Optional scalar metadata selected by the Agent's MCP request-meta allowlist
-	Images           []ImageAttachment `json:"images,omitempty"`             // Attached images for multimodal chat
-	Channel          string            `json:"channel,omitempty"`            // Source channel: "web", "api", "im", etc.
+	Query            string          `json:"query"`                        // Required query text
+	KnowledgeBaseIDs []string        `json:"knowledge_base_ids,omitempty"` // Optional KBs for this query
+	KnowledgeIDs     []string        `json:"knowledge_ids,omitempty"`      // Optional specific knowledge IDs for this query
+	AgentEnabled     bool            `json:"agent_enabled"`                // Whether to run in agent mode
+	AgentID          string          `json:"agent_id,omitempty"`           // Optional custom agent ID
+	WebSearchEnabled bool            `json:"web_search_enabled"`           // Whether to enable web search
+	SummaryModelID   string          `json:"summary_model_id,omitempty"`   // Optional summary model override
+	MentionedItems   []MentionedItem `json:"mentioned_items,omitempty"`    // @mentioned knowledge bases and files
+	DisableTitle     bool            `json:"disable_title,omitempty"`      // Whether to disable auto title generation
+	MCPServiceIDs    []string        `json:"mcp_service_ids,omitempty"`    // Optional MCP service allow list (deprecated)
+	// Optional scalar metadata selected by the Agent's MCP request-meta allowlist.
+	MCPMetadata map[string]string `json:"mcp_metadata,omitempty"`
+	Images      []ImageAttachment `json:"images,omitempty"`  // Attached images for multimodal chat
+	Channel     string            `json:"channel,omitempty"` // Source channel: "web", "api", "im", etc.
 }
 
 // AgentResponseType defines the type of agent response

--- a/client/agent_manage.go
+++ b/client/agent_manage.go
@@ -88,6 +88,7 @@ type AgentConfig struct {
 	AllowedTools                []string                  `json:"allowed_tools"`
 	MCPSelectionMode            string                    `json:"mcp_selection_mode"`
 	MCPServices                 []string                  `json:"mcp_services"`
+	MCPRequestMeta              *MCPRequestMetaConfig     `json:"mcp_request_meta,omitempty"`
 	SkillsSelectionMode         string                    `json:"skills_selection_mode"`
 	SelectedSkills              []string                  `json:"selected_skills"`
 	KBSelectionMode             string                    `json:"kb_selection_mode"`
@@ -125,6 +126,14 @@ type AgentConfig struct {
 	FallbackResponse            string                    `json:"fallback_response"`
 	FallbackPrompt              string                    `json:"fallback_prompt"`
 	QuestionSuggestions         *QuestionSuggestionConfig `json:"question_suggestions,omitempty"`
+}
+
+// MCPRequestMetaConfig declares which request values an Agent may copy into
+// MCP tools/call _meta. It contains selector names only; request values are
+// collected for one call and are never stored in the Agent configuration.
+type MCPRequestMetaConfig struct {
+	Headers    []string `json:"headers,omitempty"`
+	BodyFields []string `json:"body_fields,omitempty"`
 }
 
 type QuestionSuggestionConfig struct {

--- a/docs/api/chat.md
+++ b/docs/api/chat.md
@@ -87,6 +87,56 @@ Agent 模式支持更智能的问答，包括工具调用、网络搜索、多�
 | `images` | object[] | 否 | 附带的图片（base64 格式），需要 Agent 启用图片上传 |
 | `channel` | string | 否 | 来源渠道标识：`web`、`api`、`im`、`browser_extension` |
 | `suggestion_attribution` | object | 否 | 用户从推荐问题发起本轮时传入 `{suggestion_set_id, question_id}`；服务端会校验归属 |
+| `mcp_metadata` | object<string,string> | 否 | 提供给 Agent MCP 元数据白名单选择的标量 Body 字段；最多 16 个键，键名仅允许字母、数字、`_`、`-`、`.` |
+
+### MCP 请求元数据透传
+
+如果 Agent 配置了 `mcp_request_meta`，服务端会把本次 HTTP 请求中被白名单选中的值放入每次 MCP `tools/call` 的标准 `_meta` 参数。Agent 配置接口中的示例：
+
+```json
+{
+  "mcp_request_meta": {
+    "headers": ["Authorization", "X-Trace-Id"],
+    "body_fields": ["channel", "mcp_metadata.user_role"]
+  }
+}
+```
+
+调用 Agent 时可以提供自定义的标量 Body 元数据：
+
+```json
+{
+  "query": "查询订单状态",
+  "agent_enabled": true,
+  "agent_id": "agent-001",
+  "mcp_metadata": {
+    "user_role": "auditor"
+  }
+}
+```
+
+MCP 服务收到的参数包含如下扩展字段（实际请求仍是 MCP 标准 `tools/call`）：
+
+```json
+{
+  "_meta": {
+    "io.weknora/request": {
+      "headers": {
+        "Authorization": "Bearer ...",
+        "X-Trace-Id": "trace-123"
+      },
+      "body": {
+        "channel": "api",
+        "mcp_metadata": {
+          "user_role": "auditor"
+        }
+      }
+    }
+  }
+}
+```
+
+只会透传 Agent 配置中明确列出的字段；图片、附件和未列出的请求值不会进入 `_meta`。每类最多配置 16 个字段，单个值和总大小也有限制。由于请求头可能包含凭据，请只对可信 MCP 服务启用；共享 Agent 调用不会透传调用者的请求元数据。
 
 ## 回答后推荐问题
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -17911,6 +17911,14 @@ const docTemplate = `{
                     "description": "MCPAuthWaitTimeout is how many seconds to wait for in-conversation OAuth\nauthorization before skipping. \u003c=0 uses the gate's configured timeout.",
                     "type": "integer"
                 },
+                "mcp_request_meta": {
+                    "description": "MCPRequestMeta explicitly allowlists HTTP request values copied into MCP\ntool-call _meta. The configuration stores selectors only, never values.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/github_com_Tencent_WeKnora_internal_types.MCPRequestMetaConfig"
+                        }
+                    ]
+                },
                 "mcp_selection_mode": {
                     "description": "MCP service selection mode: \"all\" = all enabled MCP services, \"selected\" = specific services, \"none\" = no MCP",
                     "type": "string"
@@ -19314,6 +19322,23 @@ const docTemplate = `{
             "type": "object",
             "additionalProperties": {
                 "type": "string"
+            }
+        },
+        "github_com_Tencent_WeKnora_internal_types.MCPRequestMetaConfig": {
+            "type": "object",
+            "properties": {
+                "body_fields": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "headers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
             }
         },
         "github_com_Tencent_WeKnora_internal_types.MCPService": {
@@ -24849,6 +24874,13 @@ const docTemplate = `{
                     "description": "Selected knowledge ID for this request",
                     "type": "array",
                     "items": {
+                        "type": "string"
+                    }
+                },
+                "mcp_metadata": {
+                    "description": "Caller-supplied scalar metadata; only Agent-allowlisted keys reach MCP _meta",
+                    "type": "object",
+                    "additionalProperties": {
                         "type": "string"
                     }
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -17904,6 +17904,14 @@
                     "description": "MCPAuthWaitTimeout is how many seconds to wait for in-conversation OAuth\nauthorization before skipping. \u003c=0 uses the gate's configured timeout.",
                     "type": "integer"
                 },
+                "mcp_request_meta": {
+                    "description": "MCPRequestMeta explicitly allowlists HTTP request values copied into MCP\ntool-call _meta. The configuration stores selectors only, never values.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/github_com_Tencent_WeKnora_internal_types.MCPRequestMetaConfig"
+                        }
+                    ]
+                },
                 "mcp_selection_mode": {
                     "description": "MCP service selection mode: \"all\" = all enabled MCP services, \"selected\" = specific services, \"none\" = no MCP",
                     "type": "string"
@@ -19307,6 +19315,23 @@
             "type": "object",
             "additionalProperties": {
                 "type": "string"
+            }
+        },
+        "github_com_Tencent_WeKnora_internal_types.MCPRequestMetaConfig": {
+            "type": "object",
+            "properties": {
+                "body_fields": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "headers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
             }
         },
         "github_com_Tencent_WeKnora_internal_types.MCPService": {
@@ -24842,6 +24867,13 @@
                     "description": "Selected knowledge ID for this request",
                     "type": "array",
                     "items": {
+                        "type": "string"
+                    }
+                },
+                "mcp_metadata": {
+                    "description": "Caller-supplied scalar metadata; only Agent-allowlisted keys reach MCP _meta",
+                    "type": "object",
+                    "additionalProperties": {
                         "type": "string"
                     }
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -881,6 +881,12 @@ definitions:
           MCPAuthWaitTimeout is how many seconds to wait for in-conversation OAuth
           authorization before skipping. <=0 uses the gate's configured timeout.
         type: integer
+      mcp_request_meta:
+        description: |-
+          MCPRequestMeta explicitly allowlists HTTP request values copied into MCP
+          tool-call _meta. The configuration stores selectors only, never values.
+        allOf:
+        - $ref: '#/definitions/github_com_Tencent_WeKnora_internal_types.MCPRequestMetaConfig'
       mcp_selection_mode:
         description: 'MCP service selection mode: "all" = all enabled MCP services,
           "selected" = specific services, "none" = no MCP'
@@ -1974,6 +1980,17 @@ definitions:
   github_com_Tencent_WeKnora_internal_types.MCPHeaders:
     additionalProperties:
       type: string
+    type: object
+  github_com_Tencent_WeKnora_internal_types.MCPRequestMetaConfig:
+    properties:
+      body_fields:
+        items:
+          type: string
+        type: array
+      headers:
+        items:
+          type: string
+        type: array
     type: object
   github_com_Tencent_WeKnora_internal_types.MCPService:
     properties:
@@ -6162,6 +6179,12 @@ definitions:
         items:
           type: string
         type: array
+      mcp_metadata:
+        additionalProperties:
+          type: string
+        description: Caller-supplied scalar metadata; only Agent-allowlisted keys
+          reach MCP _meta
+        type: object
       mcp_service_ids:
         description: Per-request MCP services selected via @mention
         items:

--- a/frontend/src/api/agent/index.ts
+++ b/frontend/src/api/agent/index.ts
@@ -59,6 +59,12 @@ export interface CustomAgentConfig {
   // 对话中触发 OAuth 授权时的等待超时（秒）：到点后自动跳过授权提示。
   // <=0 时使用服务端默认超时。仅对使用 OAuth 的 MCP 服务生效。
   mcp_auth_wait_timeout?: number;
+  // 显式允许从单次 Agent HTTP 请求复制到 MCP tools/call _meta 的字段名。
+  // 值不会持久化；共享 Agent 调用时后端会禁用该透传。
+  mcp_request_meta?: {
+    headers?: string[];
+    body_fields?: string[];
+  };
 
   // ===== Skills设置（仅Agent模式）=====
   // Skills选择模式：all=全部预装, selected=指定, none=不使用

--- a/frontend/src/api/chat/streame.ts
+++ b/frontend/src/api/chat/streame.ts
@@ -36,7 +36,7 @@ export function useStream() {
   let renderTimer: number | null = null
 
   // 启动流式请求
-  const startStream = async (params: { session_id: any; query: any; knowledge_base_ids?: string[]; knowledge_ids?: string[]; tag_ids?: string[]; agent_enabled?: boolean; agent_id?: string; agent_source_tenant_id?: string | number; web_search_enabled?: boolean; summary_model_id?: string; mcp_service_ids?: string[]; skill_names?: string[]; mentioned_items?: Array<{id: string; name: string; type: string; kb_type?: string; kb_id?: string; kb_name?: string; service_id?: string; skill_name?: string}>; images?: Array<{data: string}>; attachment_uploads?: Array<{data: string; file_name: string; file_size: number}>; attachment_ids?: string[]; suggestion_attribution?: { suggestion_set_id: string; question_id: string }; method: string; url: string; embed_token?: string; embed_session_sig?: string; embed_visitor_id?: string }) => {
+  const startStream = async (params: { session_id: any; query: any; knowledge_base_ids?: string[]; knowledge_ids?: string[]; tag_ids?: string[]; agent_enabled?: boolean; agent_id?: string; agent_source_tenant_id?: string | number; web_search_enabled?: boolean; summary_model_id?: string; mcp_service_ids?: string[]; mcp_metadata?: Record<string, string>; skill_names?: string[]; mentioned_items?: Array<{id: string; name: string; type: string; kb_type?: string; kb_id?: string; kb_name?: string; service_id?: string; skill_name?: string}>; images?: Array<{data: string}>; attachment_uploads?: Array<{data: string; file_name: string; file_size: number}>; attachment_ids?: string[]; suggestion_attribution?: { suggestion_set_id: string; question_id: string }; method: string; url: string; embed_token?: string; embed_session_sig?: string; embed_visitor_id?: string }) => {
     const myGeneration = ++streamGeneration
     // 重置状态
     output.value = '';
@@ -113,6 +113,11 @@ export function useStream() {
       // Include mcp_service_ids if provided (for Agent mode)
       if (params.mcp_service_ids !== undefined && params.mcp_service_ids.length > 0) {
         postBody.mcp_service_ids = params.mcp_service_ids;
+      }
+      // Forward only caller-supplied scalar metadata; the backend applies the
+      // Agent's allowlist before placing selected values in MCP _meta.
+      if (params.mcp_metadata !== undefined) {
+        postBody.mcp_metadata = params.mcp_metadata;
       }
       if (params.skill_names !== undefined && params.skill_names.length > 0) {
         postBody.skill_names = params.skill_names;

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -5767,6 +5767,13 @@ export default {
       authWaitTimeout: 'Authentication Wait Timeout (s)',
       authWaitTimeoutDesc: 'Maximum seconds to wait for you to complete OAuth authentication when prompted during a conversation; the prompt is skipped after it elapses (only affects OAuth MCP services).',
       authWaitTimeoutPlaceholder: 'Default 600 seconds',
+      requestMetaWarning: 'These values are sent to every MCP service this Agent can call and may contain credentials. Configure trusted services only. Shared Agent calls never forward them.',
+      requestHeaders: 'Forward Request Headers',
+      requestHeadersDesc: 'HTTP header names copied to MCP _meta, up to 16. Request values are used for this call only and are never saved.',
+      requestHeadersPlaceholder: 'For example: Authorization, X-Trace-Id',
+      requestBodyFields: 'Forward Request Body Fields',
+      requestBodyFieldsDesc: 'Copy scalar fields, ID lists, or custom strings under mcp_metadata.<key>, up to 16. Images and attachments are never eligible.',
+      requestBodyFieldsPlaceholder: 'For example: channel, mcp_metadata.user_role',
       unavailableService: 'Unavailable service'
     },
     llmCallTimeout: {

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -911,6 +911,13 @@ export default {
       authWaitTimeout: '인증 대기 시간(초)',
       authWaitTimeoutDesc: '대화 중 OAuth 인증이 필요할 때 인증 완료를 기다리는 최대 시간(초)이며, 초과하면 인증 요청을 건너뜁니다(OAuth를 사용하는 MCP 서비스에만 적용).',
       authWaitTimeoutPlaceholder: '기본 600초',
+      requestMetaWarning: '이 값은 Agent가 호출할 수 있는 모든 MCP 서비스로 전송되며 자격 증명을 포함할 수 있습니다. 신뢰할 수 있는 서비스에만 설정하세요. 공유 Agent 호출에서는 전달되지 않습니다.',
+      requestHeaders: '요청 헤더 전달',
+      requestHeadersDesc: 'MCP _meta로 복사할 HTTP 헤더 이름이며 최대 16개입니다. 값은 이번 호출에만 사용되고 저장되지 않습니다.',
+      requestHeadersPlaceholder: '예: Authorization, X-Trace-Id',
+      requestBodyFields: '요청 Body 필드 전달',
+      requestBodyFieldsDesc: '스칼라 필드, ID 목록 또는 mcp_metadata.<키> 문자열을 최대 16개 전달할 수 있습니다. 이미지와 첨부 파일은 전달되지 않습니다.',
+      requestBodyFieldsPlaceholder: '예: channel, mcp_metadata.user_role',
       unavailableService: '사용할 수 없는 서비스'
     },
     agentType: {

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -911,6 +911,13 @@ export default {
       authWaitTimeout: 'Тайм-аут ожидания аутентификации (с)',
       authWaitTimeoutDesc: 'Максимальное время ожидания (в секундах) завершения OAuth-аутентификации при запросе во время диалога; по его истечении запрос пропускается (влияет только на MCP-сервисы с OAuth).',
       authWaitTimeoutPlaceholder: 'Default 600 seconds',
+      requestMetaWarning: 'Эти значения отправляются каждому MCP-сервису, доступному агенту, и могут содержать учётные данные. Настраивайте только доверенные сервисы. Для общих агентов пересылка отключена.',
+      requestHeaders: 'Передаваемые заголовки запроса',
+      requestHeadersDesc: 'Имена HTTP-заголовков, копируемых в MCP _meta, не более 16. Значения используются только в текущем вызове и не сохраняются.',
+      requestHeadersPlaceholder: 'Например: Authorization, X-Trace-Id',
+      requestBodyFields: 'Передаваемые поля тела запроса',
+      requestBodyFieldsDesc: 'Можно передать скалярные поля, списки ID или строки mcp_metadata.<ключ>, не более 16. Изображения и вложения не передаются.',
+      requestBodyFieldsPlaceholder: 'Например: channel, mcp_metadata.user_role',
       unavailableService: 'Недоступный сервис'
     },
     agentType: {

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -913,6 +913,13 @@ export default {
       authWaitTimeout: '授权等待超时（秒）',
       authWaitTimeoutDesc: '对话中触发 OAuth 授权时，等待你完成授权的最长秒数，超时后自动跳过授权提示（仅对使用 OAuth 的 MCP 服务生效）。',
       authWaitTimeoutPlaceholder: '默认 600 秒',
+      requestMetaWarning: '这些值会发送给此 Agent 可调用的每个 MCP 服务，可能包含凭据。仅为可信服务配置；共享 Agent 调用不会透传。',
+      requestHeaders: '透传请求头',
+      requestHeadersDesc: '允许复制到 MCP _meta 的 HTTP 请求头名称，最多 16 个。请求值只用于本次调用，不会保存。',
+      requestHeadersPlaceholder: '例如 Authorization、X-Trace-Id',
+      requestBodyFields: '透传请求 Body 字段',
+      requestBodyFieldsDesc: '允许复制标量、ID 列表或 mcp_metadata.<键> 中的自定义字符串，最多 16 个；图片和附件不可透传。',
+      requestBodyFieldsPlaceholder: '例如 channel、mcp_metadata.user_role',
       unavailableService: '不可用服务'
     },
     agentType: {

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -1268,6 +1268,33 @@
                           theme="column" :placeholder="$t('agentEditor.mcp.authWaitTimeoutPlaceholder')" />
                       </div>
                     </div>
+
+                    <t-alert v-if="mcpSelectionMode !== 'none'" theme="warning"
+                      :message="$t('agentEditor.mcp.requestMetaWarning')" />
+
+                    <!-- MCP tools/call _meta 请求头白名单 -->
+                    <div v-if="mcpSelectionMode !== 'none'" class="setting-row">
+                      <div class="setting-info">
+                        <label>{{ $t('agentEditor.mcp.requestHeaders') }}</label>
+                        <p class="desc">{{ $t('agentEditor.mcp.requestHeadersDesc') }}</p>
+                      </div>
+                      <div class="setting-control">
+                        <t-tag-input v-model="formData.config.mcp_request_meta.headers"
+                          :placeholder="$t('agentEditor.mcp.requestHeadersPlaceholder')" clearable />
+                      </div>
+                    </div>
+
+                    <!-- MCP tools/call _meta 请求 body 字段白名单 -->
+                    <div v-if="mcpSelectionMode !== 'none'" class="setting-row">
+                      <div class="setting-info">
+                        <label>{{ $t('agentEditor.mcp.requestBodyFields') }}</label>
+                        <p class="desc">{{ $t('agentEditor.mcp.requestBodyFieldsDesc') }}</p>
+                      </div>
+                      <div class="setting-control">
+                        <t-tag-input v-model="formData.config.mcp_request_meta.body_fields"
+                          :placeholder="$t('agentEditor.mcp.requestBodyFieldsPlaceholder')" clearable />
+                      </div>
+                    </div>
                   </div>
                 </div>
 
@@ -2729,6 +2756,11 @@ const defaultFormData = {
     mcp_services: [] as string[],
     // 对话中触发 OAuth 授权时的等待超时（秒），默认 600
     mcp_auth_wait_timeout: 600,
+    // 单次 Agent 请求中允许复制到 MCP tools/call _meta 的字段名
+    mcp_request_meta: {
+      headers: [] as string[],
+      body_fields: [] as string[],
+    },
     // Skills 设置
     skills_selection_mode: 'none' as 'all' | 'selected' | 'none',
     selected_skills: [] as string[],
@@ -3398,6 +3430,10 @@ watch(() => props.visible, async (val) => {
       if (!agentData.config.knowledge_bases) agentData.config.knowledge_bases = [];
       if (!agentData.config.allowed_tools) agentData.config.allowed_tools = [];
       if (!agentData.config.mcp_services) agentData.config.mcp_services = [];
+      agentData.config.mcp_request_meta = {
+        headers: agentData.config.mcp_request_meta?.headers || [],
+        body_fields: agentData.config.mcp_request_meta?.body_fields || [],
+      };
       // 授权等待超时：旧数据缺省时用默认 600 秒
       if (agentData.config.mcp_auth_wait_timeout == null || agentData.config.mcp_auth_wait_timeout <= 0) {
         agentData.config.mcp_auth_wait_timeout = 600;

--- a/internal/agent/tools/mcp_tool.go
+++ b/internal/agent/tools/mcp_tool.go
@@ -26,6 +26,7 @@ type MCPTool struct {
 	// timeout (seconds) applied when a tool call triggers in-conversation auth.
 	// <=0 uses the gate's configured default.
 	authWaitTimeoutSeconds int
+	requestMeta            *types.MCPRequestMeta
 }
 
 // NewMCPTool creates a new MCP tool wrapper. authWaitTimeoutSeconds carries the
@@ -33,6 +34,7 @@ type MCPTool struct {
 func NewMCPTool(
 	service *types.MCPService, mcpTool *types.MCPTool,
 	mcpManager *mcp.MCPManager, gate approval.MCPApproval, authWaitTimeoutSeconds int,
+	requestMeta *types.MCPRequestMeta,
 ) *MCPTool {
 	return &MCPTool{
 		service:                service,
@@ -40,6 +42,7 @@ func NewMCPTool(
 		mcpManager:             mcpManager,
 		gate:                   gate,
 		authWaitTimeoutSeconds: authWaitTimeoutSeconds,
+		requestMeta:            requestMeta,
 	}
 }
 
@@ -207,7 +210,7 @@ func (t *MCPTool) Execute(ctx context.Context, args json.RawMessage) (*types.Too
 			}()
 		}
 
-		result, err := client.CallTool(callCtx, t.mcpTool.Name, input)
+		result, err := client.CallTool(callCtx, t.mcpTool.Name, input, t.requestMeta)
 		if err != nil && !isStdio {
 			logger.GetLogger(callCtx).Warnf("MCP tool call failed, retrying with fresh connection: %v", err)
 			_ = client.Disconnect()
@@ -218,7 +221,7 @@ func (t *MCPTool) Execute(ctx context.Context, args json.RawMessage) (*types.Too
 			if err != nil {
 				return nil, err
 			}
-			result, err = client.CallTool(callCtx, t.mcpTool.Name, input)
+			result, err = client.CallTool(callCtx, t.mcpTool.Name, input, t.requestMeta)
 		}
 		return result, err
 	}
@@ -415,6 +418,7 @@ func RegisterMCPTools(
 	mcpManager *mcp.MCPManager,
 	gate approval.MCPApproval,
 	oauthSess *MCPOAuthSession,
+	requestMeta *types.MCPRequestMeta,
 ) (int, error) {
 	if len(services) == 0 {
 		return 0, nil
@@ -492,7 +496,7 @@ func RegisterMCPTools(
 
 		// Register each tool
 		for _, mcpTool := range mcpTools {
-			tool := NewMCPTool(service, mcpTool, mcpManager, gate, authWaitTimeoutSeconds)
+			tool := NewMCPTool(service, mcpTool, mcpManager, gate, authWaitTimeoutSeconds, requestMeta)
 			toolName := tool.Name()
 
 			// Check for name collision before registering (first-wins policy).

--- a/internal/application/service/agent_service.go
+++ b/internal/application/service/agent_service.go
@@ -329,6 +329,10 @@ func (s *agentService) registerMCPTools(
 		}
 	}
 	if len(enabledServices) > 0 {
+		requestMeta := config.MCPRequestMeta
+		if config.SharedAgentReadOnly {
+			requestMeta = nil
+		}
 		var regCtx *tools.MCPOAuthSession
 		if eventBus != nil && sessionID != "" && assistantMessageID != "" {
 			regCtx = &tools.MCPOAuthSession{
@@ -340,7 +344,7 @@ func (s *agentService) registerMCPTools(
 			}
 		}
 		registered, err := tools.RegisterMCPTools(
-			ctx, toolRegistry, enabledServices, s.mcpManager, s.toolApprovalGate, regCtx,
+			ctx, toolRegistry, enabledServices, s.mcpManager, s.toolApprovalGate, regCtx, requestMeta,
 		)
 		if err != nil {
 			logger.Warnf(ctx, "Failed to register MCP tools: %v", err)

--- a/internal/application/service/session_agent_qa.go
+++ b/internal/application/service/session_agent_qa.go
@@ -289,6 +289,7 @@ func (s *sessionService) buildAgentConfig(
 		MCPSelectionMode:            customAgent.Config.MCPSelectionMode,
 		MCPServices:                 customAgent.Config.MCPServices,
 		MCPAuthWaitTimeout:          customAgent.Config.MCPAuthWaitTimeout,
+		MCPRequestMeta:              mcpRequestMetaForAgentRun(req),
 		Thinking:                    customAgent.Config.Thinking,
 		CitationEnabled:             customAgent.Config.CitationEnabled,
 		RetrieveKBOnlyWhenMentioned: customAgent.Config.RetrieveKBOnlyWhenMentioned,
@@ -409,6 +410,13 @@ func (s *sessionService) buildAgentConfig(
 	}
 
 	return agentConfig, nil
+}
+
+func mcpRequestMetaForAgentRun(req *types.QARequest) *types.MCPRequestMeta {
+	if req == nil || req.SharedAgentReadOnly {
+		return nil
+	}
+	return req.MCPRequestMeta
 }
 
 func mergeResolvedTagKnowledgeIDs(

--- a/internal/application/service/session_agent_qa_mcp_meta_test.go
+++ b/internal/application/service/session_agent_qa_mcp_meta_test.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestMCPRequestMetaForAgentRun(t *testing.T) {
+	meta := &types.MCPRequestMeta{Headers: map[string]string{"Authorization": "Bearer token"}}
+
+	if got := mcpRequestMetaForAgentRun(&types.QARequest{MCPRequestMeta: meta}); got != meta {
+		t.Fatal("local Agent run should retain its request metadata")
+	}
+	if got := mcpRequestMetaForAgentRun(&types.QARequest{
+		MCPRequestMeta:      meta,
+		SharedAgentReadOnly: true,
+	}); got != nil {
+		t.Fatal("shared Agent run must not receive caller request metadata")
+	}
+	if got := mcpRequestMetaForAgentRun(nil); got != nil {
+		t.Fatal("nil request should not produce metadata")
+	}
+}

--- a/internal/handler/custom_agent.go
+++ b/internal/handler/custom_agent.go
@@ -102,6 +102,10 @@ func (h *CustomAgentHandler) CreateAgent(c *gin.Context) {
 		c.Error(err)
 		return
 	}
+	if err := req.Config.MCPRequestMeta.Validate(); err != nil {
+		c.Error(errors.NewBadRequestError(err.Error()))
+		return
+	}
 
 	// Build agent object
 	agent := &types.CustomAgent{
@@ -347,6 +351,10 @@ func (h *CustomAgentHandler) UpdateAgent(c *gin.Context) {
 	}
 	if err := h.validateAgentSandboxConfig(ctx, req.Config); err != nil {
 		c.Error(err)
+		return
+	}
+	if err := req.Config.MCPRequestMeta.Validate(); err != nil {
+		c.Error(errors.NewBadRequestError(err.Error()))
 		return
 	}
 

--- a/internal/handler/session/mcp_request_meta.go
+++ b/internal/handler/session/mcp_request_meta.go
@@ -1,0 +1,145 @@
+package session
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func buildMCPRequestMeta(
+	headers http.Header,
+	request *CreateKnowledgeQARequest,
+	config *types.MCPRequestMetaConfig,
+	sharedAgentReadOnly bool,
+) *types.MCPRequestMeta {
+	// A shared Agent can point at MCP servers controlled by another workspace.
+	// Forwarding the caller's credentials there would turn the share into a
+	// credential-exfiltration primitive, even when the selector was explicit.
+	if request == nil || config == nil || sharedAgentReadOnly {
+		return nil
+	}
+
+	meta := &types.MCPRequestMeta{}
+	totalBytes := 0
+	seenHeaders := make(map[string]struct{}, len(config.Headers))
+	for _, configuredName := range config.Headers {
+		if len(seenHeaders) >= types.MCPRequestMetaMaxSelectors {
+			break
+		}
+		configuredName = strings.TrimSpace(configuredName)
+		if !types.IsAllowedMCPRequestHeader(configuredName) {
+			continue
+		}
+		name := http.CanonicalHeaderKey(configuredName)
+		lowerName := strings.ToLower(name)
+		if _, seen := seenHeaders[lowerName]; seen {
+			continue
+		}
+		seenHeaders[lowerName] = struct{}{}
+
+		values := headers.Values(configuredName)
+		if len(values) == 0 {
+			continue
+		}
+		value := strings.Join(values, ", ")
+		entryBytes := len(name) + len(value)
+		if len(value) > types.MCPRequestMetaMaxValueBytes ||
+			totalBytes+entryBytes > types.MCPRequestMetaMaxTotalBytes {
+			continue
+		}
+		if meta.Headers == nil {
+			meta.Headers = make(map[string]string)
+		}
+		meta.Headers[name] = value
+		totalBytes += entryBytes
+	}
+
+	seenBodyFields := make(map[string]struct{}, len(config.BodyFields))
+	for _, configuredField := range config.BodyFields {
+		if len(seenBodyFields) >= types.MCPRequestMetaMaxSelectors {
+			break
+		}
+		field := strings.TrimSpace(configuredField)
+		if !types.IsAllowedMCPRequestBodyField(field) {
+			continue
+		}
+		if _, seen := seenBodyFields[field]; seen {
+			continue
+		}
+		seenBodyFields[field] = struct{}{}
+
+		value, present := mcpRequestBodyValue(request, field)
+		if !present {
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			continue
+		}
+		entryBytes := len(field) + len(encoded)
+		if len(encoded) > types.MCPRequestMetaMaxValueBytes ||
+			totalBytes+entryBytes > types.MCPRequestMetaMaxTotalBytes {
+			continue
+		}
+		if meta.Body == nil {
+			meta.Body = make(map[string]any)
+		}
+		if strings.HasPrefix(field, "mcp_metadata.") {
+			key := strings.TrimPrefix(field, "mcp_metadata.")
+			nested, _ := meta.Body["mcp_metadata"].(map[string]string)
+			if nested == nil {
+				nested = make(map[string]string)
+				meta.Body["mcp_metadata"] = nested
+			}
+			nested[key] = value.(string)
+		} else {
+			meta.Body[field] = value
+		}
+		totalBytes += entryBytes
+	}
+
+	if meta.Empty() {
+		return nil
+	}
+	return meta
+}
+
+func mcpRequestBodyValue(request *CreateKnowledgeQARequest, field string) (any, bool) {
+	switch field {
+	case "query":
+		return request.Query, true
+	case "agent_enabled":
+		return request.AgentEnabled, true
+	case "agent_id":
+		return request.AgentID, true
+	case "agent_source_tenant_id":
+		return request.AgentSourceTenantID, true
+	case "web_search_enabled":
+		return request.WebSearchEnabled, true
+	case "summary_model_id":
+		return request.SummaryModelID, true
+	case "disable_title":
+		return request.DisableTitle, true
+	case "channel":
+		return request.Channel, true
+	case "knowledge_base_ids":
+		return append([]string{}, request.KnowledgeBaseIDs...), true
+	case "knowledge_ids":
+		return append([]string{}, request.KnowledgeIds...), true
+	case "mcp_service_ids":
+		return append([]string{}, request.MCPServiceIDs...), true
+	case "skill_names":
+		return append([]string{}, request.SkillNames...), true
+	case "tag_ids":
+		return append([]string{}, request.TagIDs...), true
+	}
+
+	const prefix = "mcp_metadata."
+	if strings.HasPrefix(field, prefix) {
+		value, ok := request.MCPMetadata[strings.TrimPrefix(field, prefix)]
+		return value, ok
+	}
+	return nil, false
+}

--- a/internal/handler/session/mcp_request_meta_test.go
+++ b/internal/handler/session/mcp_request_meta_test.go
@@ -1,0 +1,98 @@
+package session
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildMCPRequestMetaUsesExplicitAllowlist(t *testing.T) {
+	headers := http.Header{
+		"Authorization": {"Bearer request-token"},
+		"X-Trace-Id":    {"trace-a", "trace-b"},
+		"X-Unlisted":    {"must-not-leak"},
+	}
+	request := &CreateKnowledgeQARequest{
+		Query:            "where is the report?",
+		AgentEnabled:     true,
+		AgentID:          "agent-1",
+		Channel:          "api",
+		KnowledgeBaseIDs: []string{"kb-1", "kb-2"},
+		MCPMetadata: map[string]string{
+			"user_role": "auditor",
+			"secret":    "must-not-leak",
+		},
+	}
+	config := &types.MCPRequestMetaConfig{
+		Headers: []string{"authorization", "X-Trace-ID", "x-trace-id", "X-Missing"},
+		BodyFields: []string{
+			"channel", "agent_enabled", "knowledge_base_ids",
+			"mcp_metadata.user_role", "mcp_metadata.missing", "images",
+		},
+	}
+
+	got := buildMCPRequestMeta(headers, request, config, false)
+	require.NotNil(t, got)
+	assert.Equal(t, map[string]string{
+		"Authorization": "Bearer request-token",
+		"X-Trace-Id":    "trace-a, trace-b",
+	}, got.Headers)
+	assert.Equal(t, "api", got.Body["channel"])
+	assert.Equal(t, true, got.Body["agent_enabled"])
+	assert.Equal(t, []string{"kb-1", "kb-2"}, got.Body["knowledge_base_ids"])
+	assert.Equal(t, map[string]string{"user_role": "auditor"}, got.Body["mcp_metadata"])
+	assert.NotContains(t, got.Headers, "X-Unlisted")
+	assert.NotContains(t, got.Body["mcp_metadata"], "secret")
+}
+
+func TestBuildMCPRequestMetaSkipsSharedAgents(t *testing.T) {
+	got := buildMCPRequestMeta(
+		http.Header{"Authorization": {"Bearer caller-secret"}},
+		&CreateKnowledgeQARequest{MCPMetadata: map[string]string{"role": "admin"}},
+		&types.MCPRequestMetaConfig{
+			Headers:    []string{"Authorization"},
+			BodyFields: []string{"mcp_metadata.role"},
+		},
+		true,
+	)
+	assert.Nil(t, got)
+}
+
+func TestBuildMCPRequestMetaSkipsOversizedValues(t *testing.T) {
+	headers := http.Header{
+		"Authorization": {strings.Repeat("a", types.MCPRequestMetaMaxValueBytes+1)},
+		"X-Trace-Id":    {"trace-ok"},
+	}
+	request := &CreateKnowledgeQARequest{MCPMetadata: map[string]string{
+		"oversized": strings.Repeat("b", types.MCPRequestMetaMaxValueBytes+1),
+		"small":     "kept",
+	}}
+	config := &types.MCPRequestMetaConfig{
+		Headers: []string{"Authorization", "X-Trace-Id"},
+		BodyFields: []string{
+			"mcp_metadata.oversized", "mcp_metadata.small",
+		},
+	}
+
+	got := buildMCPRequestMeta(headers, request, config, false)
+	require.NotNil(t, got)
+	assert.Equal(t, map[string]string{"X-Trace-Id": "trace-ok"}, got.Headers)
+	assert.Equal(t, map[string]string{"small": "kept"}, got.Body["mcp_metadata"])
+}
+
+func TestBuildMCPRequestMetaReturnsNilWithoutSelectedValues(t *testing.T) {
+	got := buildMCPRequestMeta(
+		http.Header{},
+		&CreateKnowledgeQARequest{},
+		&types.MCPRequestMetaConfig{
+			Headers:    []string{"X-Missing"},
+			BodyFields: []string{"mcp_metadata.missing"},
+		},
+		false,
+	)
+	assert.Nil(t, got)
+}

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -46,6 +46,7 @@ type qaRequestContext struct {
 	tagScopes             []types.TagScope
 	tagIDs                []string
 	mcpServiceIDs         []string
+	mcpRequestMeta        *types.MCPRequestMeta
 	skillNames            []string
 	summaryModelID        string
 	webSearchEnabled      bool
@@ -86,6 +87,7 @@ func (rc *qaRequestContext) buildQARequest() *types.QARequest {
 		KnowledgeIDs:        rc.knowledgeIDs,
 		TagScopes:           rc.tagScopes,
 		MCPServiceIDs:       rc.mcpServiceIDs,
+		MCPRequestMeta:      rc.mcpRequestMeta,
 		SkillNames:          rc.skillNames,
 		ImageURLs:           imageURLs,
 		ImageDescription:    imageDescription,
@@ -114,6 +116,10 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 	var request CreateKnowledgeQARequest
 	if err := c.ShouldBindJSON(&request); err != nil {
 		logger.Error(ctx, "Failed to parse request data", err)
+		return nil, nil, errors.NewBadRequestError(err.Error())
+	}
+	if err := types.ValidateMCPRequestMetadata(request.MCPMetadata); err != nil {
+		logger.Warnf(ctx, "Rejected MCP request metadata: %v", err)
 		return nil, nil, errors.NewBadRequestError(err.Error())
 	}
 
@@ -145,7 +151,9 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 	}
 
 	// Log request details
-	if requestJSON, err := json.Marshal(request); err == nil {
+	requestForLog := request
+	requestForLog.MCPMetadata = nil // Values may contain credentials; never write them to logs.
+	if requestJSON, err := json.Marshal(requestForLog); err == nil {
 		logger.Infof(ctx, "[%s] Request: session_id=%s, request=%s",
 			logPrefix, sessionID, secutils.SanitizeForLog(secutils.CompactImageDataURLForLog(string(requestJSON))))
 	}
@@ -189,6 +197,14 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 			sharedAgentReadOnly = false
 		}
 	}
+
+	var mcpRequestMetaConfig *types.MCPRequestMetaConfig
+	if customAgent != nil {
+		mcpRequestMetaConfig = customAgent.Config.MCPRequestMeta
+	}
+	mcpRequestMeta := buildMCPRequestMeta(
+		c.Request.Header, &request, mcpRequestMetaConfig, sharedAgentReadOnly,
+	)
 
 	// Log merge results for debugging
 	logger.Infof(ctx, "[%s] @mention merge: request.KnowledgeBaseIDs=%v, request.MentionedItems=%d, merged kbIDs=%v, merged knowledgeIDs=%v",
@@ -374,6 +390,7 @@ func (h *Handler) parseQARequest(c *gin.Context, logPrefix string) (*qaRequestCo
 		tagScopes:             tagScopes,
 		tagIDs:                secutils.SanitizeForLogArray(tagIDs),
 		mcpServiceIDs:         secutils.SanitizeForLogArray(mcpServiceIDs),
+		mcpRequestMeta:        mcpRequestMeta,
 		skillNames:            secutils.SanitizeForLogArray(skillNames),
 		summaryModelID:        secutils.SanitizeForLog(request.SummaryModelID),
 		webSearchEnabled:      request.WebSearchEnabled,

--- a/internal/handler/session/types.go
+++ b/internal/handler/session/types.go
@@ -51,6 +51,7 @@ type CreateKnowledgeQARequest struct {
 	WebSearchEnabled      bool                         `json:"web_search_enabled"`                    // Whether web search is enabled for this request
 	SummaryModelID        string                       `json:"summary_model_id"`                      // Optional summary model ID for this request (overrides session default)
 	MCPServiceIDs         []string                     `json:"mcp_service_ids"`                       // Per-request MCP services selected via @mention
+	MCPMetadata           map[string]string            `json:"mcp_metadata,omitempty"`                // Caller-supplied scalar metadata; only Agent-allowlisted keys reach MCP _meta
 	SkillNames            []string                     `json:"skill_names"`                           // Per-request Skills selected via @mention
 	TagIDs                []string                     `json:"tag_ids"`                               // @mentioned tag IDs (display/debug; scoped via MentionedItems)
 	MentionedItems        []MentionedItemRequest       `json:"mentioned_items"`                       // @mentioned knowledge bases and files

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -36,7 +36,7 @@ type MCPClient interface {
 	ListResources(ctx context.Context) ([]*types.MCPResource, error)
 
 	// CallTool calls a tool on the MCP service
-	CallTool(ctx context.Context, name string, args map[string]interface{}) (*CallToolResult, error)
+	CallTool(ctx context.Context, name string, args map[string]interface{}, requestMeta *types.MCPRequestMeta) (*CallToolResult, error)
 
 	// ReadResource reads a resource from the MCP service
 	ReadResource(ctx context.Context, uri string) (*ReadResourceResult, error)
@@ -470,17 +470,17 @@ func (c *mcpGoClient) ListResources(ctx context.Context) ([]*types.MCPResource, 
 }
 
 // CallTool calls a tool on the MCP service
-func (c *mcpGoClient) CallTool(ctx context.Context, name string, args map[string]interface{}) (*CallToolResult, error) {
+func (c *mcpGoClient) CallTool(
+	ctx context.Context,
+	name string,
+	args map[string]interface{},
+	requestMeta *types.MCPRequestMeta,
+) (*CallToolResult, error) {
 	if !c.initialized {
 		return nil, ErrNotConnected
 	}
 
-	req := mcp.CallToolRequest{
-		Params: mcp.CallToolParams{
-			Name:      name,
-			Arguments: args,
-		},
-	}
+	req := newCallToolRequest(name, args, requestMeta)
 
 	result, err := oauthCall(ctx, c, func() (*mcp.CallToolResult, error) {
 		return c.client.CallTool(ctx, req)
@@ -511,6 +511,25 @@ func (c *mcpGoClient) CallTool(ctx context.Context, name string, args map[string
 		IsError: result.IsError,
 		Content: content,
 	}, nil
+}
+
+func newCallToolRequest(
+	name string,
+	args map[string]interface{},
+	requestMeta *types.MCPRequestMeta,
+) mcp.CallToolRequest {
+	req := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      name,
+			Arguments: args,
+		},
+	}
+	if requestMeta != nil && !requestMeta.Empty() {
+		req.Params.Meta = &mcp.Meta{AdditionalFields: map[string]any{
+			types.MCPRequestMetaNamespace: requestMeta,
+		}}
+	}
+	return req
 }
 
 // ReadResource reads a resource from the MCP service

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -8,6 +9,43 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/mark3labs/mcp-go/client/transport"
 )
+
+func TestNewCallToolRequestMetadata(t *testing.T) {
+	t.Run("serializes request values under a namespaced _meta key", func(t *testing.T) {
+		req := newCallToolRequest("lookup", map[string]interface{}{"id": "42"}, &types.MCPRequestMeta{
+			Headers: map[string]string{"Authorization": "Bearer token"},
+			Body:    map[string]any{"channel": "api"},
+		})
+
+		data, err := json.Marshal(req.Params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatal(err)
+		}
+		meta, ok := decoded["_meta"].(map[string]any)
+		if !ok {
+			t.Fatalf("_meta missing from %s", data)
+		}
+		requestMeta, ok := meta[types.MCPRequestMetaNamespace].(map[string]any)
+		if !ok {
+			t.Fatalf("namespace %q missing from %s", types.MCPRequestMetaNamespace, data)
+		}
+		headers := requestMeta["headers"].(map[string]any)
+		if headers["Authorization"] != "Bearer token" {
+			t.Fatalf("Authorization = %v", headers["Authorization"])
+		}
+	})
+
+	t.Run("omits _meta when no values were selected", func(t *testing.T) {
+		req := newCallToolRequest("lookup", nil, &types.MCPRequestMeta{})
+		if req.Params.Meta != nil {
+			t.Fatal("empty request metadata should be omitted")
+		}
+	})
+}
 
 func TestAsOAuthRequired(t *testing.T) {
 	t.Run("nil error", func(t *testing.T) {

--- a/internal/types/agent.go
+++ b/internal/types/agent.go
@@ -114,6 +114,9 @@ type AgentConfig struct {
 	// Per-request @mention pins (runtime only; injected as <must_use> in the user message).
 	PinnedMCPServiceIDs []string `json:"-"`
 	PinnedSkillNames    []string `json:"-"`
+	// MCPRequestMeta is captured once by the Agent HTTP handler and passed to
+	// every MCP tool registered for this run. It is never persisted.
+	MCPRequestMeta *MCPRequestMeta `json:"-"`
 	// SharedAgentReadOnly prevents a shared agent from mutating resources in
 	// its source workspace. It is set from the verified share relation, never
 	// inferred from a client-provided tenant ID.

--- a/internal/types/custom_agent.go
+++ b/internal/types/custom_agent.go
@@ -147,6 +147,9 @@ type CustomAgentConfig struct {
 	// MCPAuthWaitTimeout is how many seconds to wait for in-conversation OAuth
 	// authorization before skipping. <=0 uses the gate's configured timeout.
 	MCPAuthWaitTimeout int `yaml:"mcp_auth_wait_timeout,omitempty" json:"mcp_auth_wait_timeout,omitempty"`
+	// MCPRequestMeta explicitly allowlists HTTP request values copied into MCP
+	// tool-call _meta. The configuration stores selectors only, never values.
+	MCPRequestMeta *MCPRequestMetaConfig `yaml:"mcp_request_meta,omitempty" json:"mcp_request_meta,omitempty"`
 
 	// ===== Skills Settings (only for smart-reasoning mode) =====
 	// Skills selection mode: "all" = all preloaded skills, "selected" = specific skills, "none" = no skills

--- a/internal/types/mcp_request_meta.go
+++ b/internal/types/mcp_request_meta.go
@@ -1,0 +1,164 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// MCPRequestMetaNamespace is the extension key placed inside MCP's _meta object.
+	// A namespaced key prevents collisions with protocol-defined metadata.
+	MCPRequestMetaNamespace = "io.weknora/request"
+
+	// MCPRequestMetaMaxSelectors bounds persisted agent configuration and the
+	// amount of caller-controlled data considered for one MCP request.
+	MCPRequestMetaMaxSelectors  = 16
+	MCPRequestMetaMaxValueBytes = 8 * 1024
+	MCPRequestMetaMaxTotalBytes = 32 * 1024
+)
+
+// MCPRequestMetaConfig is an explicit allowlist for copying selected values
+// from an Agent HTTP request into MCP tool-call metadata. Only names are stored
+// on the agent; request values remain scoped to a single Agent run.
+type MCPRequestMetaConfig struct {
+	Headers    []string `yaml:"headers,omitempty" json:"headers,omitempty"`
+	BodyFields []string `yaml:"body_fields,omitempty" json:"body_fields,omitempty"`
+}
+
+// Validate rejects configurations that could create ambiguous or unbounded
+// forwarding rules. Runtime extraction applies the same limits defensively for
+// legacy rows and built-in YAML configurations.
+func (c *MCPRequestMetaConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	if len(c.Headers) > MCPRequestMetaMaxSelectors {
+		return fmt.Errorf("mcp request metadata supports at most %d header names", MCPRequestMetaMaxSelectors)
+	}
+	if len(c.BodyFields) > MCPRequestMetaMaxSelectors {
+		return fmt.Errorf("mcp request metadata supports at most %d body fields", MCPRequestMetaMaxSelectors)
+	}
+
+	for _, name := range c.Headers {
+		if !validHTTPHeaderName(strings.TrimSpace(name)) {
+			return fmt.Errorf("invalid MCP request metadata header name %q", name)
+		}
+	}
+	for _, field := range c.BodyFields {
+		field = strings.TrimSpace(field)
+		if !validMCPRequestBodyField(field) {
+			return fmt.Errorf("unsupported MCP request metadata body field %q", field)
+		}
+	}
+	return nil
+}
+
+// MCPRequestMeta contains the values captured for one Agent request. It is a
+// runtime-only value and must never be persisted or logged.
+type MCPRequestMeta struct {
+	Headers map[string]string `json:"headers,omitempty"`
+	Body    map[string]any    `json:"body,omitempty"`
+}
+
+func (m *MCPRequestMeta) Empty() bool {
+	return m == nil || (len(m.Headers) == 0 && len(m.Body) == 0)
+}
+
+func validHTTPHeaderName(name string) bool {
+	if name == "" || len(name) > 128 {
+		return false
+	}
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || strings.ContainsRune("!#$%&'*+-.^_`|~", r) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// IsAllowedMCPRequestHeader reports whether name is a syntactically valid HTTP
+// field name accepted by the MCP request-metadata allowlist.
+func IsAllowedMCPRequestHeader(name string) bool {
+	return validHTTPHeaderName(strings.TrimSpace(name))
+}
+
+var mcpRequestBodyScalarFields = map[string]struct{}{
+	"query":                  {},
+	"agent_enabled":          {},
+	"agent_id":               {},
+	"agent_source_tenant_id": {},
+	"web_search_enabled":     {},
+	"summary_model_id":       {},
+	"disable_title":          {},
+	"channel":                {},
+}
+
+var mcpRequestBodyListFields = map[string]struct{}{
+	"knowledge_base_ids": {},
+	"knowledge_ids":      {},
+	"mcp_service_ids":    {},
+	"skill_names":        {},
+	"tag_ids":            {},
+}
+
+// IsAllowedMCPRequestBodyField reports whether a selector names a bounded,
+// non-binary field in CreateKnowledgeQARequest. Custom API metadata lives under
+// mcp_metadata.<key>; images and attachments are deliberately not selectable.
+func IsAllowedMCPRequestBodyField(field string) bool {
+	return validMCPRequestBodyField(strings.TrimSpace(field))
+}
+
+// ValidateMCPRequestMetadata validates the caller-supplied scalar metadata
+// object before it is considered for forwarding to an MCP server.
+func ValidateMCPRequestMetadata(metadata map[string]string) error {
+	if len(metadata) > MCPRequestMetaMaxSelectors {
+		return fmt.Errorf("mcp request metadata supports at most %d values", MCPRequestMetaMaxSelectors)
+	}
+
+	totalBytes := 0
+	for key, value := range metadata {
+		if !validMCPRequestMetadataKey(key) {
+			return fmt.Errorf("invalid MCP request metadata key %q", key)
+		}
+		if len(value) > MCPRequestMetaMaxValueBytes {
+			return fmt.Errorf("MCP request metadata value for %q exceeds %d bytes", key, MCPRequestMetaMaxValueBytes)
+		}
+		entryBytes := len(key) + len(value)
+		if totalBytes+entryBytes > MCPRequestMetaMaxTotalBytes {
+			return fmt.Errorf("MCP request metadata exceeds %d bytes", MCPRequestMetaMaxTotalBytes)
+		}
+		totalBytes += entryBytes
+	}
+	return nil
+}
+
+func validMCPRequestBodyField(field string) bool {
+	if _, ok := mcpRequestBodyScalarFields[field]; ok {
+		return true
+	}
+	if _, ok := mcpRequestBodyListFields[field]; ok {
+		return true
+	}
+	const prefix = "mcp_metadata."
+	if !strings.HasPrefix(field, prefix) {
+		return false
+	}
+	key := strings.TrimPrefix(field, prefix)
+	return validMCPRequestMetadataKey(key)
+}
+
+func validMCPRequestMetadataKey(key string) bool {
+	if key == "" || len(key) > 128 {
+		return false
+	}
+	for _, r := range key {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '_' || r == '-' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/types/mcp_request_meta_test.go
+++ b/internal/types/mcp_request_meta_test.go
@@ -1,0 +1,129 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestMCPRequestMetaConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *MCPRequestMetaConfig
+		wantErr bool
+	}{
+		{name: "nil", config: nil},
+		{
+			name: "valid allowlist",
+			config: &MCPRequestMetaConfig{
+				Headers:    []string{"Authorization", "X-Trace-Id"},
+				BodyFields: []string{"channel", "knowledge_base_ids", "mcp_metadata.user_role"},
+			},
+		},
+		{
+			name:    "reject header injection",
+			config:  &MCPRequestMetaConfig{Headers: []string{"X-Trace\r\nX-Evil"}},
+			wantErr: true,
+		},
+		{
+			name:    "reject binary body field",
+			config:  &MCPRequestMetaConfig{BodyFields: []string{"attachment_uploads"}},
+			wantErr: true,
+		},
+		{
+			name:    "reject malformed custom metadata selector",
+			config:  &MCPRequestMetaConfig{BodyFields: []string{"mcp_metadata.user role"}},
+			wantErr: true,
+		},
+		{
+			name: "reject too many headers",
+			config: &MCPRequestMetaConfig{
+				Headers: make([]string, MCPRequestMetaMaxSelectors+1),
+			},
+			wantErr: true,
+		},
+		{
+			name: "reject oversized metadata key",
+			config: &MCPRequestMetaConfig{
+				BodyFields: []string{"mcp_metadata." + strings.Repeat("x", 129)},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMCPRequestMetaEmpty(t *testing.T) {
+	var nilMeta *MCPRequestMeta
+	if !nilMeta.Empty() {
+		t.Fatal("nil metadata should be empty")
+	}
+	if !(&MCPRequestMeta{}).Empty() {
+		t.Fatal("zero metadata should be empty")
+	}
+	if (&MCPRequestMeta{Headers: map[string]string{"X-Trace-Id": "abc"}}).Empty() {
+		t.Fatal("metadata with a header should not be empty")
+	}
+}
+
+func TestValidateMCPRequestMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		wantErr  bool
+	}{
+		{
+			name:     "valid scalar values",
+			metadata: map[string]string{"user_role": "auditor", "trace.id": "trace-1"},
+		},
+		{
+			name: "reject too many values",
+			metadata: func() map[string]string {
+				values := make(map[string]string, MCPRequestMetaMaxSelectors+1)
+				for i := 0; i <= MCPRequestMetaMaxSelectors; i++ {
+					values[fmt.Sprintf("key_%d", i)] = "value"
+				}
+				return values
+			}(),
+			wantErr: true,
+		},
+		{
+			name:     "reject invalid key",
+			metadata: map[string]string{"user role": "auditor"},
+			wantErr:  true,
+		},
+		{
+			name:     "reject oversized value",
+			metadata: map[string]string{"token": strings.Repeat("x", MCPRequestMetaMaxValueBytes+1)},
+			wantErr:  true,
+		},
+		{
+			name: "reject oversized aggregate",
+			metadata: map[string]string{
+				"one":   strings.Repeat("x", 7000),
+				"two":   strings.Repeat("x", 7000),
+				"three": strings.Repeat("x", 7000),
+				"four":  strings.Repeat("x", 7000),
+				"five":  strings.Repeat("x", 7000),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMCPRequestMetadata(tt.metadata)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateMCPRequestMetadata() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/types/qa_request.go
+++ b/internal/types/qa_request.go
@@ -14,6 +14,7 @@ type QARequest struct {
 	KnowledgeIDs        []string           // Specific knowledge (file) IDs to search
 	TagScopes           []TagScope         // Tag-constrained KB scopes from @mentions
 	MCPServiceIDs       []string           // Per-request MCP service IDs from @mentions
+	MCPRequestMeta      *MCPRequestMeta    // Selected HTTP request values for this Agent run; runtime-only and never logged
 	SkillNames          []string           // Per-request preloaded skill names from @mentions
 	ImageURLs           []string           // Image URLs for multimodal input
 	ImageDescription    string             // VLM-generated image description (fallback for non-vision models)


### PR DESCRIPTION
## Summary
- add explicit Agent allowlists for request headers and bounded body fields
- forward selected values in a namespaced MCP tools/call _meta field
- validate caller-supplied scalar metadata and keep it out of request logs
- prevent shared read-only Agents from forwarding caller credentials
- update the Agent UI, official Go client, API docs, and Swagger schema

Closes #1185

## Validation
- go test ./client
- go test ./docs
- go test ./internal/types/mcp_request_meta.go ./internal/types/mcp_request_meta_test.go -v
- npm --prefix frontend run type-check
- npm --prefix frontend run build
- npm --prefix packages/dsh-weknora run typecheck
- npm --prefix packages/dsh-weknora run build
- git diff --check

The broader backend package test selection could not run in this Windows environment because the local Go cgo toolchain cannot complete its GCC probe; the affected existing pg_query dependency requires cgo.