### PR TITLE
fix: sanitize qdrant string payloads

### DIFF
--- a/internal/application/repository/retriever/qdrant/repository.go
+++ b/internal/application/repository/retriever/qdrant/repository.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/Tencent/WeKnora/internal/common"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
@@ -401,7 +402,7 @@ func (q *qdrantRepository) BatchUpdateChunkEnabledStatus(ctx context.Context, ch
 		if len(enabledChunkIDs) > 0 {
 			_, err := q.client.SetPayload(ctx, &qdrant.SetPayloadPoints{
 				CollectionName: collectionName,
-				Payload:        qdrant.NewValueMap(map[string]any{fieldIsEnabled: true}),
+				Payload:        newQdrantValueMap(map[string]any{fieldIsEnabled: true}),
 				PointsSelector: qdrant.NewPointsSelectorFilter(&qdrant.Filter{
 					Must: []*qdrant.Condition{
 						qdrant.NewMatchKeywords(fieldChunkID, enabledChunkIDs...),
@@ -417,7 +418,7 @@ func (q *qdrantRepository) BatchUpdateChunkEnabledStatus(ctx context.Context, ch
 		if len(disabledChunkIDs) > 0 {
 			_, err := q.client.SetPayload(ctx, &qdrant.SetPayloadPoints{
 				CollectionName: collectionName,
-				Payload:        qdrant.NewValueMap(map[string]any{fieldIsEnabled: false}),
+				Payload:        newQdrantValueMap(map[string]any{fieldIsEnabled: false}),
 				PointsSelector: qdrant.NewPointsSelectorFilter(&qdrant.Filter{
 					Must: []*qdrant.Condition{
 						qdrant.NewMatchKeywords(fieldChunkID, disabledChunkIDs...),
@@ -469,7 +470,7 @@ func (q *qdrantRepository) BatchUpdateChunkTagID(ctx context.Context, chunkTagMa
 		for tagID, chunkIDs := range tagGroups {
 			_, err := q.client.SetPayload(ctx, &qdrant.SetPayloadPoints{
 				CollectionName: collectionName,
-				Payload:        qdrant.NewValueMap(map[string]any{fieldTagID: tagID}),
+				Payload:        newQdrantValueMap(map[string]any{fieldTagID: tagID}),
 				PointsSelector: qdrant.NewPointsSelectorFilter(&qdrant.Filter{
 					Must: []*qdrant.Condition{
 						qdrant.NewMatchKeywords(fieldChunkID, chunkIDs...),
@@ -808,7 +809,7 @@ func (q *qdrantRepository) CopyIndices(ctx context.Context,
 			if v, ok := payload[fieldIsEnabled]; ok {
 				isEnabled = v.GetBoolValue()
 			}
-			newPayload := qdrant.NewValueMap(map[string]any{
+			newPayload := newQdrantValueMap(map[string]any{
 				fieldContent:         payload[fieldContent].GetStringValue(),
 				fieldSourceID:        targetSourceID,
 				fieldSourceType:      payload[fieldSourceType].GetIntegerValue(),
@@ -879,7 +880,18 @@ func createPayload(embedding *QdrantVectorEmbedding) map[string]*qdrant.Value {
 		fieldTagID:           embedding.TagID,
 		fieldIsEnabled:       embedding.IsEnabled,
 	}
-	return qdrant.NewValueMap(payload)
+	return newQdrantValueMap(payload)
+}
+
+func newQdrantValueMap(payload map[string]any) map[string]*qdrant.Value {
+	sanitizedPayload := make(map[string]any, len(payload))
+	for key, value := range payload {
+		if stringValue, ok := value.(string); ok {
+			value = common.CleanInvalidUTF8(stringValue)
+		}
+		sanitizedPayload[key] = value
+	}
+	return qdrant.NewValueMap(sanitizedPayload)
 }
 
 func buildRetrieveResult(results []*types.IndexWithScore, retrieverType types.RetrieverType) []*types.RetrieveResult {

--- a/internal/application/repository/retriever/qdrant/repository.go
+++ b/internal/application/repository/retriever/qdrant/repository.go
@@ -887,7 +887,9 @@ func newQdrantValueMap(payload map[string]any) map[string]*qdrant.Value {
 	sanitizedPayload := make(map[string]any, len(payload))
 	for key, value := range payload {
 		if stringValue, ok := value.(string); ok {
-			value = common.CleanInvalidUTF8(stringValue)
+			if strings.IndexByte(stringValue, 0) != -1 || !utf8.ValidString(stringValue) {
+				value = common.CleanInvalidUTF8(stringValue)
+			}
 		}
 		sanitizedPayload[key] = value
 	}

--- a/internal/application/repository/retriever/qdrant/repository_test.go
+++ b/internal/application/repository/retriever/qdrant/repository_test.go
@@ -1,0 +1,80 @@
+package qdrant
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+func TestNewQdrantValueMapSanitizesInvalidUTF8AndNUL(t *testing.T) {
+	malformed := "prefix" + string([]byte{0xff}) + "\x00suffix"
+	payload := newQdrantValueMap(map[string]any{
+		fieldContent:    malformed,
+		fieldSourceType: int64(1),
+		fieldIsEnabled:  true,
+	})
+
+	got := payload[fieldContent].GetStringValue()
+	if got != "prefixsuffix" {
+		t.Fatalf("unexpected sanitized content: %q", got)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("sanitized content is not valid UTF-8: % x", []byte(got))
+	}
+	if gotSourceType := payload[fieldSourceType].GetIntegerValue(); gotSourceType != 1 {
+		t.Fatalf("source type changed: got %d, want 1", gotSourceType)
+	}
+	if gotEnabled := payload[fieldIsEnabled].GetBoolValue(); !gotEnabled {
+		t.Fatal("is_enabled changed during payload sanitization")
+	}
+}
+
+func TestNewQdrantValueMapPreservesValidUTF8(t *testing.T) {
+	valid := "valid UTF-8 中文内容"
+	payload := newQdrantValueMap(map[string]any{
+		fieldContent: valid,
+	})
+
+	got := payload[fieldContent].GetStringValue()
+	if got != valid {
+		t.Fatalf("valid content changed: got %q, want %q", got, valid)
+	}
+}
+
+func TestCreatePayloadSanitizesAllStringFields(t *testing.T) {
+	malformed := "a" + string([]byte{0xff}) + "\x00b"
+	embedding := &QdrantVectorEmbedding{
+		Content:         malformed,
+		SourceID:        malformed,
+		SourceType:      2,
+		ChunkID:         malformed,
+		KnowledgeID:     malformed,
+		KnowledgeBaseID: malformed,
+		TagID:           malformed,
+		IsEnabled:       true,
+	}
+
+	payload := createPayload(embedding)
+	stringFields := []string{
+		fieldContent,
+		fieldSourceID,
+		fieldChunkID,
+		fieldKnowledgeID,
+		fieldKnowledgeBaseID,
+		fieldTagID,
+	}
+	for _, field := range stringFields {
+		got := payload[field].GetStringValue()
+		if got != "ab" {
+			t.Errorf("%s was not sanitized correctly: got %q", field, got)
+		}
+		if !utf8.ValidString(got) {
+			t.Errorf("%s remains invalid UTF-8: % x", field, []byte(got))
+		}
+	}
+	if got := payload[fieldSourceType].GetIntegerValue(); got != 2 {
+		t.Errorf("source type changed: got %d, want 2", got)
+	}
+	if got := payload[fieldIsEnabled].GetBoolValue(); !got {
+		t.Error("is_enabled changed during payload creation")
+	}
+}


### PR DESCRIPTION
## Description

- Sanitize direct string values at the Qdrant payload construction boundary with `common.CleanInvalidUTF8`.
- Route save, batch save, copy, tag update, and enabled status payloads through one helper.
- Preserve valid UTF-8 strings and non-string payload values.

## Type of Change

- [x] Bug fix
- [x] Test

## Related Issue

Fixes #2965

## Testing

- [x] `go test ./internal/application/repository/retriever/qdrant -count=1`
- [x] `go test ./internal/application/repository/retriever/qdrant -count=10`
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/application/repository/retriever/qdrant` reports 0 issues
- [x] `git diff --check origin/main...HEAD`
- [ ] Full diff-scoped lint with `golangci-lint run --new-from-rev=origin/main ./...` could not type-check the existing SQLite retriever package on Windows because `sqlite3.h` is unavailable. The command reported 0 issues before the environment error.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed package pass
- [x] Diff-scoped lint passes for the changed package
- [x] Full-repository lint limitation is documented above
- [x] Self-reviewed the code
- [x] Added regression tests covering malformed UTF-8, NUL bytes, valid UTF-8, and non-string values
- [x] Documentation changes are not required for this internal bug fix
- [x] No breaking changes

## Screenshots / Recordings

Not applicable. This change has no user-visible UI impact.