### PR TITLE
fix(preview): prevent large markdown preview freezes

### DIFF
--- a/frontend/src/components/document-preview.markdown.test.ts
+++ b/frontend/src/components/document-preview.markdown.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { renderDocumentPreviewMarkdown } from '../utils/documentPreviewMarkdown.ts'
+import { applyDocumentPreviewImageAttributes } from '../utils/security.ts'
+
+test('preview Markdown keeps native lazy image attributes', () => {
+  const html = renderDocumentPreviewMarkdown('![test](https://example.com/test.png)', value => value)
+
+  assert.match(html, /loading="lazy"/)
+  assert.match(html, /decoding="async"/)
+  assert.match(html, /fetchpriority="low"/)
+})
+
+test('preview Markdown keeps the marked-katex extension when using an image renderer', () => {
+  const html = renderDocumentPreviewMarkdown('公式 $E = mc^2$', value => value)
+
+  assert.match(html, /katex/)
+})
+
+test('raw HTML images cannot override preview loading attributes', () => {
+  const attributes = new Map([['alt', 'score > 90'], ['title', 'A > B'], ['loading', 'eager'], ['fetchpriority', 'high']])
+  const image = { tagName: 'IMG', setAttribute: (name: string, value: string) => attributes.set(name, value) }
+  applyDocumentPreviewImageAttributes(image as unknown as Node)
+  assert.equal(attributes.get('alt'), 'score > 90')
+  assert.equal(attributes.get('title'), 'A > B')
+  assert.equal(attributes.get('loading'), 'lazy')
+  assert.equal(attributes.get('decoding'), 'async')
+  assert.equal(attributes.get('fetchpriority'), 'low')
+})

--- a/frontend/src/components/document-preview.vue
+++ b/frontend/src/components/document-preview.vue
@@ -6,10 +6,10 @@ import { previewTemporaryAttachment } from '@/api/chat/temporary-attachments';
 import { downloadArtifact } from '@/api/chat';
 import hljs from 'highlight.js';
 import 'highlight.js/styles/github.css';
-import markedKatex from 'marked-katex-extension';
 import 'katex/dist/katex.min.css';
 import { useI18n } from 'vue-i18n';
