### PR TITLE
feat(knowledge): 下载与原始文件预览权限收紧为创建者或管理员

### DIFF
--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -741,6 +741,9 @@ const processedChunks = computed(() => {
 });
 
 const canPreview = (): boolean => {
+  // The preview tab streams the original file (same API as download), so it
+  // follows the download permission instead of the read permission.
+  if (!props.canDownloadKB) return false;
   if (props.details?.type !== 'file') return false;
   const ft = resolveFilePreviewExt(props.details?.title, props.details?.file_type);
   if (!ft) return false;
@@ -787,6 +790,7 @@ const audioBlobUrl = ref('');
 const audioLoading = ref(false);
 
 const loadAudioPreview = async () => {
+  if (!props.canDownloadKB) return;
   if (!props.details?.id || audioBlobUrl.value) return;
   audioLoading.value = true;
   try {

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -321,14 +321,18 @@ const canMutateKnowledge = computed(() => {
 // Effective permission: from direct org share list or from GET /knowledge-bases/:id (e.g. agent-visible KB)
 const effectiveKBPermission = computed(() => orgStore.getKBPermission(kbId.value) || kbInfo.value?.my_permission || '');
 
-// Downloading returns the original source file, which is intentionally more
-// restrictive than viewing parsed content or using the preview tab. A tenant
-// Viewer can never download; for cross-tenant KBs the effective share
-// permission must additionally be Editor or Admin.
+// Downloading and previewing both return the original source file, which is
+// intentionally more restrictive than viewing parsed content: within the home
+// tenant only the KB creator or an Admin+ may fetch it; for cross-tenant KBs
+// the effective share permission must be Editor or Admin. Callers without it
+// see only the merged/chunked parsed content.
 const canDownloadKnowledge = computed(() => {
   if (!authStore.hasRole('contributor')) return false;
-  const permission = effectiveKBPermission.value;
-  return !permission || permission === 'owner' || permission === 'admin' || permission === 'editor';
+  if (isViaShare.value) {
+    const permission = effectiveKBPermission.value;
+    return permission === 'owner' || permission === 'admin' || permission === 'editor';
+  }
+  return isOwner.value || authStore.hasRole('admin');
 });
 
 const knowledgeList = ref<Array<{ id: string; name: string; type?: string }>>([]);

--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -1524,6 +1524,36 @@ func (h *KnowledgeHandler) ClearKnowledgeBaseContents(c *gin.Context) {
 // @Security     Bearer
 // @Security     ApiKeyAuth
 // @Router       /knowledge/{id}/download [get]
+// checkKnowledgeOriginalFilePermission guards access to the original source
+// file (both download and inline preview) on top of the route guards: within
+// the owning tenant only the KB creator or Admin+ may fetch it. Cross-tenant
+// org-share callers keep the editor+ floor already enforced by the callers'
+// resolveKnowledgeAndValidateKBAccess(…, OrgRoleEditor) check.
+func (h *KnowledgeHandler) checkKnowledgeOriginalFilePermission(c *gin.Context, knowledge *types.Knowledge) error {
+	ctx := c.Request.Context()
+	kb, err := h.kbService.GetKnowledgeBaseByID(ctx, knowledge.KnowledgeBaseID)
+	if err != nil {
+		if goerrors.Is(err, repository.ErrKnowledgeBaseNotFound) {
+			return errors.NewNotFoundError("knowledge base not found")
+		}
+		logger.ErrorWithFields(ctx, err, nil)
+		return errors.NewInternalServerError("cannot verify knowledge base ownership")
+	}
+	// The KBAccess middleware rewrites only the request context, so the
+	// caller's own tenant must be read from the gin keys.
+	if knowledge.TenantID != c.GetUint64(types.TenantIDContextKey.String()) {
+		return nil
+	}
+	if evalErr := middleware.EvaluateOwnershipOrRole(ctx, h.cfg, types.TenantRoleAdmin, kb.CreatorID, nil); evalErr != nil {
+		if goerrors.Is(evalErr, middleware.ErrOwnershipForbidden) {
+			return errors.NewForbiddenError("No permission to access the original file of this knowledge base")
+		}
+		logger.ErrorWithFields(ctx, evalErr, nil)
+		return errors.NewInternalServerError("cannot verify knowledge base ownership")
+	}
+	return nil
+}
+
 func (h *KnowledgeHandler) DownloadKnowledgeFile(c *gin.Context) {
 	ctx := c.Request.Context()
 
@@ -1539,8 +1569,12 @@ func (h *KnowledgeHandler) DownloadKnowledgeFile(c *gin.Context) {
 	// Keep a handler-level Editor check in addition to the route guard. The
 	// original file is more sensitive than parsed-content reads and must not
 	// be downloadable through a read-only organization share.
-	_, effCtx, err := h.resolveKnowledgeAndValidateKBAccess(c, id, types.OrgRoleEditor)
+	knowledge, effCtx, err := h.resolveKnowledgeAndValidateKBAccess(c, id, types.OrgRoleEditor)
 	if err != nil {
+		c.Error(err)
+		return
+	}
+	if err := h.checkKnowledgeOriginalFilePermission(c, knowledge); err != nil {
 		c.Error(err)
 		return
 	}
@@ -1609,8 +1643,15 @@ func (h *KnowledgeHandler) PreviewKnowledgeFile(c *gin.Context) {
 		return
 	}
 
-	_, effCtx, err := h.resolveKnowledgeAndValidateKBAccess(c, id, types.OrgRoleViewer)
+	// Same editor+ floor as the download route: the preview response is the
+	// original source file, so callers who may not download may not fetch it
+	// through preview either (parsed-content reads stay Viewer-accessible).
+	knowledge, effCtx, err := h.resolveKnowledgeAndValidateKBAccess(c, id, types.OrgRoleEditor)
 	if err != nil {
+		c.Error(err)
+		return
+	}
+	if err := h.checkKnowledgeOriginalFilePermission(c, knowledge); err != nil {
 		c.Error(err)
 		return
 	}

--- a/internal/handler/knowledge_preview_security_test.go
+++ b/internal/handler/knowledge_preview_security_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/middleware"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
@@ -17,6 +18,15 @@ import (
 type previewKnowledgeServiceStub struct {
 	interfaces.KnowledgeService
 	filename string
+}
+
+type previewKBServiceStub struct {
+	interfaces.KnowledgeBaseService
+	kb *types.KnowledgeBase
+}
+
+func (s *previewKBServiceStub) GetKnowledgeBaseByID(context.Context, string) (*types.KnowledgeBase, error) {
+	return s.kb, nil
 }
 
 type closeNotifyRecorder struct {
@@ -41,11 +51,18 @@ func TestPreviewKnowledgeFileForcesActiveContentDownload(t *testing.T) {
 	router := gin.New()
 	router.Use(middleware.ErrorHandler())
 	router.Use(func(c *gin.Context) {
+		ctx := context.WithValue(c.Request.Context(), types.TenantRoleContextKey, types.TenantRoleAdmin)
+		c.Request = c.Request.WithContext(ctx)
 		c.Set(types.TenantIDContextKey.String(), uint64(42))
 		c.Next()
 	})
 
-	h := &KnowledgeHandler{kgService: &previewKnowledgeServiceStub{filename: "payload.html"}}
+	enabled := true
+	h := &KnowledgeHandler{
+		cfg:       &config.Config{Tenant: &config.TenantConfig{EnableRBAC: &enabled}},
+		kgService: &previewKnowledgeServiceStub{filename: "payload.html"},
+		kbService: &previewKBServiceStub{kb: &types.KnowledgeBase{ID: "kb1", TenantID: 42, CreatorID: "user-1"}},
+	}
 	router.GET("/knowledge/:id/preview", h.PreviewKnowledgeFile)
 
 	req := httptest.NewRequest(http.MethodGet, "/knowledge/k1/preview", nil)

--- a/internal/router/router_knowledge_download_test.go
+++ b/internal/router/router_knowledge_download_test.go
@@ -2,8 +2,10 @@ package router
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	apprepo "github.com/Tencent/WeKnora/internal/application/repository"
@@ -27,6 +29,34 @@ func (s *downloadKnowledgeLookup) GetKnowledgeByIDOnly(_ context.Context, id str
 	return nil, apprepo.ErrKnowledgeNotFound
 }
 
+type downloadKnowledgeServiceStub struct {
+	interfaces.KnowledgeService
+	knowledge *types.Knowledge
+}
+
+func (s *downloadKnowledgeServiceStub) GetKnowledgeByIDOnly(_ context.Context, id string) (*types.Knowledge, error) {
+	if s.knowledge != nil && s.knowledge.ID == id {
+		return s.knowledge, nil
+	}
+	return nil, apprepo.ErrKnowledgeNotFound
+}
+
+func (s *downloadKnowledgeServiceStub) GetKnowledgeFile(context.Context, string) (io.ReadCloser, string, error) {
+	return io.NopCloser(strings.NewReader("file-body")), "doc.pdf", nil
+}
+
+type downloadKBServiceStub struct {
+	interfaces.KnowledgeBaseService
+	kb *types.KnowledgeBase
+}
+
+func (s *downloadKBServiceStub) GetKnowledgeBaseByID(_ context.Context, id string) (*types.KnowledgeBase, error) {
+	if s.kb != nil && s.kb.ID == id {
+		return s.kb, nil
+	}
+	return nil, apprepo.ErrKnowledgeBaseNotFound
+}
+
 type downloadKBShareStub struct {
 	interfaces.KBShareService
 	permission types.OrgMemberRole
@@ -46,9 +76,19 @@ func (s *downloadKBShareStub) GetKBSourceTenant(_ context.Context, _ string) (ui
 	return s.source, nil
 }
 
+type downloadCloseNotifyRecorder struct {
+	*httptest.ResponseRecorder
+}
+
+func (r *downloadCloseNotifyRecorder) CloseNotify() <-chan bool {
+	ch := make(chan bool, 1)
+	return ch
+}
+
 func newKnowledgeDownloadRouteTestEngine(
 	t *testing.T,
 	role types.TenantRole,
+	userID string,
 	knowledge *types.Knowledge,
 	kb *types.KnowledgeBase,
 	share interfaces.KBShareService,
@@ -57,39 +97,57 @@ func newKnowledgeDownloadRouteTestEngine(
 	gin.SetMode(gin.TestMode)
 
 	enabled := true
+	cfg := &config.Config{Tenant: &config.TenantConfig{EnableRBAC: &enabled}}
 	guards := &rbacGuards{
-		cfg:              &config.Config{Tenant: &config.TenantConfig{EnableRBAC: &enabled}},
+		cfg:              cfg,
 		knowledgeService: &downloadKnowledgeLookup{knowledge: knowledge},
 		kbService:        &stubWikiKBLookup{kbs: map[string]*types.KnowledgeBase{kb.ID: kb}},
 		kbShareService:   share,
 	}
+
+	h := handler.NewKnowledgeHandler(
+		cfg,
+		&downloadKnowledgeServiceStub{knowledge: knowledge},
+		&downloadKBServiceStub{kb: kb},
+		share,
+		nil, nil, nil,
+	)
 
 	r := gin.New()
 	r.Use(middleware.ErrorHandler())
 	r.Use(func(c *gin.Context) {
 		ctx := context.WithValue(c.Request.Context(), types.TenantIDContextKey, uint64(1))
 		ctx = context.WithValue(ctx, types.TenantRoleContextKey, role)
+		if userID != "" {
+			ctx = context.WithValue(ctx, types.UserIDContextKey, userID)
+		}
 		c.Request = c.Request.WithContext(ctx)
 		c.Set(types.TenantIDContextKey.String(), uint64(1))
 		c.Next()
 	})
-	RegisterKnowledgeRoutes(r.Group("/api/v1"), &handler.KnowledgeHandler{}, guards)
+	RegisterKnowledgeRoutes(r.Group("/api/v1"), h, guards)
 	return r
+}
+
+func serveKnowledgeFile(t *testing.T, engine *gin.Engine, url string) *downloadCloseNotifyRecorder {
+	t.Helper()
+	rec := &downloadCloseNotifyRecorder{ResponseRecorder: httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	engine.ServeHTTP(rec, req)
+	return rec
 }
 
 func TestKnowledgeDownloadRejectsTenantViewer(t *testing.T) {
 	engine := newKnowledgeDownloadRouteTestEngine(
 		t,
 		types.TenantRoleViewer,
+		"me",
 		&types.Knowledge{ID: "knowledge-own", KnowledgeBaseID: "kb-own", TenantID: 1},
-		&types.KnowledgeBase{ID: "kb-own", TenantID: 1},
+		&types.KnowledgeBase{ID: "kb-own", TenantID: 1, CreatorID: "other"},
 		nil,
 	)
 
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/knowledge/knowledge-own/download", nil)
-	engine.ServeHTTP(rec, req)
-
+	rec := serveKnowledgeFile(t, engine, "/api/v1/knowledge/knowledge-own/download")
 	require.Equal(t, http.StatusForbidden, rec.Code, "body=%s", rec.Body.String())
 }
 
@@ -97,14 +155,124 @@ func TestKnowledgeDownloadRejectsReadOnlySharedKB(t *testing.T) {
 	engine := newKnowledgeDownloadRouteTestEngine(
 		t,
 		types.TenantRoleContributor,
+		"me",
 		&types.Knowledge{ID: "knowledge-shared", KnowledgeBaseID: "kb-shared", TenantID: 2},
-		&types.KnowledgeBase{ID: "kb-shared", TenantID: 2},
+		&types.KnowledgeBase{ID: "kb-shared", TenantID: 2, CreatorID: "other"},
 		&downloadKBShareStub{permission: types.OrgRoleViewer, source: 2},
 	)
 
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/knowledge/knowledge-shared/download", nil)
-	engine.ServeHTTP(rec, req)
-
+	rec := serveKnowledgeFile(t, engine, "/api/v1/knowledge/knowledge-shared/download")
 	require.Equal(t, http.StatusForbidden, rec.Code, "body=%s", rec.Body.String())
+}
+
+func TestKnowledgeDownloadRejectsNonCreatorContributor(t *testing.T) {
+	engine := newKnowledgeDownloadRouteTestEngine(
+		t,
+		types.TenantRoleContributor,
+		"me",
+		&types.Knowledge{ID: "knowledge-own", KnowledgeBaseID: "kb-own", TenantID: 1},
+		&types.KnowledgeBase{ID: "kb-own", TenantID: 1, CreatorID: "other"},
+		nil,
+	)
+
+	rec := serveKnowledgeFile(t, engine, "/api/v1/knowledge/knowledge-own/download")
+	require.Equal(t, http.StatusForbidden, rec.Code, "body=%s", rec.Body.String())
+}
+
+func TestKnowledgeDownloadRejectsLegacyTenantOwnedKB(t *testing.T) {
+	engine := newKnowledgeDownloadRouteTestEngine(
+		t,
+		types.TenantRoleContributor,
+		"me",
+		&types.Knowledge{ID: "knowledge-own", KnowledgeBaseID: "kb-own", TenantID: 1},
+		&types.KnowledgeBase{ID: "kb-own", TenantID: 1, CreatorID: ""},
+		nil,
+	)
+
+	rec := serveKnowledgeFile(t, engine, "/api/v1/knowledge/knowledge-own/download")
+	require.Equal(t, http.StatusForbidden, rec.Code, "body=%s", rec.Body.String())
+}
+
+func TestKnowledgeDownloadAllowsCreator(t *testing.T) {
+	engine := newKnowledgeDownloadRouteTestEngine(
+		t,
+		types.TenantRoleContributor,
+		"me",
+		&types.Knowledge{ID: "knowledge-own", KnowledgeBaseID: "kb-own", TenantID: 1},
+		&types.KnowledgeBase{ID: "kb-own", TenantID: 1, CreatorID: "me"},
+		nil,
+	)
+
+	rec := serveKnowledgeFile(t, engine, "/api/v1/knowledge/knowledge-own/download")
+	require.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+}
+
+func TestKnowledgeDownloadAllowsAdmin(t *testing.T) {
+	engine := newKnowledgeDownloadRouteTestEngine(
+		t,
+		types.TenantRoleAdmin,
+		"me",
+		&types.Knowledge{ID: "knowledge-own", KnowledgeBaseID: "kb-own", TenantID: 1},
+		&types.KnowledgeBase{ID: "kb-own", TenantID: 1, CreatorID: "other"},
+		nil,
+	)
+
+	rec := serveKnowledgeFile(t, engine, "/api/v1/knowledge/knowledge-own/download")
+	require.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+}
+
+func TestKnowledgeDownloadAllowsSharedEditor(t *testing.T) {
+	engine := newKnowledgeDownloadRouteTestEngine(
+		t,
+		types.TenantRoleContributor,
+		"me",
+		&types.Knowledge{ID: "knowledge-shared", KnowledgeBaseID: "kb-shared", TenantID: 2},
+		&types.KnowledgeBase{ID: "kb-shared", TenantID: 2, CreatorID: "other"},
+		&downloadKBShareStub{permission: types.OrgRoleEditor, source: 2},
+	)
+
+	rec := serveKnowledgeFile(t, engine, "/api/v1/knowledge/knowledge-shared/download")
+	require.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+}
+
+func TestKnowledgePreviewRejectsNonCreatorContributor(t *testing.T) {
+	engine := newKnowledgeDownloadRouteTestEngine(
+		t,
+		types.TenantRoleContributor,
+		"me",
+		&types.Knowledge{ID: "knowledge-own", KnowledgeBaseID: "kb-own", TenantID: 1},
+		&types.KnowledgeBase{ID: "kb-own", TenantID: 1, CreatorID: "other"},
+		nil,
+	)
+
+	rec := serveKnowledgeFile(t, engine, "/api/v1/knowledge/knowledge-own/preview")
+	require.Equal(t, http.StatusForbidden, rec.Code, "body=%s", rec.Body.String())
+}
+
+func TestKnowledgePreviewRejectsReadOnlySharedKB(t *testing.T) {
+	engine := newKnowledgeDownloadRouteTestEngine(
+		t,
+		types.TenantRoleContributor,
+		"me",
+		&types.Knowledge{ID: "knowledge-shared", KnowledgeBaseID: "kb-shared", TenantID: 2},
+		&types.KnowledgeBase{ID: "kb-shared", TenantID: 2, CreatorID: "other"},
+		&downloadKBShareStub{permission: types.OrgRoleViewer, source: 2},
+	)
+
+	rec := serveKnowledgeFile(t, engine, "/api/v1/knowledge/knowledge-shared/preview")
+	require.Equal(t, http.StatusForbidden, rec.Code, "body=%s", rec.Body.String())
+}
+
+func TestKnowledgePreviewAllowsCreator(t *testing.T) {
+	engine := newKnowledgeDownloadRouteTestEngine(
+		t,
+		types.TenantRoleContributor,
+		"me",
+		&types.Knowledge{ID: "knowledge-own", KnowledgeBaseID: "kb-own", TenantID: 1},
+		&types.KnowledgeBase{ID: "kb-own", TenantID: 1, CreatorID: "me"},
+		nil,
+	)
+
+	rec := serveKnowledgeFile(t, engine, "/api/v1/knowledge/knowledge-own/preview")
+	require.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
 }

--- a/internal/router/routes_knowledge.go
+++ b/internal/router/routes_knowledge.go
@@ -109,12 +109,15 @@ func RegisterKnowledgeRoutes(r *gin.RouterGroup, handler *handler.KnowledgeHandl
 		k.PUT("/manual/:id", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.UpdateManualKnowledge)
 		k.POST("/:id/reparse", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.ReparseKnowledge)
 		k.POST("/:id/cancel-parse", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.CancelKnowledgeParse)
-		// Downloading exposes the original source file, so it has a stricter
-		// boundary than viewing parsed content or previewing it: tenant Viewers
-		// cannot download from their own workspace, and org-shared Viewer access
-		// cannot download from the source workspace. API keys still follow the
-		// retrieve capability declared by kRead; role guards intentionally defer
-		// machine-principal authorization to the API-key gate.
+		// Downloading and previewing expose the original source file, so they
+		// have a stricter boundary than viewing parsed content: within the
+		// owning tenant only the KB creator or Admin+ may fetch it, and
+		// org-shared Viewer access cannot fetch it from the source workspace
+		// either. Both floors are enforced in the handlers
+		// (DownloadKnowledgeFile / PreviewKnowledgeFile), not by route guards.
+		// API keys still follow the retrieve capability declared by kRead;
+		// role guards intentionally defer machine-principal authorization to
+		// the API-key gate.
 		kRead.GET("/:id/download", g.Contributor(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.DownloadKnowledgeFile)
 		kRead.GET("/:id/preview", g.Viewer(), g.KBAccessReadFromKnowledgeIDParam("id"), handler.PreviewKnowledgeFile)
 		k.PUT("/image/:id/:chunk_id", g.OwnedKnowledgeKBOrAdmin(), g.KBAccessWriteFromKnowledgeIDParam("id"), handler.UpdateImageInfo)


### PR DESCRIPTION
## 问题

空间"编辑者"（Contributor）对他人创建的知识库只有查看权限，但仍能下载其中的原始文件：

- 后端 `GET /knowledge/:id/download` 路由守卫只要求 Contributor 角色，对同租户 KB 一律放行，没有校验 KB 创建者；
- `GET /knowledge/:id/preview` 只要求 Viewer，返回的却是与下载完全相同的原始文件字节——只隐藏前端按钮无法阻止用户直接调接口获取原件。

## 方案

下载与原始文件预览使用同一套服务端强制权限（`checkKnowledgeOriginalFilePermission`）：

| 身份 | 下载 / 预览原件 | 分块 / 全文（解析内容） |
|---|---|---|
| KB 创建者 | ✅ | ✅ |
| 同空间 Admin+ | ✅ | ✅ |
| 编辑者（他人 KB） | ❌ 403 | ✅ |
| 本空间 Viewer | ❌ | ✅ |
| 跨空间共享 editor/admin | ✅ | ✅ |
| 跨空间共享 viewer / 共享智能体可见 | ❌ | ✅ |

后端：
- `PreviewKnowledgeFile` 的访问级别从 OrgRoleViewer 提升到 OrgRoleEditor（与下载一致），并接入同一权限检查；
- 同租户用 `middleware.EvaluateOwnershipOrRole` 复用全仓库 "creator OR Admin+" 矩阵（自动兼容 API key 短路、cross-tenant superuser、EnableRBAC rollout 语义）；
- 跨空间共享维持现状（editor+ 可下载）。

前端：
- `canDownloadKnowledge` 收紧为同空间"创建者或 Admin+"、跨空间共享 editor+，一处 computed 同时控制预览抽屉下载按钮、卡片菜单、列表菜单；
- 无权限时预览 tab 隐藏（仅显示全文/分块），音频播放器不再加载（同样走 preview 接口）。

## 兼容性

- `creator_id` 为空的老 KB（RBAC migration 已回填，实际罕见）：仅 Admin+ 可下载，与 `RequireOwnershipOrRole` 既有矩阵一致；
- `EnableRBAC=false` 部署：ownership 检查与全仓库守卫一致 fail-open；共享 viewer 拦截不受影响（在 resolve 层）；
- API key：机器主体维持 `EvaluateOwnershipOrRole` 既有短路语义，同空间 key 不受影响。

## 测试

`internal/router/router_knowledge_download_test.go` 重写为真实 handler 全链路用例（10 个）：非 creator 编辑者 download/preview 双 403、creator/Admin/共享 editor 放行、共享 viewer preview 403、空 creator 老 KB fail-closed，并保留原有 2 个回归用例。

`go test ./internal/router/ ./internal/handler/`、`gofmt`、前端 `type-check` / `build` 全部通过。