### PR TITLE
fix(ui): prevent invite registration form header overlap

### DIFF
--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -301,7 +301,8 @@
 
               <t-form-item :label="$t('auth.confirmPassword')" name="confirmPassword">
                 <t-input v-model="registerData.confirmPassword" :placeholder="$t('auth.confirmPasswordPlaceholder')"
-                  type="password" autocomplete="new-password" size="large" :disabled="loading" @enter="handleRegister" />
+                  type="password" autocomplete="new-password" size="large" :disabled="loading"
+                  @enter="handleRegister" />
               </t-form-item>
 
               <t-button type="submit" theme="primary" size="large" block :loading="loading" class="submit-button">
@@ -1182,7 +1183,7 @@ onMounted(async () => {
   display: flex;
   align-items: flex-end;
   justify-content: center;
-  padding: 40px 50px 100px 30px;
+  padding: 112px 50px 100px 30px;
   box-sizing: border-box;
   position: relative;
 }


### PR DESCRIPTION
## Description

修复邀请链接注册页面中，“创建账户”卡片在较矮视口下遮挡顶部“官方网站”按钮的问题。

通过增加表单区域的顶部安全间距，避免较高的邀请注册表单侵入顶部导航区域。

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Testing

- 检查邀请链接注册页面布局
- 确认“创建账户”卡片不再遮挡“官方网站”按钮
- `git diff --check origin/main...HEAD` 通过

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [ ] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

问题：
<img width="1891" height="1028" alt="image" src="https://github.com/user-attachments/assets/b33627e7-3dfe-4279-8ce0-86251c3507d3" />

修复后：

<img width="1920" height="1039" alt="image" src="https://github.com/user-attachments/assets/c3c8d93e-1f22-4215-a031-f124b4d122c6" />
