### PR TITLE
fix: widen audit log drawer

### DIFF
--- a/frontend/src/views/settings/TenantMembers.vue
+++ b/frontend/src/views/settings/TenantMembers.vue
@@ -2508,9 +2508,6 @@ watch(
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  /* The six audit columns need roughly 930px before the drawer body's
-     padding. Keep the outcome column in view on ordinary desktop widths,
-     while allowing the drawer to shrink safely on smaller screens. */
   max-width: 100vw;
   max-height: 100vh;
   height: 100%;

--- a/frontend/src/views/settings/TenantMembers.vue
+++ b/frontend/src/views/settings/TenantMembers.vue
@@ -381,7 +381,7 @@
          route is g.Admin()-gated; rendering it for lower roles would
          just produce an unhelpful 403. Lazy-loaded on first open. -->
     <t-drawer v-if="canViewAudit" v-model:visible="auditDrawerVisible" :header="$t('tenantMember.audit.tabLabel')"
-      drawer-class-name="tenant-members-audit-drawer" size="880px" :footer="false" placement="right" destroy-on-close>
+      drawer-class-name="tenant-members-audit-drawer" size="1120px" :footer="false" placement="right" destroy-on-close>
       <div class="audit-drawer-inner audit-panel audit-panel--drawer">
         <div class="audit-header">
           <span class="audit-desc">{{ $t('tenantMember.audit.description') }}</span>
@@ -2508,6 +2508,10 @@ watch(
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
+  /* The six audit columns need roughly 930px before the drawer body's
+     padding. Keep the outcome column in view on ordinary desktop widths,
+     while allowing the drawer to shrink safely on smaller screens. */
+  max-width: 100vw;
   max-height: 100vh;
   height: 100%;
 }

--- a/frontend/src/views/settings/TenantMembers.vue
+++ b/frontend/src/views/settings/TenantMembers.vue
@@ -380,8 +380,10 @@
     <!-- Audit log drawer. Only rendered for Admin+ because the backend
          route is g.Admin()-gated; rendering it for lower roles would
          just produce an unhelpful 403. Lazy-loaded on first open. -->
-    <t-drawer v-if="canViewAudit" v-model:visible="auditDrawerVisible" :header="$t('tenantMember.audit.tabLabel')"
-      drawer-class-name="tenant-members-audit-drawer" size="1120px" :footer="false" placement="right" destroy-on-close>
+    <SettingDrawer v-if="canViewAudit" v-model:visible="auditDrawerVisible"
+      :title="$t('tenantMember.audit.tabLabel')" width="1120px" :min-width="720" :max-width="1600"
+      storage-key="setting-drawer:width:tenant-members-audit" :hide-footer="true"
+      drawer-class-name="tenant-members-audit-drawer">
       <div class="audit-drawer-inner audit-panel audit-panel--drawer">
         <div class="audit-header">
           <span class="audit-desc">{{ $t('tenantMember.audit.description') }}</span>
@@ -506,7 +508,7 @@
           </div>
         </div>
       </div>
-    </t-drawer>
+    </SettingDrawer>
   </div>
 </template>
 
@@ -514,6 +516,7 @@
 import { computed, nextTick, onUnmounted, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { MessagePlugin } from 'tdesign-vue-next'
+import SettingDrawer from '@/components/settings/SettingDrawer.vue'
 import { copyWithToast } from '@/utils/clipboard'
 import { useAuthStore } from '@/stores/auth'
 import { AUDIT_ACTION_I18N_ROOTS } from '@/i18n/auditActionRegistry'
@@ -2520,5 +2523,10 @@ watch(
   flex-direction: column;
   box-sizing: border-box;
   overflow: hidden !important;
+}
+
+.t-drawer.tenant-members-audit-drawer .setting-drawer__body {
+  flex: 1 1 auto;
+  min-height: 0;
 }
 </style>


### PR DESCRIPTION
## Description

Widen the Settings → Member Management → Audit Log drawer from 880px to 1120px.

This keeps the final “Outcome” column visible alongside the other audit fields on standard desktop screens, avoiding the need to horizontally scroll the table. The drawer remains constrained to the viewport width on smaller screens.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A

## Testing

- Ran `npm run type-check`
- Ran `git diff --check origin/main...HEAD`

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

bug：


https://github.com/user-attachments/assets/a11f0ce5-9423-42cf-8169-c975b1ae13a4


fixes：

https://github.com/user-attachments/assets/097d9f27-f18c-4728-aae3-fae20373fd09


