### PR TITLE
fix(frontend): escape attachment parsing error summary bound via v-html

### DIFF
--- a/frontend/src/utils/attachmentParsingDisplay.test.mjs
+++ b/frontend/src/utils/attachmentParsingDisplay.test.mjs
@@ -52,3 +52,34 @@ test('getAttachmentParsingSummaryHtml renders skipped count', () => {
   })
   assert.equal(html, '已解析 <strong>2</strong> 个附件，<strong>1</strong> 个未完成已跳过')
 })
+
+// The summary is bound with v-html, so a failed parse must never inject raw
+// markup. The backend embeds the attachment filename in the error text, and
+// the upload-side filename filter only blocks a small set of event-handler
+// patterns, so names like `<details open ontoggle=...>.pdf` reach this path.
+test('getAttachmentParsingSummaryHtml escapes HTML in failed output', () => {
+  const html = getAttachmentParsingSummaryHtml(t, {
+    success: false,
+    output:
+      '附件解析失败: attachment <details open ontoggle=alert(document.domain)>.pdf failed to parse: corrupt file',
+  })
+  assert.ok(!/<[a-z]/i.test(html), `raw HTML tag leaked: ${html}`)
+  assert.ok(html.includes('&lt;details'), `expected escaped text, got: ${html}`)
+})
+
+test('getAttachmentParsingSummaryHtml escapes img onerror payloads', () => {
+  const html = getAttachmentParsingSummaryHtml(t, {
+    success: false,
+    error: 'attachment <img src=x onerror=alert(document.domain)> failed to parse: bad content',
+  })
+  assert.ok(!/<[a-z]/i.test(html), `raw HTML tag leaked: ${html}`)
+  assert.ok(html.includes('&lt;img'), `expected escaped text, got: ${html}`)
+})
+
+test('getAttachmentParsingSummaryHtml keeps plain error text intact', () => {
+  const html = getAttachmentParsingSummaryHtml(t, {
+    success: false,
+    output: '附件解析失败: attachment report.pdf failed to parse: unexpected EOF',
+  })
+  assert.equal(html, 'attachment report.pdf failed to parse: unexpected EOF')
+})

--- a/frontend/src/utils/attachmentParsingDisplay.ts
+++ b/frontend/src/utils/attachmentParsingDisplay.ts
@@ -1,5 +1,7 @@
 import type { ComposerTranslation } from 'vue-i18n'
 
+import { escapeHTML } from './security.ts'
+
 type AttachmentParsingEvent = {
   success?: boolean
   output?: string
@@ -44,7 +46,9 @@ export function getAttachmentParsingSummaryHtml(
     const err = String(event.error || event.output || '').trim()
     if (!err) return ''
     const normalized = err.replace(/^附件解析失败:\s*/i, '').trim()
-    return normalized || err
+    // The summary is bound with v-html and the backend error embeds the
+    // user-supplied attachment filename, so it must be escaped first.
+    return escapeHTML(normalized || err)
   }
 
   const { parsed, skipped } = resolveAttachmentParsingCounts(event)


### PR DESCRIPTION
## 问题

附件解析失败时,摘要区域通过 `v-html` 渲染,而渲染内容包含后端返回的错误文本——其中嵌入了**用户上传的原始文件名**。恶意文件名可注入活体 HTML 元素并执行事件处理器,构成 XSS。

## 根因链路

1. 上传名为 `<details open ontoggle=alert(document.domain)>.pdf` 的文件——后端 `ValidateInput`(internal/utils/security.go)的事件处理器黑名单只覆盖 `onload/onerror/onclick/onmouseover/onfocus/onblur`,`ontoggle` 等不在列,文件名可完整穿过
2. 解析失败后,后端把原始文件名拼进错误文本: `temporary_document.go:621` → `qa.go:1216` 的 `附件解析失败: ...`
3. 前端 `getAttachmentParsingSummaryHtml` 对 `success===false` 分支**原样返回**该错误字符串
4. 返回值经 `v-html` 绑定(RagPipelineProgress.vue:79/204、AgentStreamDisplay.vue:208/497)→ 活体 `<details>` 元素进入 DOM,toggle 事件在插入时即触发

用 jsdom 按仓库真实管线验证: 修复前 payload 以活体元素形式进入 DOM,修复后为纯转义文本。

## 修法

`getAttachmentParsingSummaryHtml` 的 error 分支返回前,用项目已有的共享工具 `escapeHTML`(utils/security.ts,转义 `& < > " ' ` / = ` 全集)转义。单点修复覆盖两个 v-html 调用点,不新增依赖。

## 验证

- 新增 3 个单元测试(ontoggle payload 转义、img/onerror payload 转义、纯文本不透转义)——先写测试确认 RED,修复后 GREEN
- 全量前端测试 583/583 通过,`npm run type-check`(vue-tsc)干净
- 正常错误文本(含中文、`A&B.pdf` 这类合法字符)展示无二次转义回归

## 与 #2863 的关系(如实说明)

#2863 报告的是 `<img src=x onerror=...>` 型 XSS,但未指明入口。我审计了全部 63 处 `v-html`/`v-stable-html` 绑定和全部 6 处 `marked.parse` 调用点(聊天回答、文档预览、wiki、知识块等),**Markdown 渲染路径均已有 DOMPurify 消毒**,字面报告的路径未能复现。本 PR 修复的是同属一类(用户输入未经转义进入 v-html)的另一条**已实证**的入口,故用 Refs 而非 Closes。

Refs #2863