### PR TITLE
fix(provider): match BaseURL host case-insensitively in DetectProvider

### DIFF
--- a/internal/models/provider/provider.go
+++ b/internal/models/provider/provider.go
@@ -222,7 +222,12 @@ func ListByModelType(modelType types.ModelType) []ProviderInfo {
 }
 
 // DetectProvider 通过 BaseURL 检测服务商
+//
+// 主机名按 RFC 4343 是大小写不敏感的，用户填写的 BaseURL 也可能带大写，
+// 因此先统一转成小写再匹配；否则形如 https://API.OPENAI.COM/v1 的地址会
+// 落到 ProviderGeneric，被当成兼容 OpenAI 的自定义部署来解析请求与响应。
 func DetectProvider(baseURL string) ProviderName {
+	baseURL = strings.ToLower(baseURL)
 	switch {
 	case containsAny(baseURL, "dashscope.aliyuncs.com"):
 		return ProviderAliyun

--- a/internal/models/provider/provider_test.go
+++ b/internal/models/provider/provider_test.go
@@ -55,6 +55,17 @@ func TestDetectProvider(t *testing.T) {
 		{"http://localhost:11434/v1", ProviderGeneric},
 		{"https://integrate.api.nvidia.com/v1", ProviderNvidia},
 		{"https://ai.api.nvidia.com/v1/retrieval/nvidia/reranking", ProviderNvidia},
+		// 主机名大小写不敏感（RFC 4343）：带大写的 BaseURL 必须识别成同一个服务商，
+		// 否则会落到 ProviderGeneric 并用兼容 OpenAI 的口径去解析别家的响应。
+		{"https://API.OPENAI.COM/v1", ProviderOpenAI},
+		{"https://Api.OpenAI.com/v1", ProviderOpenAI},
+		{"HTTPS://API.DEEPSEEK.COM/v1", ProviderDeepSeek},
+		{"https://DashScope.aliyuncs.com/compatible-mode/v1", ProviderAliyun},
+		{"https://Open.BigModel.cn/api/paas/v4", ProviderZhipu},
+		{"https://LiteLLM.example.com/v1", ProviderLiteLLM},
+		{"https://API.HUNYUAN.CLOUD.TENCENT.COM/v1", ProviderHunyuan},
+		// 大写的自定义域名仍然应该是 Generic，不能被误判成某个已知服务商。
+		{"https://CUSTOM-ENDPOINT.EXAMPLE.COM/v1", ProviderGeneric},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 问题

`DetectProvider` 用小写子串去匹配原始 `BaseURL`，因此只要用户填的地址带大写字母，就会**跳过所有分支落到 `ProviderGeneric`**：

```
https://api.openai.com/v1   -> openai
https://API.OPENAI.COM/v1   -> generic   ← 同一个端点，识别结果不同
HTTPS://API.DEEPSEEK.COM/v1 -> generic
```

主机名按 RFC 4343 是大小写不敏感的，`API.OPENAI.COM` 与 `api.openai.com` 指向同一服务，但前者被当成「兼容 OpenAI 的自定义部署」，服务商专属的请求构造与响应解析不会生效。

这正是 #573 描述的那类后果：**用错误的口径去解析别家模型的返回**。#573 的主诉是希望自定义域名下能指定服务商（需要新的配置面，属于产品决策），本 PR 只修其中确定是缺陷的一半——同一域名因大小写而识别不一致。

## 影响面

`DetectProvider` 有 8 个调用点，覆盖 chat / thinking / embedding / vlm / rerank：

| 文件 | 行 |
|---|---|
| `internal/models/chat/remote_api.go` | 52 |
| `internal/models/chat/chat.go` | 188 |
| `internal/models/chat/thinking.go` | 156 |
| `internal/models/embedding/embedder.go` | 122 |
| `internal/models/provider/provider.go` | 303 |
| `internal/models/vlm/remote_api.go` | 58 |
| `internal/models/vlm/vlm.go` | 109 |
| `internal/models/rerank/reranker.go` | 137 |

## 改动

在匹配前把 `BaseURL` 统一转小写：

```go
baseURL = strings.ToLower(baseURL)
```

- **不改变任何既有识别结果**：我逐条核对了 switch 里全部 `containsAny` 的匹配串，**全部本来就是小写**（脚本枚举确认，无一例外，也没有非字面量参数）；`strings` 已在 import 中。
- **自定义域名仍是 `Generic`**：新增 `https://CUSTOM-ENDPOINT.EXAMPLE.COM/v1` 用例锁住这点，避免为了修大写而把未知域名误判成已知服务商。
- 只动 `DetectProvider` 一处，未改 `containsAny`，其他调用方语义不受影响。

## 验证

- `go test ./internal/models/provider/` — **ok**，既有 21 条用例全过，新增 7 条。
- **确认新用例有效**：仅移除 `strings.ToLower` 这一行，测试即失败（例如 `API.HUNYUAN.CLOUD.TENCENT.COM` 期望 `hunyuan`、实际 `generic`）。
- `go build ./...` — 通过（仅有仓库既有的 cgo/sqlite 弃用告警与重复库链接告警，与本改动无关）。
- `gofmt -l` 无输出；`go vet ./internal/models/provider/` 无输出。

新增用例沿用该文件既有的表驱动写法，覆盖全大写、混合大小写、连 scheme 一起大写，以及大写自定义域名的兜底。

🤖 Written with [Claude Code](https://claude.ai/code).
