### PR TITLE
fix(config): honor WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS env over…

### DIFF
--- a/internal/config/auth_legacy_env_test.go
+++ b/internal/config/auth_legacy_env_test.go
@@ -30,6 +30,7 @@ func TestApplyAuthAndTenantDefaults_DisableRegistrationDrivesRegistrationMode(t 
 			t.Setenv("DISABLE_REGISTRATION", tc.disable)
 			// Other tenant env vars must not leak between cases.
 			t.Setenv("WEKNORA_TENANT_ENABLE_RBAC", "")
+			t.Setenv("WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS", "")
 			t.Setenv("WEKNORA_TENANT_MAX_OWNED_PER_USER", "")
 			t.Setenv("WEKNORA_TENANT_SELF_SERVICE_CREATION_ENABLED", "")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -859,6 +859,20 @@ func applyAuthAndTenantDefaults(cfg *Config) {
 		cfg.Tenant.EnableRBAC = &on
 	}
 
+	// EnableCrossTenantAccess gates the cluster-wide cross-workspace routes
+	// (middleware.RequireCrossTenantAccess). It is documented in .env.example
+	// and echoed in the startup log line, but historically only the config.yaml
+	// `enable_cross_tenant_access` value was honoured — the env override was
+	// never actually applied, so operators who set
+	// WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS=true saw no effect and
+	// cross-tenant routes kept returning "Cross-workspace access is disabled".
+	// Mirror the WEKNORA_TENANT_ENABLE_RBAC pattern above: an explicitly set
+	// env value always wins (true or false) over config.yaml without a
+	// redeploy; when unset, the config.yaml value is preserved.
+	if value := strings.TrimSpace(os.Getenv("WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS")); value != "" {
+		cfg.Tenant.EnableCrossTenantAccess = strings.EqualFold(value, "true")
+	}
+
 	if value := strings.TrimSpace(os.Getenv("WEKNORA_TENANT_SELF_SERVICE_CREATION_ENABLED")); value != "" {
 		if enabled, err := strconv.ParseBool(value); err == nil {
 			cfg.Tenant.SelfServiceCreationEnabled = &enabled

--- a/internal/config/cross_tenant_env_test.go
+++ b/internal/config/cross_tenant_env_test.go
@@ -1,0 +1,65 @@
+package config
+
+import "testing"
+
+// TestApplyAuthAndTenantDefaults_CrossTenantAccessEnvOverride pins down the
+// env-vs-YAML contract for WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS.
+//
+// Previously the variable was documented in .env.example and echoed in the
+// startup log, but applyAuthAndTenantDefaults never read it — only the
+// config.yaml `tenant.enable_cross_tenant_access` value took effect. Operators
+// who set WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS=true saw no change and
+// middleware.RequireCrossTenantAccess kept returning 1002 "Cross-workspace
+// access is disabled". This test locks in the "env always wins when set"
+// contract that other tenant env vars (enable_rbac, max_owned_per_user, ...)
+// already follow.
+func TestApplyAuthAndTenantDefaults_CrossTenantAccessEnvOverride(t *testing.T) {
+	cases := []struct {
+		name     string
+		env      string // value for WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS ("" == unset)
+		yaml     bool   // value pre-set on cfg.Tenant.EnableCrossTenantAccess
+		expected bool
+	}{
+		{"unset preserves YAML true", "", true, true},
+		{"unset preserves YAML false", "", false, false},
+		{"true overrides YAML false", "true", false, true},
+		{"TRUE overrides case-insensitively", "TRUE", false, true},
+		{"false overrides YAML true", "false", true, false},
+		{"whitespace is trimmed before parsing", " true ", false, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS", tc.env)
+			// Other tenant env vars must not leak between cases.
+			t.Setenv("WEKNORA_TENANT_ENABLE_RBAC", "")
+			t.Setenv("WEKNORA_TENANT_MAX_OWNED_PER_USER", "")
+			t.Setenv("WEKNORA_TENANT_SELF_SERVICE_CREATION_ENABLED", "")
+			t.Setenv("DISABLE_REGISTRATION", "")
+
+			cfg := &Config{Tenant: &TenantConfig{EnableCrossTenantAccess: tc.yaml}}
+			applyAuthAndTenantDefaults(cfg)
+
+			if cfg.Tenant.EnableCrossTenantAccess != tc.expected {
+				t.Fatalf(
+					"EnableCrossTenantAccess = %v, want %v (env=%q yaml=%v)",
+					cfg.Tenant.EnableCrossTenantAccess, tc.expected, tc.env, tc.yaml,
+				)
+			}
+		})
+	}
+}
+
+// TestApplyAuthAndTenantDefaults_CrossTenantAccessKeepsWorkingWithNilTenant
+// guards against a nil *TenantConfig panic: applyAuthAndTenantDefaults
+// allocates the section itself, so callers with a bare &Config{} are safe.
+func TestApplyAuthAndTenantDefaults_CrossTenantAccessKeepsWorkingWithNilTenant(t *testing.T) {
+	t.Setenv("WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS", "true")
+
+	cfg := &Config{}
+	applyAuthAndTenantDefaults(cfg)
+
+	if cfg.Tenant == nil || !cfg.Tenant.EnableCrossTenantAccess {
+		t.Fatalf("env override should allocate Tenant and set EnableCrossTenantAccess=true, got %+v", cfg.Tenant)
+	}
+}


### PR DESCRIPTION
…ride

The env var WEKNORA_TENANT_ENABLE_CROSS_TENANT_ACCESS was documented in .env.example and echoed in the startup log line, but applyAuthAndTenantDefaults never read it. Only the config.yaml `tenant.enable_cross_tenant_access` value took effect, so operators who set the env var to enable cluster-wide cross-workspace access saw no change and RequireCrossTenantAccess kept returning 1002 "Cross-workspace access is disabled".

Mirror the existing WEKNORA_TENANT_ENABLE_RBAC override: an explicitly set env value always wins (true or false) over config.yaml, and when unset the config.yaml value is preserved. Adds a dedicated table test for the env-vs-YAML contract.

<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

## Type of Change
<!-- Check applicable items -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->

## Checklist
- [ ] `git diff --check origin/main...HEAD` passes
- [ ] Changed source files are formatted
- [ ] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [ ] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