-import { sanitizeHTML, sanitizeMarkdownHTML, safeMarkdownToHTML } from '@/utils/security';
+import { sanitizeHTML, sanitizeMarkdownHTML } from '@/utils/security';
+import { renderDocumentPreviewMarkdown } from '@/utils/documentPreviewMarkdown';
 import { openMermaidFullscreen } from '@/utils/mermaidViewer';
 import { renderMermaidToSvg } from '@/utils/mermaidShared';
 import {
@@ -169,7 +169,6 @@ async function renderText(blob: Blob, fileType: string) {
 }
 
 async function renderMarkdown(blob: Blob) {
-  const { marked } = await import('marked');
   const text = await blob.text();
 
   // 校验文本内容是否有效
@@ -178,33 +177,7 @@ async function renderMarkdown(blob: Blob) {
     return;
   }
 
-  marked.use({
-    breaks: true,
-    gfm: true,
-  });
-  marked.use(markedKatex({ throwOnError: false, nonStandard: true }));
-  const renderer = new marked.Renderer();
-  renderer.code = function ({text, lang}) {
-    // 空值校验：防止 text 为 undefined 或 null
-    if (!text || typeof text !== 'string') {
-      text = '';
-    }
-
-    let highlighted = '';
-    if (lang && hljs.getLanguage(lang)) {
-      try { highlighted = hljs.highlight(text, { language: lang }).value; }
-      catch { highlighted = hljs.highlightAuto(text).value; }
-    } else {
-      highlighted = hljs.highlightAuto(text).value;
-    }
-    return `<pre><code class="hljs">${highlighted}</code></pre>`;
-  };
-  const mathSafeText = preprocessMathDelimiters(text);
-  const safeText = safeMarkdownToHTML(mathSafeText);
-  // Keep this renderer local. `marked.use` mutates a shared singleton and
-  // would otherwise inherit renderers installed by the chunk-content view.
-  const rawHtml = marked.parse(safeText, { renderer }) as string;
-  markdownHtml.value = sanitizeHTML(rawHtml);
+  markdownHtml.value = renderDocumentPreviewMarkdown(text);
 }
 
 function onImageLoad(e: Event) {
@@ -975,7 +948,12 @@ onUnmounted(() => {
     border-radius: 3px;
     font-size: 0.9em;
   }
-  img { max-width: 100%; border-radius: 4px; }
+  img {
+    max-width: 100%;
+    border-radius: 4px;
+    content-visibility: auto;
+    contain-intrinsic-size: auto 180px;
+  }
   hr { border: none; border-top: 1px solid @border-color; margin: 20px 0; }
   a { color: @accent; text-decoration: none; &:hover { color: @accent-hover; text-decoration: underline; } }
   strong { font-weight: 600; }

--- a/frontend/src/utils/documentPreviewMarkdown.ts
+++ b/frontend/src/utils/documentPreviewMarkdown.ts
@@ -1,0 +1,38 @@
+import hljs from 'highlight.js'
+import { Marked, Renderer } from 'marked'
+import markedKatex from 'marked-katex-extension'
+import { escapeHTML, isValidImageURL, safeMarkdownToHTML, sanitizeDocumentPreviewHTML } from './security'
+
+const PREVIEW_IMAGE_ATTRIBUTES = 'loading="lazy" decoding="async" fetchpriority="low"'
+
+function isSafePreviewImageHref(href: unknown): href is string {
+  if (typeof href !== 'string' || !href.trim()) return false
+  if (isValidImageURL(href)) return true
+  const trimmed = href.trim()
+  return !trimmed.startsWith('//') && !trimmed.startsWith('#') && !/^[a-z][a-z\d+.-]*:/i.test(trimmed)
+}
+
+function createPreviewMarkdownRenderer(): Renderer {
+  const renderer = new Renderer()
+  renderer.image = ({ href, title, text }) => {
+    if (!isSafePreviewImageHref(href)) return ''
+    const safeHref = href.replace(/"/g, '&quot;')
+    const safeTitle = title ? ` title="${escapeHTML(title)}"` : ''
+    return `<img src="${safeHref}" alt="${escapeHTML(text || '')}"${safeTitle} class="markdown-image" ${PREVIEW_IMAGE_ATTRIBUTES}>`
+  }
+  renderer.code = ({ text, lang }) => {
+    const source = typeof text === 'string' ? text : ''
+    const highlighted = lang && hljs.getLanguage(lang)
+      ? (() => { try { return hljs.highlight(source, { language: lang }).value } catch { return hljs.highlightAuto(source).value } })()
+      : hljs.highlightAuto(source).value
+    return `<pre><code class="hljs">${highlighted}</code></pre>`
+  }
+  return renderer
+}
+
+export function renderDocumentPreviewMarkdown(markdown: string, sanitize: (html: string) => string = sanitizeDocumentPreviewHTML): string {
+  const marked = new Marked({ breaks: true, gfm: true })
+  marked.use(markedKatex({ throwOnError: false, nonStandard: true }))
+  const mathSafe = markdown.replace(/\\\[([\s\S]*?)\\\]/g, '$$$$$1$$$$').replace(/\\\(([\s\S]*?)\\\)/g, '$$$1$$')
+  return sanitize(marked.parse(safeMarkdownToHTML(mathSafe), { renderer: createPreviewMarkdownRenderer() }) as string)
+}

--- a/frontend/src/utils/security.ts
+++ b/frontend/src/utils/security.ts
@@ -33,6 +33,7 @@ const STORAGE_BACKEND_IMG_SRC_RE = new RegExp(
 type SecurityHooks = {
   beforeSanitizeElements: NodeHook;
   afterSanitizeElements: NodeHook;
+  afterSanitizeAttributes?: NodeHook;
 };
 
 function sanitizeWithSecurityHooks(
@@ -42,12 +43,23 @@ function sanitizeWithSecurityHooks(
 ): string {
   DOMPurify.addHook('beforeSanitizeElements', hooks.beforeSanitizeElements);
   DOMPurify.addHook('afterSanitizeElements', hooks.afterSanitizeElements);
+  if (hooks.afterSanitizeAttributes) DOMPurify.addHook('afterSanitizeAttributes', hooks.afterSanitizeAttributes);
   try {
     return DOMPurify.sanitize(html, config);
   } finally {
+    if (hooks.afterSanitizeAttributes) DOMPurify.removeHook('afterSanitizeAttributes', hooks.afterSanitizeAttributes);
     DOMPurify.removeHook('afterSanitizeElements', hooks.afterSanitizeElements);
     DOMPurify.removeHook('beforeSanitizeElements', hooks.beforeSanitizeElements);
   }
+}
+
+export function applyDocumentPreviewImageAttributes(currentNode: Node): void {
+  if (!('tagName' in currentNode) || !('setAttribute' in currentNode)) return;
+  const element = currentNode as Element;
+  if (element.tagName !== 'IMG') return;
+  element.setAttribute('loading', 'lazy');
+  element.setAttribute('decoding', 'async');
+  element.setAttribute('fetchpriority', 'low');
 }
 
 // 配置 DOMPurify 的安全策略
@@ -70,6 +82,7 @@ const DOMPurifyConfig = {
   // 允许的属性
   ALLOWED_ATTR: [
     'href', 'title', 'alt', 'src', 'class', 'id', 'style', 'data-protected-src', 'data-img-loading',
+    'loading', 'decoding', 'fetchpriority',
     'data-artifact-index', 'data-protected-resource', 'download',
     'target', 'rel', 'width', 'height', 'open',
     'type', 'aria-label', 'disabled', 'role', 'tabindex',
@@ -114,6 +127,21 @@ export function sanitizeHTML(html: string): string {
   } catch (error) {
     console.error('HTML sanitization failed:', error);
     // 如果清理失败，返回转义的纯文本
+    return escapeHTML(html);
+  }
+}
+
+/** Sanitize DocumentPreview Markdown and enforce a single image loading policy. */
+export function sanitizeDocumentPreviewHTML(html: string): string {
+  if (!html || typeof html !== 'string') return '';
+  try {
+    const preparedHTML = protectProviderImageSrcInHTML(html);
+    return sanitizeWithSecurityHooks(preparedHTML, DOMPurifyConfig as unknown as Config, {
+      ...domPurifySecurityHooks,
+      afterSanitizeAttributes: applyDocumentPreviewImageAttributes,
+    });
+  } catch (error) {
+    console.error('Document preview HTML sanitization failed:', error);
     return escapeHTML(html);
   }
 }


### PR DESCRIPTION
## Summary
- render Markdown images with native lazy loading, async decoding, and low fetch priority
- allow the added image attributes through DOMPurify
- keep Markdown rendering on `marked.parse()` so marked-katex extensions remain active
- add regression coverage for image attributes and KaTeX rendering

## Validation
- `npx tsx --test src/components/document-preview.markdown.test.ts`
- `npm run type-check`

This keeps large Markdown as a continuous document while avoiding eager loading of every remote image.