### PR TITLE
fix(frontend): include nginx-api-proxy.conf in the UI image build

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,4 +1,5 @@
 *
 !dist
 !nginx.conf
+!nginx-api-proxy.conf
 !docker-entrypoint.sh


### PR DESCRIPTION
## Summary
- `frontend/Dockerfile` copies `nginx-api-proxy.conf` into the image, but `.dockerignore` still used `*` plus a whitelist that omitted that file.
- Docker Buildx therefore failed `build-ui` with `"/nginx-api-proxy.conf": not found` while computing the cache key.
- Allow the snippet through the frontend image context so the weknora-ui image can build again.

## Test plan
- [x] `scripts/verify_frontend_pr.sh` (`npm test`, `type-check`, `build`) via pre-push
- [ ] Confirm `build-ui` in **Build and Push Docker Image** succeeds after merge (COPY of `nginx-api-proxy.conf` no longer missing from context)