### PR TITLE
fix(agent): load editor resources for contributors

### DIFF
--- a/frontend/src/stores/editorResources.ts
+++ b/frontend/src/stores/editorResources.ts
@@ -40,7 +40,8 @@ export function pickUsableStorageProvider(
 }
 
 type EditorResourceKey =
-  | 'storageEngine'
+  | 'storageEngineConfig'
+  | 'storageEngineStatus'
   | 'mcpServices'
   | 'skills'
   | 'skillCatalog'
@@ -84,17 +85,28 @@ export const useEditorResourcesStore = defineStore('editorResources', () => {
     return p
   }
 
-  async function ensureStorageEngine(force = false): Promise<void> {
-    return runOnce('storageEngine', force, async () => {
-      const [configRes, statusRes] = await Promise.all([
-        getStorageEngineConfig(),
-        getStorageEngineStatus(),
-      ])
+  async function ensureStorageEngineConfig(force = false): Promise<void> {
+    return runOnce('storageEngineConfig', force, async () => {
+      const configRes = await getStorageEngineConfig()
       storageConfig.value = configRes?.data ?? null
+      loadedAt.value.storageEngineConfig = Date.now()
+    })
+  }
+
+  async function ensureStorageEngineStatus(force = false): Promise<void> {
+    return runOnce('storageEngineStatus', force, async () => {
+      const statusRes = await getStorageEngineStatus()
       storageStatus.value = statusRes?.data?.engines ?? []
       storageAllowedProviders.value = statusRes?.data?.allowed_providers ?? []
-      loadedAt.value.storageEngine = Date.now()
+      loadedAt.value.storageEngineStatus = Date.now()
     })
+  }
+
+  async function ensureStorageEngine(force = false): Promise<void> {
+    await Promise.all([
+      ensureStorageEngineConfig(force),
+      ensureStorageEngineStatus(force),
+    ])
   }
 
   function resolveUsableStorageProvider(candidate?: string): string {
@@ -196,14 +208,18 @@ export const useEditorResourcesStore = defineStore('editorResources', () => {
 
   /** 智能体编辑器打开时预取的依赖（不含 IM channels / 单 KB shares） */
   async function prefetchAgentEditorDeps(force = false): Promise<void> {
-    await Promise.all([
+    // Wait for every independent request so one failure cannot hide resources
+    // that loaded successfully. The caller still receives the first error for logging.
+    const results = await Promise.allSettled([
       ensureMcpServices(force),
       ensureAgentTypePresets(force),
       ensurePromptTemplates(force),
-      ensureStorageEngine(force),
+      ensureStorageEngineStatus(force),
       ensurePlaceholders(force),
       ensureTenantRetrievalConfig(force),
     ])
+    const failure = results.find((result) => result.status === 'rejected')
+    if (failure?.status === 'rejected') throw failure.reason
   }
 
   function invalidate(...keys: EditorResourceKey[]) {
@@ -247,6 +263,7 @@ export const useEditorResourcesStore = defineStore('editorResources', () => {
     parserEngines,
     systemInfo,
     ensureStorageEngine,
+    ensureStorageEngineStatus,
     resolveUsableStorageProvider,
     ensureMcpServices,
     ensureSkills,

--- a/frontend/src/views/agent/AgentEditorModal.test.mjs
+++ b/frontend/src/views/agent/AgentEditorModal.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 import test from 'node:test'
 
 const source = readFileSync(new URL('./AgentEditorModal.vue', import.meta.url), 'utf8')
+const editorResourcesSource = readFileSync(new URL('../../stores/editorResources.ts', import.meta.url), 'utf8')
 
 test('editing an agent closes the editor after a successful save', () => {
   assert.match(
@@ -33,6 +34,42 @@ test('shows a post-create hint after the first successful save', () => {
   assert.match(source, /const isPostCreateSession = computed\(\(\) => !!savedAgent\.value\)/)
   assert.match(source, /settings-footer-note/)
   assert.match(source, /agent\.editor\.postCreateHint\.title/)
+})
+
+test('a failed optional dependency does not discard loaded models and knowledge bases', () => {
+  const loadDependencies = source.match(
+    /const loadDependencies = async \(\) => \{([\s\S]*?)^\};/m
+  )?.[1]
+
+  assert.ok(loadDependencies, 'expected to find loadDependencies')
+  assert.match(loadDependencies, /await Promise\.allSettled\(/)
+  assert.match(loadDependencies, /allModels\.value = chatResources\.allModels/)
+  assert.match(loadDependencies, /kbOptions\.value = \[\.\.\.myKbs, \.\.\.sharedKbs\]/)
+})
+
+test('agent editor prefetch only reads viewer-safe storage status', () => {
+  const statusLoad = editorResourcesSource.match(
+    /async function ensureStorageEngineStatus\(force = false\): Promise<void> \{([\s\S]*?)^  \}/m
+  )?.[1]
+  const prefetch = editorResourcesSource.match(
+    /async function prefetchAgentEditorDeps\(force = false\): Promise<void> \{([\s\S]*?)^  \}/m
+  )?.[1]
+  const fullStorageLoad = editorResourcesSource.match(
+    /async function ensureStorageEngine\(force = false\): Promise<void> \{([\s\S]*?)^  \}/m
+  )?.[1]
+
+  assert.ok(statusLoad, 'expected to find ensureStorageEngineStatus')
+  assert.match(statusLoad, /getStorageEngineStatus\(\)/)
+  assert.doesNotMatch(statusLoad, /getStorageEngineConfig\(\)/)
+
+  assert.ok(prefetch, 'expected to find prefetchAgentEditorDeps')
+  assert.match(prefetch, /Promise\.allSettled/)
+  assert.match(prefetch, /ensureStorageEngineStatus\(force\)/)
+  assert.doesNotMatch(prefetch, /ensureStorageEngine\(force\)/)
+
+  assert.ok(fullStorageLoad, 'expected to find ensureStorageEngine')
+  assert.match(fullStorageLoad, /ensureStorageEngineConfig\(force\)/)
+  assert.match(fullStorageLoad, /ensureStorageEngineStatus\(force\)/)
 })
 
 // Locate a settings row by the i18n key of its label and return the attributes

--- a/frontend/src/views/agent/AgentEditorModal.test.mjs
+++ b/frontend/src/views/agent/AgentEditorModal.test.mjs
@@ -36,15 +36,25 @@ test('shows a post-create hint after the first successful save', () => {
   assert.match(source, /agent\.editor\.postCreateHint\.title/)
 })
 
-test('a failed optional dependency does not discard loaded models and knowledge bases', () => {
+test('applies each resource only when its own dependency load succeeds', () => {
   const loadDependencies = source.match(
     /const loadDependencies = async \(\) => \{([\s\S]*?)^\};/m
   )?.[1]
 
   assert.ok(loadDependencies, 'expected to find loadDependencies')
   assert.match(loadDependencies, /await Promise\.allSettled\(/)
-  assert.match(loadDependencies, /allModels\.value = chatResources\.allModels/)
-  assert.match(loadDependencies, /kbOptions\.value = \[\.\.\.myKbs, \.\.\.sharedKbs\]/)
+  assert.match(
+    loadDependencies,
+    /if \(modelsResult\.status === 'fulfilled'\) \{\s*allModels\.value = chatResources\.allModels;\s*\} else \{\s*allModels\.value = \[\];\s*\}/
+  )
+  assert.match(
+    loadDependencies,
+    /if \(knowledgeBasesResult\.status === 'fulfilled'\) \{[\s\S]*?kbOptions\.value = \[\.\.\.myKbs, \.\.\.sharedKbs\];\s*\} else \{\s*kbOptions\.value = \[\];\s*\}/
+  )
+  assert.match(
+    loadDependencies,
+    /if \(webSearchProvidersResult\.status === 'fulfilled'\) \{\s*webSearchProviderList\.value = chatResources\.webSearchProviders as WebSearchProviderEntity\[\];\s*\} else \{\s*webSearchProviderList\.value = \[\];\s*\}/
+  )
 })
 
 test('agent editor prefetch only reads viewer-safe storage status', () => {

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -3815,7 +3815,7 @@ watch(() => uiStore.showSettingsModal, async (visible, prevVisible) => {
     try {
       await Promise.all([
         chatResources.ensureModels(true),
-        editorResources.ensureStorageEngine(true),
+        editorResources.ensureStorageEngineStatus(true),
         chatResources.ensureSandboxConfigs(true),
       ]);
       if (chatResources.allModels.length > 0) {
@@ -3885,46 +3885,48 @@ const applyPromptTemplateDefaults = (cfg: PromptTemplatesConfig | null) => {
 
 // 加载依赖数据（复用空间级缓存，避免重复请求）
 const loadDependencies = async () => {
-  try {
-    await Promise.all([
-      chatResources.ensureModels(),
-      chatResources.ensureKnowledgeBases(),
-      chatResources.ensureWebSearchProviders(),
-      chatResources.ensureSandboxConfigs(),
-      editorResources.prefetchAgentEditorDeps(),
-    ]);
-
-    if (chatResources.allModels.length > 0) {
-      allModels.value = chatResources.allModels;
+  const dependencies = [
+    ['models', chatResources.ensureModels()],
+    ['knowledge bases', chatResources.ensureKnowledgeBases()],
+    ['web search providers', chatResources.ensureWebSearchProviders()],
+    ['sandbox configs', chatResources.ensureSandboxConfigs()],
+    ['editor resources', editorResources.prefetchAgentEditorDeps()],
+  ] as const;
+  const results = await Promise.allSettled(dependencies.map(([, request]) => request));
+  results.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      console.warn(`Failed to load agent editor ${dependencies[index][0]}`, result.reason);
     }
+  });
 
-    const myKbs = chatResources.rawKnowledgeBases.map((kb: any) => mapKbToOption(kb, false));
-    const myKbIds = new Set(myKbs.map(kb => kb.value));
-    const sharedKbs = (orgStore.sharedKnowledgeBases || [])
-      .filter((shared: any) => shared.knowledge_base && !myKbIds.has(shared.knowledge_base.id))
-      .map((shared: any) => mapKbToOption(shared.knowledge_base, true, shared.org_name));
-    kbOptions.value = [...myKbs, ...sharedKbs];
-
-    agentTypePresets.value = editorResources.agentTypePresets as AgentTypePreset[];
-    applyPromptTemplateDefaults(editorResources.promptTemplates);
-
-    storageEngineStatus.value = editorResources.storageStatus;
-
-    webSearchProviderList.value = chatResources.webSearchProviders as WebSearchProviderEntity[];
-
-    if (editorResources.placeholders) {
-      placeholderData.value = editorResources.placeholders;
-    }
-
-    const rc = editorResources.tenantRetrievalConfig as Record<string, number> | null;
-    if (rc?.embedding_top_k) defaultEmbeddingTopK.value = rc.embedding_top_k;
-    if (rc?.keyword_threshold !== undefined) defaultKeywordThreshold.value = rc.keyword_threshold;
-    if (rc?.vector_threshold !== undefined) defaultVectorThreshold.value = rc.vector_threshold;
-    if (rc?.rerank_top_k) defaultRerankTopK.value = rc.rerank_top_k;
-    if (rc?.rerank_threshold !== undefined) defaultRerankThreshold.value = rc.rerank_threshold;
-  } catch (e) {
-    console.error('Failed to load dependencies', e);
+  if (chatResources.allModels.length > 0) {
+    allModels.value = chatResources.allModels;
   }
+
+  const myKbs = chatResources.rawKnowledgeBases.map((kb: any) => mapKbToOption(kb, false));
+  const myKbIds = new Set(myKbs.map(kb => kb.value));
+  const sharedKbs = (orgStore.sharedKnowledgeBases || [])
+    .filter((shared: any) => shared.knowledge_base && !myKbIds.has(shared.knowledge_base.id))
+    .map((shared: any) => mapKbToOption(shared.knowledge_base, true, shared.org_name));
+  kbOptions.value = [...myKbs, ...sharedKbs];
+
+  agentTypePresets.value = editorResources.agentTypePresets as AgentTypePreset[];
+  applyPromptTemplateDefaults(editorResources.promptTemplates);
+
+  storageEngineStatus.value = editorResources.storageStatus;
+
+  webSearchProviderList.value = chatResources.webSearchProviders as WebSearchProviderEntity[];
+
+  if (editorResources.placeholders) {
+    placeholderData.value = editorResources.placeholders;
+  }
+
+  const rc = editorResources.tenantRetrievalConfig as Record<string, number> | null;
+  if (rc?.embedding_top_k) defaultEmbeddingTopK.value = rc.embedding_top_k;
+  if (rc?.keyword_threshold !== undefined) defaultKeywordThreshold.value = rc.keyword_threshold;
+  if (rc?.vector_threshold !== undefined) defaultVectorThreshold.value = rc.vector_threshold;
+  if (rc?.rerank_top_k) defaultRerankTopK.value = rc.rerank_top_k;
+  if (rc?.rerank_threshold !== undefined) defaultRerankThreshold.value = rc.rerank_threshold;
 };
 
 // 跳转到模型管理页面添加模型

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -3885,37 +3885,59 @@ const applyPromptTemplateDefaults = (cfg: PromptTemplatesConfig | null) => {
 
 // 加载依赖数据（复用空间级缓存，避免重复请求）
 const loadDependencies = async () => {
+  const [
+    modelsResult,
+    knowledgeBasesResult,
+    webSearchProvidersResult,
+    sandboxConfigsResult,
+    editorResourcesResult,
+  ] = await Promise.allSettled([
+    chatResources.ensureModels(),
+    chatResources.ensureKnowledgeBases(),
+    chatResources.ensureWebSearchProviders(),
+    chatResources.ensureSandboxConfigs(),
+    editorResources.prefetchAgentEditorDeps(),
+  ]);
   const dependencies = [
-    ['models', chatResources.ensureModels()],
-    ['knowledge bases', chatResources.ensureKnowledgeBases()],
-    ['web search providers', chatResources.ensureWebSearchProviders()],
-    ['sandbox configs', chatResources.ensureSandboxConfigs()],
-    ['editor resources', editorResources.prefetchAgentEditorDeps()],
+    ['models', modelsResult],
+    ['knowledge bases', knowledgeBasesResult],
+    ['web search providers', webSearchProvidersResult],
+    ['sandbox configs', sandboxConfigsResult],
+    ['editor resources', editorResourcesResult],
   ] as const;
-  const results = await Promise.allSettled(dependencies.map(([, request]) => request));
-  results.forEach((result, index) => {
+  dependencies.forEach(([name, result]) => {
     if (result.status === 'rejected') {
-      console.warn(`Failed to load agent editor ${dependencies[index][0]}`, result.reason);
+      console.warn(`Failed to load agent editor ${name}`, result.reason);
     }
   });
 
-  if (chatResources.allModels.length > 0) {
+  if (modelsResult.status === 'fulfilled') {
     allModels.value = chatResources.allModels;
+  } else {
+    allModels.value = [];
   }
 
-  const myKbs = chatResources.rawKnowledgeBases.map((kb: any) => mapKbToOption(kb, false));
-  const myKbIds = new Set(myKbs.map(kb => kb.value));
-  const sharedKbs = (orgStore.sharedKnowledgeBases || [])
-    .filter((shared: any) => shared.knowledge_base && !myKbIds.has(shared.knowledge_base.id))
-    .map((shared: any) => mapKbToOption(shared.knowledge_base, true, shared.org_name));
-  kbOptions.value = [...myKbs, ...sharedKbs];
+  if (knowledgeBasesResult.status === 'fulfilled') {
+    const myKbs = chatResources.rawKnowledgeBases.map((kb: any) => mapKbToOption(kb, false));
+    const myKbIds = new Set(myKbs.map(kb => kb.value));
+    const sharedKbs = (orgStore.sharedKnowledgeBases || [])
+      .filter((shared: any) => shared.knowledge_base && !myKbIds.has(shared.knowledge_base.id))
+      .map((shared: any) => mapKbToOption(shared.knowledge_base, true, shared.org_name));
+    kbOptions.value = [...myKbs, ...sharedKbs];
+  } else {
+    kbOptions.value = [];
+  }
 
   agentTypePresets.value = editorResources.agentTypePresets as AgentTypePreset[];
   applyPromptTemplateDefaults(editorResources.promptTemplates);
 
   storageEngineStatus.value = editorResources.storageStatus;
 
-  webSearchProviderList.value = chatResources.webSearchProviders as WebSearchProviderEntity[];
+  if (webSearchProvidersResult.status === 'fulfilled') {
+    webSearchProviderList.value = chatResources.webSearchProviders as WebSearchProviderEntity[];
+  } else {
+    webSearchProviderList.value = [];
+  }
 
   if (editorResources.placeholders) {
     placeholderData.value = editorResources.placeholders;


### PR DESCRIPTION
## Description

A Contributor can receive successful model and knowledge-base responses while the Agent editor also receives an expected `403` from the Admin-only `storage-engine-config` endpoint. The nested `Promise.all` chain previously promoted that optional failure into a full dependency-load failure, so the editor never copied the successful model and knowledge-base data into its local options.

This change:

- splits storage configuration and storage status into independently cached requests;
- makes Agent editor prefetch use the Viewer-safe `storage-engine-status` endpoint instead of the Admin-only configuration endpoint;
- waits for all independent requests to settle before applying every successfully loaded resource;
- preserves the full configuration + status loader used by the Knowledge Base editor.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #2991

## Testing

From `frontend/` with Node 24:

- `npm ci --no-audit --no-fund`
- `npm test -- src/views/agent/AgentEditorModal.test.mjs` — 15 passed
- `npm test` — 570 passed
- `npm run type-check`
- `npm run build`
- `git diff --check origin/main...HEAD`

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (no frontend lint script is configured; type-check passes)
- [x] Full frontend test, type-check, and build checks were run
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (not applicable: no API or user workflow contract changed)
- [x] Breaking changes are clearly called out (not applicable: no breaking change)

## Screenshots / Recordings

Not applicable: this restores existing dropdown data for Contributor roles without changing layout or styling. The role-based A/B reproduction and request status evidence are documented in #2991.
