### PR TITLE
fix(docreader): kill timed-out converter process groups

### DIFF
--- a/docreader/parser/doc_parser.py
+++ b/docreader/parser/doc_parser.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import signal
 import subprocess
 import time
 import uuid
@@ -75,18 +76,49 @@ class SandboxExecutor:
         if self.proxy:
             logger.info(f"Using proxy: {self.proxy}")
 
+        is_posix = os.name == "posix"
         process = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=env,
+            # On POSIX, start a fresh group so a timed-out command can be
+            # terminated together with children it spawned (e.g. soffice.bin).
+            start_new_session=is_posix,
         )
+        # On POSIX start_new_session makes the direct child the group leader, so
+        # retain this ID even if the direct child exits before cleanup starts.
+        process_group_id = process.pid if is_posix else None
 
         try:
             stdout, stderr = process.communicate(timeout=self.default_timeout)
             return stdout, stderr, process.returncode
         except subprocess.TimeoutExpired:
-            process.kill()
+            # Kill the whole POSIX process group, not just the direct child, and
+            # reap stdout/stderr afterwards so neither orphans nor zombies survive.
+            if process_group_id is None:
+                process.kill()
+            else:
+                try:
+                    os.killpg(process_group_id, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass  # process group already gone
+                grace_period = 0.5
+                grace_deadline = time.monotonic() + grace_period
+                try:
+                    process.communicate(timeout=grace_period)
+                except subprocess.TimeoutExpired:
+                    pass
+                remaining_grace_period = grace_deadline - time.monotonic()
+                if remaining_grace_period > 0:
+                    time.sleep(remaining_grace_period)
+                # The direct child can exit after SIGTERM while a descendant
+                # ignores it. Always finish the grace period with SIGKILL.
+                try:
+                    os.killpg(process_group_id, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+            process.communicate()
             raise RuntimeError(
                 f"Command execution timeout after {self.default_timeout} seconds"
             )

--- a/docreader/tests/test_sandbox_executor.py
+++ b/docreader/tests/test_sandbox_executor.py
@@ -1,0 +1,188 @@
+import os
+import shlex
+import signal
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import ANY, Mock, call, patch
+
+from docreader.parser.doc_parser import SandboxExecutor
+
+
+@unittest.skipUnless(os.name == "posix", "process-group cleanup is POSIX-specific")
+class TestSandboxExecutorProcessGroup(unittest.TestCase):
+    def test_timeout_kills_whole_process_group(self):
+        """A timed-out command must terminate its parent and descendants."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            child_pid_file = Path(temp_dir) / "child.pid"
+            command = [
+                "sh",
+                "-c",
+                f"sleep 30 & echo $! > {shlex.quote(str(child_pid_file))}; wait",
+            ]
+            executor = SandboxExecutor(default_timeout=1)
+
+            with self.assertRaises(RuntimeError):
+                executor.execute_in_sandbox(command)
+
+            child_pid = int(child_pid_file.read_text().strip())
+            deadline = time.monotonic() + 1
+            while True:
+                try:
+                    os.kill(child_pid, 0)
+                except ProcessLookupError:
+                    break
+                if time.monotonic() >= deadline:
+                    self.fail("timed-out command left a child process running")
+                time.sleep(0.01)
+
+
+class TestSandboxExecutorMock(unittest.TestCase):
+    @unittest.skipUnless(os.name == "posix", "POSIX signals are required")
+    def test_posix_timeout_terminates_group_and_reaps_process(self):
+        process = Mock(pid=4321)
+        process.communicate.side_effect = [
+            subprocess.TimeoutExpired(["soffice"], 1),
+            subprocess.TimeoutExpired(["soffice"], 0.5),
+            (b"", b""),
+        ]
+
+        with (
+            patch("docreader.parser.doc_parser.os.name", "posix"),
+            patch(
+                "docreader.parser.doc_parser.subprocess.Popen", return_value=process
+            ) as popen,
+            patch("docreader.parser.doc_parser.os.killpg") as killpg,
+            patch(
+                "docreader.parser.doc_parser.time.monotonic", side_effect=[0, 0.5]
+            ),
+            patch("docreader.parser.doc_parser.time.sleep") as sleep,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "timeout after 1"):
+                SandboxExecutor(default_timeout=1)._execute_with_proxy(["soffice"])
+
+        popen.assert_called_once_with(
+            ["soffice"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=ANY,
+            start_new_session=True,
+        )
+        killpg.assert_has_calls(
+            [
+                call(4321, signal.SIGTERM),
+                call(4321, signal.SIGKILL),
+            ]
+        )
+        sleep.assert_not_called()
+        self.assertEqual(
+            process.communicate.call_args_list,
+            [
+                call(timeout=1),
+                call(timeout=0.5),
+                call(),
+            ],
+        )
+
+    @unittest.skipUnless(os.name == "posix", "POSIX signals are required")
+    def test_posix_timeout_waits_full_grace_period_when_child_exits_early(self):
+        process = Mock(pid=4321)
+        process.communicate.side_effect = [
+            subprocess.TimeoutExpired(["soffice"], 1),
+            (b"", b""),
+            (b"", b""),
+        ]
+
+        with (
+            patch("docreader.parser.doc_parser.os.name", "posix"),
+            patch(
+                "docreader.parser.doc_parser.subprocess.Popen", return_value=process
+            ),
+            patch("docreader.parser.doc_parser.os.killpg") as killpg,
+            patch(
+                "docreader.parser.doc_parser.time.monotonic", side_effect=[10, 10.2]
+            ),
+            patch("docreader.parser.doc_parser.time.sleep") as sleep,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "timeout after 1"):
+                SandboxExecutor(default_timeout=1)._execute_with_proxy(["soffice"])
+
+        self.assertAlmostEqual(sleep.call_args.args[0], 0.3)
+        killpg.assert_has_calls(
+            [
+                call(4321, signal.SIGTERM),
+                call(4321, signal.SIGKILL),
+            ]
+        )
+        self.assertEqual(
+            process.communicate.call_args_list,
+            [
+                call(timeout=1),
+                call(timeout=0.5),
+                call(),
+            ],
+        )
+
+    @unittest.skipUnless(os.name == "posix", "POSIX signals are required")
+    def test_posix_timeout_reaps_when_group_already_exited(self):
+        process = Mock(pid=4321)
+        process.communicate.side_effect = [
+            subprocess.TimeoutExpired(["soffice"], 1),
+            subprocess.TimeoutExpired(["soffice"], 0.5),
+            (b"", b""),
+        ]
+
+        with (
+            patch("docreader.parser.doc_parser.os.name", "posix"),
+            patch(
+                "docreader.parser.doc_parser.subprocess.Popen", return_value=process
+            ),
+            patch(
+                "docreader.parser.doc_parser.os.killpg",
+                side_effect=ProcessLookupError,
+            ) as killpg,
+            patch(
+                "docreader.parser.doc_parser.time.monotonic", side_effect=[0, 0.5]
+            ),
+            patch("docreader.parser.doc_parser.time.sleep") as sleep,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "timeout after 1"):
+                SandboxExecutor(default_timeout=1)._execute_with_proxy(["soffice"])
+
+        self.assertEqual(killpg.call_count, 2)
+        sleep.assert_not_called()
+        self.assertEqual(process.communicate.call_args_list[-1], call())
+
+    def test_non_posix_timeout_kills_direct_child_and_reaps_process(self):
+        process = Mock(pid=4321)
+        process.communicate.side_effect = [
+            subprocess.TimeoutExpired(["soffice"], 1),
+            (b"", b""),
+        ]
+
+        with (
+            patch("docreader.parser.doc_parser.os.name", "nt"),
+            patch(
+                "docreader.parser.doc_parser.subprocess.Popen", return_value=process
+            ) as popen,
+            patch("docreader.parser.doc_parser.os.killpg", create=True) as killpg,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "timeout after 1"):
+                SandboxExecutor(default_timeout=1)._execute_with_proxy(["soffice"])
+
+        popen.assert_called_once_with(
+            ["soffice"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=ANY,
+            start_new_session=False,
+        )
+        process.kill.assert_called_once_with()
+        killpg.assert_not_called()
+        self.assertEqual(process.communicate.call_args_list, [call(timeout=1), call()])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# fix(docreader): kill timed-out converter process groups

## Description

`SandboxExecutor._execute_with_proxy` killed only the direct `Popen` child when
a command timed out. On POSIX, DOC-to-DOCX conversion can involve descendant
LibreOffice processes, which are not covered by a direct-child kill.

This change starts commands in a new POSIX session and, on timeout, terminates
the associated process group with `SIGTERM`, waits briefly, then attempts
`SIGKILL` for remaining members. It reaps the direct child's stdout/stderr
before raising the timeout error. Non-POSIX platforms retain the direct-child
`kill()` fallback.

Related but distinct: #1566. This PR specifically fixes timeout cleanup for the
subprocess group created by the DOC-to-DOCX converter.

No public API, schema, or user-facing documentation changes are included.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2966

## Changes

- Create a new session for sandboxed commands on POSIX.
- Retain the direct child PID as the POSIX process-group ID.
- On timeout, send `SIGTERM`, wait 0.5 seconds, then attempt `SIGKILL` for the
  process group and reap the direct child.
- Preserve direct-child `kill()` behavior on non-POSIX platforms.
- Add a POSIX-only descendant-cleanup regression and mock tests for POSIX
  signal ordering, disappeared groups, and the non-POSIX fallback.

## Testing

Passing CI-equivalent focused checks on the prepared branch:

```text
uv sync --project docreader --locked --no-dev --python 3.10.18
  PASS

uv run --project docreader --python 3.10.18 python -m compileall -q docreader
  PASS

uv run --project docreader --python 3.10.18 \
  python -m unittest docreader.tests.test_sandbox_executor -v
  PASS (4 tests)

go test ./docreader/proto
  PASS

git diff --check 3d40ee0affe91bc3c4f590a120b0942cd5f588ad...HEAD
  PASS
```

The Python 3.10.18 full DocReader discovery was attempted. It ran 196 tests;
12 were skipped because optional fixtures or tools are absent, and two existing
SSRF tests failed because this host resolves `example.com` to `198.18.0.105`,
which the SSRF guard correctly classifies as restricted. The failure is outside
this PR's changed files:

```text
test_allows_public_https: hostname example.com resolves to restricted IP
198.18.0.105: private IP address
test_blocks_invalid_port: expected "invalid port" but received the same
restricted-address result
```

The final PR must be rebased onto the submission-time `origin/main`, then rerun
with the final base. The full gRPC client/proto integration layer was not run:
it requires Playwright WebKit and a live DocReader server; the CI workflow must
cover that layer before merge.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes after rebasing to the final base
- [x] Changed source files are formatted
- [x] Targeted tests for the changed component pass
- [ ] Diff-scoped lint passes where applicable
- [x] Full DocReader discovery was attempted and the unrelated DNS/SSRF failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A — process-management change in DocReader; no user-visible UI.
