### PR TITLE
fix(agent): web_fetch 兼容 LLM 双重序列化的 items 参数

### DIFF
--- a/internal/agent/tools/web_fetch.go
+++ b/internal/agent/tools/web_fetch.go
@@ -78,7 +78,14 @@ func (t *WebFetchTool) Execute(ctx context.Context, args json.RawMessage) (*type
 	logger.Infof(ctx, "[Tool][WebFetch] Execute started")
 	var input WebFetchInput
 	if err := json.Unmarshal(args, &input); err != nil {
-		return &types.ToolResult{Success: false, Error: fmt.Sprintf("failed to parse args: %v", err)}, err
+		// Some models double-encode the items array as a JSON string; unwrap and retry.
+		var wrapped struct {
+			Items string `json:"items"`
+		}
+		if json.Unmarshal(args, &wrapped) != nil || json.Unmarshal([]byte(wrapped.Items), &input.Items) != nil || len(input.Items) == 0 {
+			return &types.ToolResult{Success: false, Error: fmt.Sprintf("failed to parse args: %v", err)}, err
+		}
+		logger.Warnf(ctx, "[Tool][WebFetch] Unwrapped double-encoded items string (%d item(s))", len(input.Items))
 	}
 	if len(input.Items) == 0 {
 		return &types.ToolResult{Success: false, Error: "missing required parameter: items"}, nil

--- a/internal/agent/tools/web_fetch_test.go
+++ b/internal/agent/tools/web_fetch_test.go
@@ -129,6 +129,22 @@ func TestWebFetchToolDeduplicatesGitHubBlobAndRawURLs(t *testing.T) {
 	assert.Equal(t, 1, result.Data["skipped_count"])
 }
 
+func TestWebFetchToolUnwrapsDoubleEncodedItemsString(t *testing.T) {
+	const rawURL = "https://example.com/article"
+	fetcher := newStubWebContentFetcher(map[string]string{rawURL: "article content"}, nil)
+	tool := newWebFetchTool(nil, fetcher)
+
+	// Some models emit {"items":"[{\"url\":...}]"} instead of a real array.
+	itemsJSON, _ := json.Marshal([]WebFetchItem{{URL: rawURL, Prompt: "extract facts"}})
+	encoded, _ := json.Marshal(map[string]string{"items": string(itemsJSON)})
+
+	result, err := tool.Execute(context.Background(), encoded)
+
+	require.NoError(t, err)
+	require.True(t, result.Success)
+	assert.Equal(t, 1, fetcher.callCount[rawURL])
+}
+
 func newStubWebContentFetcher(contents map[string]string, failures map[string]error) *stubWebContentFetcher {
 	return &stubWebContentFetcher{
 		contents:  contents,


### PR DESCRIPTION
## 问题

部分模型（实测某 vLLM 网关上的 Qwen3.5-397B）在**多工具 agent 上下文**中调用 `web_fetch` 时，会把 `items` 数组双重序列化为 JSON 字符串：

```json
{"items": "[{\"prompt\": \"...\", \"url\": \"https://example.com\"}]"}
```

而 `WebFetchInput.Items` 期望 `[]WebFetchItem`，`json.Unmarshal` 直接报错：

```
json: cannot unmarshal string into Go struct field WebFetchInput.items of type []tools.WebFetchItem
```

工具 0ms 即失败，URL 根本没有发出，用户侧表现为"网页抓取失败"。

## 复现特征

- 同一模型在**单工具**上下文中输出正常数组，仅在多个工具 schema 同时下发时稳定字符串化（3/3 确定性复现）；
- 其他模型（qwen3.8:27b）同上下文输出正常，属模型侧 tool-call 生成缺陷；
- 代理链路、DNS、目标站点均正常（容器内 curl 同 URL 200）。

## 修复

`internal/agent/tools/web_fetch.go` 的 `Execute`：首次反序列化失败时，若 `items` 是 JSON 字符串则解包后二次解析，成功则照常执行并记录 Warn 日志；解包仍失败则保留原有错误返回。

对 LLM 输出做容错与 `act.go` 中已有的"截断 JSON 参数修复"思路一致，不影响任何正常格式调用。

## 测试

- 新增 `TestWebFetchToolUnwrapsDoubleEncodedItemsString` 覆盖双重序列化入参；
- `go test ./internal/agent/tools/ -run TestWebFetchTool` 全部通过。