### PR TITLE
fix(frontend): recover the chat stream from an expired access token

### DIFF
--- a/frontend/src/api/chat/streame.ts
+++ b/frontend/src/api/chat/streame.ts
@@ -7,8 +7,22 @@ import {
   sanitizeStreamRequestBody,
   type StreamRequestMeta,
 } from '@/utils/chatRequestDebug';
+import { refreshAccessTokenShared, forceReloginRedirect } from '@/utils/request';
 
-
+/**
+ * The SSE handshake was rejected for auth reasons.
+ *
+ * Streaming runs on raw fetch, outside the axios instance, so nothing else
+ * refreshes the token for it. This marker lets startStream tell "your login
+ * expired" apart from a genuine stream failure and recover instead of showing
+ * a dead-end "HTTP 401" toast.
+ */
+class StreamAuthError extends Error {
+  constructor(readonly status: number) {
+    super(`HTTP ${status}`);
+    this.name = 'StreamAuthError';
+  }
+}
 
 interface StreamOptions {
   // 请求方法 (默认POST)
@@ -148,11 +162,14 @@ export function useStream() {
         sentAt: Date.now(),
       };
       
-      await fetchEventSource(url, {
+      // Wrapped so an expired access token can be refreshed and the request
+      // replayed once. Nothing has been streamed to the UI yet when the
+      // handshake 401s, so the replay is invisible to the user.
+      const runStream = (authToken: string) => fetchEventSource(url, {
         method: params.method,
         headers: {
           "Content-Type": "application/json",
-          "Authorization": embedToken ? `Embed ${embedToken}` : `Bearer ${token}`,
+          "Authorization": embedToken ? `Embed ${embedToken}` : `Bearer ${authToken}`,
           "Accept-Language": i18n.global.locale?.value || localStorage.getItem('locale') || 'zh-CN',
           "X-Request-ID": requestID,
           ...(!embedToken && tenantIdHeader ? { "X-Tenant-ID": tenantIdHeader } : {}),
@@ -167,6 +184,8 @@ export function useStream() {
         openWhenHidden: true,
 
         onopen: async (res) => {
+          // 401 is recoverable (refresh + replay); everything else is not.
+          if (res.status === 401) throw new StreamAuthError(res.status);
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           console.log(`[TTFB] response:headers request_id=${requestID} elapsed_ms=${(performance.now() - sentAt).toFixed(1)}`);
           isLoading.value = false;
@@ -190,6 +209,9 @@ export function useStream() {
         },
 
         onerror: (err) => {
+          // Let the auth marker through unwrapped so startStream can act on
+          // it; wrapping would turn it into an opaque string.
+          if (err instanceof StreamAuthError) throw err;
           throw new Error(`${i18n.global.t('error.streamFailed')}: ${err}`);
         },
 
@@ -197,6 +219,43 @@ export function useStream() {
           stopStream();
         },
       });
+
+      try {
+        await runStream(token);
+      } catch (err) {
+        // Embed visitors authenticate with an Embed token that this SPA
+        // cannot refresh — surface the failure instead of bouncing them.
+        if (!(err instanceof StreamAuthError) || embedToken) throw err;
+
+        // The access token died between page load and send. Most often the
+        // account was logged out elsewhere: the backend's Logout revokes
+        // every token issued to that user, so another device signing out
+        // kills this session mid-conversation. Reuse the axios refresh path
+        // (shared queue, so concurrent 401s trigger one refresh) and replay.
+        console.warn('[Stream] auth rejected on handshake, refreshing token and retrying once');
+        let refreshedToken: string;
+        try {
+          refreshedToken = await refreshAccessTokenShared();
+        } catch {
+          // Credentials cleared and /login redirect already issued.
+          throw new Error(i18n.global.t('error.pleaseRelogin'));
+        }
+
+        // A newer send superseded this one while we were refreshing.
+        if (myGeneration !== streamGeneration) return;
+
+        try {
+          await runStream(refreshedToken);
+        } catch (retryErr) {
+          if (retryErr instanceof StreamAuthError) {
+            // A token minted seconds ago was rejected — the session is gone
+            // for good (revoked, not merely expired). Send them to /login.
+            forceReloginRedirect();
+            throw new Error(i18n.global.t('error.pleaseRelogin'));
+          }
+          throw retryErr;
+        }
+      }
     } catch (err) {
       error.value = err instanceof Error ? err.message : String(err)
       stopStream()

--- a/frontend/src/api/chat/streame.ts
+++ b/frontend/src/api/chat/streame.ts
@@ -7,22 +7,12 @@ import {
   sanitizeStreamRequestBody,
   type StreamRequestMeta,
 } from '@/utils/chatRequestDebug';
-import { refreshAccessTokenShared, forceReloginRedirect } from '@/utils/request';
-
-/**
- * The SSE handshake was rejected for auth reasons.
- *
- * Streaming runs on raw fetch, outside the axios instance, so nothing else
- * refreshes the token for it. This marker lets startStream tell "your login
- * expired" apart from a genuine stream failure and recover instead of showing
- * a dead-end "HTTP 401" toast.
- */
-class StreamAuthError extends Error {
-  constructor(readonly status: number) {
-    super(`HTTP ${status}`);
-    this.name = 'StreamAuthError';
-  }
-}
+import {
+  StreamAuthError,
+  isStreamAuthError,
+  refreshAccessTokenShared,
+  runStreamWithAuthRetry,
+} from '@/utils/authRefresh';
 
 interface StreamOptions {
   // 请求方法 (默认POST)
@@ -52,6 +42,7 @@ export function useStream() {
   // 启动流式请求
   const startStream = async (params: { session_id: any; query: any; knowledge_base_ids?: string[]; knowledge_ids?: string[]; tag_ids?: string[]; agent_enabled?: boolean; agent_id?: string; agent_source_tenant_id?: string | number; web_search_enabled?: boolean; summary_model_id?: string; mcp_service_ids?: string[]; skill_names?: string[]; mentioned_items?: Array<{id: string; name: string; type: string; kb_type?: string; kb_id?: string; kb_name?: string; service_id?: string; skill_name?: string}>; images?: Array<{data: string}>; attachment_uploads?: Array<{data: string; file_name: string; file_size: number}>; attachment_ids?: string[]; suggestion_attribution?: { suggestion_set_id: string; question_id: string }; method: string; url: string; embed_token?: string; embed_session_sig?: string; embed_visitor_id?: string }) => {
     const myGeneration = ++streamGeneration
+    const streamAbort = controller
     // 重置状态
     output.value = '';
     error.value = null;
@@ -180,7 +171,7 @@ export function useStream() {
           params.method == "POST"
             ? JSON.stringify(postBody)
             : null,
-        signal: controller.signal,
+        signal: streamAbort.signal,
         openWhenHidden: true,
 
         onopen: async (res) => {
@@ -209,9 +200,7 @@ export function useStream() {
         },
 
         onerror: (err) => {
-          // Let the auth marker through unwrapped so startStream can act on
-          // it; wrapping would turn it into an opaque string.
-          if (err instanceof StreamAuthError) throw err;
+          if (isStreamAuthError(err)) throw err;
           throw new Error(`${i18n.global.t('error.streamFailed')}: ${err}`);
         },
 
@@ -220,42 +209,19 @@ export function useStream() {
         },
       });
 
-      try {
-        await runStream(token);
-      } catch (err) {
-        // Embed visitors authenticate with an Embed token that this SPA
-        // cannot refresh — surface the failure instead of bouncing them.
-        if (!(err instanceof StreamAuthError) || embedToken) throw err;
-
-        // The access token died between page load and send. Most often the
-        // account was logged out elsewhere: the backend's Logout revokes
-        // every token issued to that user, so another device signing out
-        // kills this session mid-conversation. Reuse the axios refresh path
-        // (shared queue, so concurrent 401s trigger one refresh) and replay.
-        console.warn('[Stream] auth rejected on handshake, refreshing token and retrying once');
-        let refreshedToken: string;
-        try {
-          refreshedToken = await refreshAccessTokenShared();
-        } catch {
-          // Credentials cleared and /login redirect already issued.
-          throw new Error(i18n.global.t('error.pleaseRelogin'));
-        }
-
-        // A newer send superseded this one while we were refreshing.
-        if (myGeneration !== streamGeneration) return;
-
-        try {
-          await runStream(refreshedToken);
-        } catch (retryErr) {
-          if (retryErr instanceof StreamAuthError) {
-            // A token minted seconds ago was rejected — the session is gone
-            // for good (revoked, not merely expired). Send them to /login.
-            forceReloginRedirect();
-            throw new Error(i18n.global.t('error.pleaseRelogin'));
-          }
-          throw retryErr;
-        }
-      }
+      await runStreamWithAuthRetry({
+        run: runStream,
+        initialToken: token,
+        isEmbed: Boolean(embedToken),
+        isCurrent: () => myGeneration === streamGeneration && !streamAbort.signal.aborted,
+        refreshAccessToken: () => refreshAccessTokenShared({
+          messages: {
+            pleaseRelogin: i18n.global.t('error.pleaseRelogin'),
+            tokenRefreshFailed: i18n.global.t('error.tokenRefreshFailed'),
+          },
+        }),
+        reloginMessage: i18n.global.t('error.pleaseRelogin'),
+      });
     } catch (err) {
       error.value = err instanceof Error ? err.message : String(err)
       stopStream()

--- a/frontend/src/utils/authRefresh.test.ts
+++ b/frontend/src/utils/authRefresh.test.ts
@@ -1,0 +1,218 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+import {
+  StreamAuthError,
+  forceReloginRedirect,
+  isStreamAuthError,
+  refreshAccessTokenShared,
+  resetAuthRefreshStateForTests,
+  runStreamWithAuthRetry,
+} from './authRefresh.ts'
+
+type Store = Record<string, string>
+
+function installBrowser(pathname = '/chat') {
+  const store: Store = {}
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      getItem: (key: string) => (key in store ? store[key] : null),
+      setItem: (key: string, value: string) => {
+        store[key] = String(value)
+      },
+      removeItem: (key: string) => {
+        delete store[key]
+      },
+    },
+    configurable: true,
+    writable: true,
+  })
+  const location = { pathname, href: `http://localhost${pathname}` }
+  Object.defineProperty(globalThis, 'window', {
+    value: { location },
+    configurable: true,
+    writable: true,
+  })
+  return { store, location }
+}
+
+test.afterEach(() => {
+  resetAuthRefreshStateForTests()
+})
+
+test('isStreamAuthError matches the class and name-only wrappers', () => {
+  assert.equal(isStreamAuthError(new StreamAuthError(401)), true)
+  assert.equal(isStreamAuthError({ name: 'StreamAuthError', message: 'HTTP 401' }), true)
+  assert.equal(isStreamAuthError(new Error('HTTP 401')), false)
+  assert.equal(isStreamAuthError('HTTP 401'), false)
+})
+
+test('concurrent 401s share a single refresh call', async () => {
+  const { store } = installBrowser()
+  store.weknora_refresh_token = 'rt-1'
+  let calls = 0
+  let release!: (value: { success: true; data: { token: string; refreshToken: string } }) => void
+  const pending = new Promise<{ success: true; data: { token: string; refreshToken: string } }>(
+    (resolve) => {
+      release = resolve
+    },
+  )
+  const refresh = async () => {
+    calls += 1
+    return pending
+  }
+
+  const first = refreshAccessTokenShared({ refresh })
+  await Promise.resolve()
+  const second = refreshAccessTokenShared({ refresh })
+  assert.equal(calls, 1)
+
+  release({ success: true, data: { token: 'access-2', refreshToken: 'rt-2' } })
+  assert.deepEqual(await Promise.all([first, second]), ['access-2', 'access-2'])
+  assert.equal(store.weknora_token, 'access-2')
+  assert.equal(store.weknora_refresh_token, 'rt-2')
+  assert.equal(calls, 1)
+})
+
+test('missing refresh token clears credentials, redirects, and throws an Error', async () => {
+  const { store, location } = installBrowser()
+  store.weknora_token = 'expired'
+  store.weknora_user = '{}'
+  store.weknora_selected_tenant_id = '9'
+
+  await assert.rejects(
+    () => refreshAccessTokenShared({
+      refresh: async () => {
+        throw new Error('should not refresh')
+      },
+      messages: { pleaseRelogin: 'please-relogin', tokenRefreshFailed: 'refresh-failed' },
+    }),
+    (err: unknown) => err instanceof Error && err.message === 'please-relogin',
+  )
+  assert.equal(store.weknora_token, undefined)
+  assert.equal(store.weknora_selected_tenant_id, undefined)
+  assert.equal(location.href, '/login')
+})
+
+test('a failed refresh clears the newly irrelevant session and redirects', async () => {
+  const { store, location } = installBrowser()
+  store.weknora_refresh_token = 'rt-dead'
+  store.weknora_token = 'expired'
+  store.weknora_selected_tenant_id = '9'
+
+  await assert.rejects(
+    () => refreshAccessTokenShared({
+      refresh: async () => ({ success: false, message: 'revoked' }),
+    }),
+    /revoked/,
+  )
+  assert.equal(store.weknora_refresh_token, undefined)
+  assert.equal(store.weknora_selected_tenant_id, undefined)
+  assert.equal(location.href, '/login')
+})
+
+test('runStreamWithAuthRetry refreshes once and replays with the new token', async () => {
+  installBrowser()
+  const tokens: string[] = []
+  const result = await runStreamWithAuthRetry({
+    initialToken: 'expired',
+    isEmbed: false,
+    isCurrent: () => true,
+    refreshAccessToken: async () => 'fresh',
+    reloginMessage: 'please-relogin',
+    run: async (token) => {
+      tokens.push(token)
+      if (token === 'expired') throw new StreamAuthError(401)
+      return `ok:${token}`
+    },
+  })
+  assert.deepEqual(tokens, ['expired', 'fresh'])
+  assert.equal(result, 'ok:fresh')
+})
+
+test('embed visitors are not refreshed or redirected', async () => {
+  let refreshed = 0
+  await assert.rejects(
+    () => runStreamWithAuthRetry({
+      initialToken: 'embed-token',
+      isEmbed: true,
+      isCurrent: () => true,
+      refreshAccessToken: async () => {
+        refreshed += 1
+        return 'nope'
+      },
+      reloginMessage: 'please-relogin',
+      run: async () => {
+        throw new StreamAuthError(401)
+      },
+    }),
+    (err: unknown) => err instanceof StreamAuthError,
+  )
+  assert.equal(refreshed, 0)
+})
+
+test('a second handshake 401 after a successful refresh does not wipe tokens', async () => {
+  const { store, location } = installBrowser()
+  store.weknora_token = 'expired'
+  store.weknora_refresh_token = 'rt-1'
+  location.href = 'http://localhost/chat'
+
+  await assert.rejects(
+    () => runStreamWithAuthRetry({
+      initialToken: 'expired',
+      isEmbed: false,
+      isCurrent: () => true,
+      refreshAccessToken: async () => {
+        const token = await refreshAccessTokenShared({
+          refresh: async () => ({
+            success: true,
+            data: { token: 'fresh', refreshToken: 'rt-2' },
+          }),
+        })
+        return token
+      },
+      reloginMessage: 'please-relogin',
+      run: async () => {
+        throw new StreamAuthError(401)
+      },
+    }),
+    (err: unknown) => err instanceof Error && err.message === 'please-relogin',
+  )
+  assert.equal(store.weknora_token, 'fresh')
+  assert.equal(store.weknora_refresh_token, 'rt-2')
+  assert.equal(location.href, 'http://localhost/chat')
+})
+
+test('a superseded send skips the replay', async () => {
+  let runs = 0
+  const result = await runStreamWithAuthRetry({
+    initialToken: 'expired',
+    isEmbed: false,
+    isCurrent: () => false,
+    refreshAccessToken: async () => 'fresh',
+    reloginMessage: 'please-relogin',
+    run: async () => {
+      runs += 1
+      throw new StreamAuthError(401)
+    },
+  })
+  assert.equal(runs, 1)
+  assert.equal(result, undefined)
+})
+
+test('forceReloginRedirect does not bounce embed visitors to /login', () => {
+  const { store, location } = installBrowser('/embed/ch-1')
+  store.weknora_token = 'jwt'
+  forceReloginRedirect()
+  assert.equal(store.weknora_token, undefined)
+  assert.equal(location.href, 'http://localhost/embed/ch-1')
+})
+
+test('chat stream wires the shared retry and keeps the abort controller', () => {
+  const source = readFileSync(new URL('../api/chat/streame.ts', import.meta.url), 'utf8')
+  assert.match(source, /runStreamWithAuthRetry/)
+  assert.match(source, /isStreamAuthError/)
+  assert.match(source, /streamAbort/)
+  assert.doesNotMatch(source, /forceReloginRedirect/)
+})

--- a/frontend/src/utils/authRefresh.ts
+++ b/frontend/src/utils/authRefresh.ts
@@ -1,0 +1,196 @@
+/**
+ * Shared access-token refresh used by both axios and the chat SSE client.
+ *
+ * Refresh tokens rotate, so concurrent 401s must queue behind one in-flight
+ * /auth/refresh. The SSE handshake runs on raw fetch and cannot use the
+ * axios interceptor; both planes call {@link refreshAccessTokenShared}.
+ */
+
+const AUTH_STORAGE_KEYS = [
+  'weknora_token',
+  'weknora_refresh_token',
+  'weknora_user',
+  'weknora_tenant',
+  'weknora_knowledge_bases',
+  'weknora_current_kb',
+  'weknora_selected_tenant_id',
+  'weknora_selected_tenant_name',
+  'weknora_memberships',
+] as const
+
+let isRefreshing = false
+let failedQueue: Array<{
+  resolve: (token: string) => void
+  reject: (error: unknown) => void
+}> = []
+
+export type TokenRefreshResult = {
+  success: boolean
+  data?: { token: string; refreshToken: string }
+  message?: string
+}
+
+export type RefreshAccessTokenOptions = {
+  refresh?: (refreshToken: string) => Promise<TokenRefreshResult>
+  messages?: {
+    pleaseRelogin: string
+    tokenRefreshFailed: string
+  }
+}
+
+const defaultMessages = {
+  pleaseRelogin: 'Please log in again',
+  tokenRefreshFailed: 'Token refresh failed',
+}
+
+export class StreamAuthError extends Error {
+  constructor(readonly status: number) {
+    super(`HTTP ${status}`)
+    this.name = 'StreamAuthError'
+  }
+}
+
+export function isStreamAuthError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  if (err instanceof StreamAuthError) return true
+  return (err as { name?: string }).name === 'StreamAuthError'
+}
+
+export function isEmbedPage(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.location.pathname.startsWith('/embed/')
+}
+
+export function redirectToLogin() {
+  if (typeof window === 'undefined') return
+  if (window.location.pathname === '/login') return
+  if (isEmbedPage()) return
+  window.location.href = '/login'
+}
+
+export function clearAuthStorage() {
+  for (const key of AUTH_STORAGE_KEYS) {
+    localStorage.removeItem(key)
+  }
+}
+
+export function forceReloginRedirect() {
+  clearAuthStorage()
+  redirectToLogin()
+}
+
+function processQueue(error: unknown, token: string | null = null) {
+  failedQueue.forEach(({ resolve, reject }) => {
+    if (error) {
+      reject(error)
+    } else {
+      resolve(token as string)
+    }
+  })
+  failedQueue = []
+}
+
+async function defaultRefresh(refreshToken: string): Promise<TokenRefreshResult> {
+  const { refreshToken: refreshTokenAPI } = await import('../api/auth/index')
+  return refreshTokenAPI(refreshToken)
+}
+
+/**
+ * Refresh the access token, de-duplicated across all callers.
+ *
+ * Resolves with the new access token. On failure it has already cleared
+ * credentials and redirected to /login.
+ */
+export async function refreshAccessTokenShared(
+  options: RefreshAccessTokenOptions = {},
+): Promise<string> {
+  const messages = { ...defaultMessages, ...options.messages }
+  const refresh = options.refresh ?? defaultRefresh
+
+  if (isRefreshing) {
+    return new Promise<string>((resolve, reject) => {
+      failedQueue.push({ resolve, reject })
+    })
+  }
+
+  isRefreshing = true
+  const storedRefreshToken = localStorage.getItem('weknora_refresh_token')
+
+  if (!storedRefreshToken) {
+    clearAuthStorage()
+    const noRefreshTokenError = new Error(messages.pleaseRelogin)
+    processQueue(noRefreshTokenError, null)
+    isRefreshing = false
+    redirectToLogin()
+    throw noRefreshTokenError
+  }
+
+  try {
+    const response = await refresh(storedRefreshToken)
+
+    if (!response.success || !response.data?.token) {
+      throw new Error(response.message || messages.tokenRefreshFailed)
+    }
+
+    const { token, refreshToken: newRefreshToken } = response.data
+    localStorage.setItem('weknora_token', token)
+    if (newRefreshToken) {
+      localStorage.setItem('weknora_refresh_token', newRefreshToken)
+    }
+    processQueue(null, token)
+    return token
+  } catch (refreshError) {
+    clearAuthStorage()
+    processQueue(refreshError, null)
+    redirectToLogin()
+    throw refreshError
+  } finally {
+    isRefreshing = false
+  }
+}
+
+/**
+ * Replay an SSE handshake once after a 401. Refresh failure already
+ * redirected; a second 401 after a successful refresh is surfaced to the
+ * caller without wiping the newly minted session (axios does the same).
+ *
+ * Returns undefined when a newer send or an abort superseded the replay.
+ */
+export async function runStreamWithAuthRetry<T>(options: {
+  run: (token: string) => Promise<T>
+  initialToken: string
+  isEmbed: boolean
+  isCurrent: () => boolean
+  refreshAccessToken: () => Promise<string>
+  reloginMessage: string
+}): Promise<T | undefined> {
+  try {
+    return await options.run(options.initialToken)
+  } catch (err) {
+    if (!isStreamAuthError(err) || options.isEmbed) throw err
+
+    let refreshedToken: string
+    try {
+      refreshedToken = await options.refreshAccessToken()
+    } catch {
+      throw new Error(options.reloginMessage)
+    }
+
+    if (!options.isCurrent()) return undefined
+
+    try {
+      return await options.run(refreshedToken)
+    } catch (retryErr) {
+      if (isStreamAuthError(retryErr)) {
+        throw new Error(options.reloginMessage)
+      }
+      throw retryErr
+    }
+  }
+}
+
+/** Reset module locks between unit tests. */
+export function resetAuthRefreshStateForTests() {
+  isRefreshing = false
+  failedQueue = []
+}

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -110,6 +110,86 @@ function redirectToLogin() {
   window.location.href = '/login';
 }
 
+/**
+ * Clear stored credentials and send the SPA to /login.
+ *
+ * Exported for callers that authenticate outside this axios instance (the SSE
+ * client) and therefore can't rely on the response interceptor to do it.
+ */
+export function forceReloginRedirect() {
+  localStorage.removeItem('weknora_token');
+  localStorage.removeItem('weknora_refresh_token');
+  localStorage.removeItem('weknora_user');
+  localStorage.removeItem('weknora_tenant');
+  redirectToLogin();
+}
+
+/**
+ * Refresh the access token, de-duplicated across all callers.
+ *
+ * The axios interceptor and the SSE client share one in-flight refresh, so a
+ * burst of 401s produces a single /auth/refresh call instead of N racing ones
+ * (refresh tokens rotate — concurrent refreshes invalidate each other).
+ *
+ * Resolves with the new access token. On failure it has already cleared the
+ * credentials and redirected to /login, so callers only need to surface a
+ * message.
+ */
+export async function refreshAccessTokenShared(): Promise<string> {
+  if (isRefreshing) {
+    // A refresh is already in flight — wait for its result instead of
+    // starting a second one.
+    return new Promise<string>((resolve, reject) => {
+      failedQueue.push({ resolve, reject });
+    });
+  }
+
+  isRefreshing = true;
+  const storedRefreshToken = localStorage.getItem('weknora_refresh_token');
+
+  if (!storedRefreshToken) {
+    localStorage.removeItem('weknora_token');
+    localStorage.removeItem('weknora_user');
+    localStorage.removeItem('weknora_tenant');
+    const noRefreshTokenError = { message: t('error.pleaseRelogin') };
+    processQueue(noRefreshTokenError, null);
+    isRefreshing = false;
+    redirectToLogin();
+    throw noRefreshTokenError;
+  }
+
+  try {
+    // 动态导入refresh token API
+    const { refreshToken: refreshTokenAPI } = await import('../api/auth/index');
+    const response = await refreshTokenAPI(storedRefreshToken);
+
+    if (!response.success || !response.data) {
+      throw new Error(response.message || t('error.tokenRefreshFailed'));
+    }
+
+    const { token, refreshToken: newRefreshToken } = response.data;
+
+    localStorage.setItem('weknora_token', token);
+    localStorage.setItem('weknora_refresh_token', newRefreshToken);
+    processQueue(null, token);
+
+    return token;
+  } catch (refreshError) {
+    // 刷新失败，清除所有token并跳转到登录页
+    localStorage.removeItem('weknora_token');
+    localStorage.removeItem('weknora_refresh_token');
+    localStorage.removeItem('weknora_user');
+    localStorage.removeItem('weknora_tenant');
+
+    processQueue(refreshError, null);
+    redirectToLogin();
+
+    throw refreshError;
+  } finally {
+    isRefreshing = false;
+  }
+}
+
 instance.interceptors.response.use(
   (response) => {
     // 根据业务状态码处理逻辑
@@ -147,70 +227,15 @@ instance.interceptors.response.use(
 
     // 如果是401错误且不是刷新token的请求，尝试刷新token
     if (error.response.status === 401 && !originalRequest._retry && !originalRequest.url?.includes('/auth/refresh')) {
-      if (isRefreshing) {
-        // 如果正在刷新token，将请求加入队列
-        return new Promise((resolve, reject) => {
-          failedQueue.push({ resolve, reject });
-        }).then(token => {
-          originalRequest.headers['Authorization'] = 'Bearer ' + token;
-          return instance(originalRequest);
-        }).catch(err => {
-          return Promise.reject(err);
-        });
-      }
-      
       originalRequest._retry = true;
-      isRefreshing = true;
-      
-      const refreshToken = localStorage.getItem('weknora_refresh_token');
-      
-      if (refreshToken) {
-        try {
-          // 动态导入refresh token API
-          const { refreshToken: refreshTokenAPI } = await import('../api/auth/index');
-          const response = await refreshTokenAPI(refreshToken);
-          
-          if (response.success && response.data) {
-            const { token, refreshToken: newRefreshToken } = response.data;
-            
-            // 更新localStorage中的token
-            localStorage.setItem('weknora_token', token);
-            localStorage.setItem('weknora_refresh_token', newRefreshToken);
-            
-            // 更新请求头
-            originalRequest.headers['Authorization'] = 'Bearer ' + token;
-            
-            // 处理队列中的请求
-            processQueue(null, token);
-            
-            return instance(originalRequest);
-          } else {
-            throw new Error(response.message || t('error.tokenRefreshFailed'));
-          }
-        } catch (refreshError) {
-          // 刷新失败，清除所有token并跳转到登录页
-          localStorage.removeItem('weknora_token');
-          localStorage.removeItem('weknora_refresh_token');
-          localStorage.removeItem('weknora_user');
-          localStorage.removeItem('weknora_tenant');
-          
-          processQueue(refreshError, null);
-          
-          redirectToLogin();
-          
-          return Promise.reject(refreshError);
-        } finally {
-          isRefreshing = false;
-        }
-      } else {
-        // 没有refresh token，直接跳转到登录页
-        localStorage.removeItem('weknora_token');
-        localStorage.removeItem('weknora_user');
-        localStorage.removeItem('weknora_tenant');
-        
-        redirectToLogin();
-        
-        return Promise.reject({ message: t('error.pleaseRelogin') });
+      try {
+        // Shared with the SSE client so both planes queue behind one refresh.
+        const token = await refreshAccessTokenShared();
+        originalRequest.headers['Authorization'] = 'Bearer ' + token;
+        return instance(originalRequest);
+      } catch (refreshError) {
+        // refreshAccessTokenShared already cleared credentials and redirected.
+        return Promise.reject(refreshError);
       }
     }
     

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -4,6 +4,13 @@ import { generateRandomString, MAX_FILE_SIZE_MB, MAX_SKILL_BUNDLE_SIZE_MB } from
 import i18n from '@/i18n'
 import { getApiBaseUrl } from './api-base';
 import { isSkillBundleUploadUrl } from './uploadLimit';
+import {
+  forceReloginRedirect,
+  isEmbedPage,
+  refreshAccessTokenShared,
+} from './authRefresh';
+
+export { forceReloginRedirect, refreshAccessTokenShared };
 
 const t = (key: string) => i18n.global.t(key)
 
@@ -68,10 +75,6 @@ instance.interceptors.request.use(
   }
 );
 
-// Token刷新标志，防止多个请求同时刷新token
-let isRefreshing = false;
-let failedQueue: Array<{ resolve: Function; reject: Function }> = [];
-
 // Share-link endpoints (/auth/invitations/lookup, /auth/register-by-invite)
 // are reachable by anonymous users opening an invite link. A 401 from these
 // must surface to the page (e.g. expired token), not trigger the
@@ -82,112 +85,6 @@ const PUBLIC_AUTH_PATHS = ['/auth/auto-setup', '/auth/login', '/auth/register', 
 function isPublicAuthRequest(url?: string): boolean {
   if (!url) return false;
   return PUBLIC_AUTH_PATHS.some(p => url.includes(p));
-}
-
-// 处理队列中的请求
-const processQueue = (error: any, token: string | null = null) => {
-  failedQueue.forEach(({ resolve, reject }) => {
-    if (error) {
-      reject(error);
-    } else {
-      resolve(token);
-    }
-  });
-  
-  failedQueue = [];
-};
-
-function isEmbedPage(): boolean {
-  if (typeof window === 'undefined') return false;
-  return window.location.pathname.startsWith('/embed/');
-}
-
-function redirectToLogin() {
-  if (typeof window === 'undefined') return;
-  if (window.location.pathname === '/login') return;
-  // Embed 渠道用 Embed token 鉴权，匿名访问不应被踢到登录页
-  if (isEmbedPage()) return;
-  window.location.href = '/login';
-}
-
-/**
- * Clear stored credentials and send the SPA to /login.
- *
- * Exported for callers that authenticate outside this axios instance (the SSE
- * client) and therefore can't rely on the response interceptor to do it.
- */
-export function forceReloginRedirect() {
-  localStorage.removeItem('weknora_token');
-  localStorage.removeItem('weknora_refresh_token');
-  localStorage.removeItem('weknora_user');
-  localStorage.removeItem('weknora_tenant');
-  redirectToLogin();
-}
-
-/**
- * Refresh the access token, de-duplicated across all callers.
- *
- * The axios interceptor and the SSE client share one in-flight refresh, so a
- * burst of 401s produces a single /auth/refresh call instead of N racing ones
- * (refresh tokens rotate — concurrent refreshes invalidate each other).
- *
- * Resolves with the new access token. On failure it has already cleared the
- * credentials and redirected to /login, so callers only need to surface a
- * message.
- */
-export async function refreshAccessTokenShared(): Promise<string> {
-  if (isRefreshing) {
-    // A refresh is already in flight — wait for its result instead of
-    // starting a second one.
-    return new Promise<string>((resolve, reject) => {
-      failedQueue.push({ resolve, reject });
-    });
-  }
-
-  isRefreshing = true;
-  const storedRefreshToken = localStorage.getItem('weknora_refresh_token');
-
-  if (!storedRefreshToken) {
-    localStorage.removeItem('weknora_token');
-    localStorage.removeItem('weknora_user');
-    localStorage.removeItem('weknora_tenant');
-    const noRefreshTokenError = { message: t('error.pleaseRelogin') };
-    processQueue(noRefreshTokenError, null);
-    isRefreshing = false;
-    redirectToLogin();
-    throw noRefreshTokenError;
-  }
-
-  try {
-    // 动态导入refresh token API
-    const { refreshToken: refreshTokenAPI } = await import('../api/auth/index');
-    const response = await refreshTokenAPI(storedRefreshToken);
-
-    if (!response.success || !response.data) {
-      throw new Error(response.message || t('error.tokenRefreshFailed'));
-    }
-
-    const { token, refreshToken: newRefreshToken } = response.data;
-
-    localStorage.setItem('weknora_token', token);
-    localStorage.setItem('weknora_refresh_token', newRefreshToken);
-    processQueue(null, token);
-
-    return token;
-  } catch (refreshError) {
-    // 刷新失败，清除所有token并跳转到登录页
-    localStorage.removeItem('weknora_token');
-    localStorage.removeItem('weknora_refresh_token');
-    localStorage.removeItem('weknora_user');
-    localStorage.removeItem('weknora_tenant');
-
-    processQueue(refreshError, null);
-    redirectToLogin();
-
-    throw refreshError;
-  } finally {
-    isRefreshing = false;
-  }
 }
 
 instance.interceptors.response.use(
@@ -229,8 +126,12 @@ instance.interceptors.response.use(
     if (error.response.status === 401 && !originalRequest._retry && !originalRequest.url?.includes('/auth/refresh')) {
       originalRequest._retry = true;
       try {
-        // Shared with the SSE client so both planes queue behind one refresh.
-        const token = await refreshAccessTokenShared();
+        const token = await refreshAccessTokenShared({
+          messages: {
+            pleaseRelogin: t('error.pleaseRelogin'),
+            tokenRefreshFailed: t('error.tokenRefreshFailed'),
+          },
+        });
         originalRequest.headers['Authorization'] = 'Bearer ' + token;
         return instance(originalRequest);
       } catch (refreshError) {


### PR DESCRIPTION
## Problem

When the access token expires while a chat page is open, sending a message fails silently:

- the user's bubble is appended to the conversation, but no answer ever arrives;
- the only feedback is a transient `流式连接失败: Error: HTTP 401` / `Stream connection failed: Error: HTTP 401` toast;
- the app does **not** refresh the token and does **not** redirect to `/login`.

Users read this as "the app ignored me" and re-send, which stacks up duplicate bubbles that
aren't persisted server-side (they vanish on reload). The re-login prompt only appears once some
*unrelated* polling request happens to hit 401 and trips the axios interceptor — in one case we
measured that arriving more than a minute after the failed send.

## Reproduction

1. Log in and open a conversation.
2. Invalidate the access token without touching this tab — the easiest way is to sign out of the
   same account elsewhere (`Logout` calls `RevokeTokensByUserID`, which revokes *every* token
   issued to that user, so any other device signing out is enough). Letting the token expire
   naturally works too.
3. Return to the tab and send a message.

Observed: an orphaned user bubble plus an `HTTP 401` toast; no re-login prompt.
Expected: the token is refreshed and the message goes through, or the user is told to log in again.

## Root cause

`frontend/src/api/chat/streame.ts` streams over `@microsoft/fetch-event-source`, i.e. raw `fetch`.
It never passes through the axios instance in `frontend/src/utils/request.ts`, so the 401 handling
that already exists there — refresh, queue concurrent retries, clear credentials and redirect on
failure — simply does not apply to the one request that matters most in the product:

```ts
onopen: async (res) => { if (!res.ok) throw new Error(`HTTP ${res.status}`); }
onerror: (err) => { throw new Error(`${t('error.streamFailed')}: ${err}`); }
// → catch → error.value = err.message → toast, and nothing else
```

## Fix

**`utils/request.ts`** — extract the refresh out of the interceptor into an exported
`refreshAccessTokenShared()`, preserving the existing `isRefreshing` / `failedQueue` de-duplication,
and have the interceptor call it. Behaviour is unchanged; there is now one implementation instead of
one-per-transport. Also export `forceReloginRedirect()` for callers that authenticate outside axios.

**`api/chat/streame.ts`** — mark a 401 handshake with a `StreamAuthError`, and on that error refresh
once and replay the request with the new token. If the refresh fails, or a freshly minted token is
rejected again (the session was revoked, not merely expired), clear credentials, redirect to
`/login`, and surface `error.pleaseRelogin` instead of a raw status code.

## Why the replay is safe

- **It can't duplicate a message.** A 401 is produced by the auth middleware before the handler
  runs, so nothing is persisted — verified against server logs and the `messages` table: the
  rejected request left no row.
- **It's invisible.** The handshake failed, so not a single chunk has been rendered yet.
- **It happens at most once**, and only for 401. 403 and every other status keep their existing path.
- **Cancellation is respected**: the stream generation counter is re-checked after the refresh, so a
  newer send supersedes the replay.
- **Embed visitors are excluded** — they authenticate with an Embed token the SPA cannot refresh, and
  bouncing an anonymous visitor to `/login` would be wrong.
- **One refresh, not N.** Both transports now queue behind the same in-flight refresh, which matters
  because refresh tokens rotate — concurrent refreshes invalidate each other.

Control flow through the library was checked against
`@microsoft/fetch-event-source/lib/cjs/fetch.js`: `await onopen(response)` runs inside the `try`, so
a throw reaches `onerror`, and a throw from `onerror` rejects the promise. `dispose()` aborts only
the library's internal controller, leaving the caller-supplied `signal` usable for the replay.

## Testing

- `npx vue-tsc --build --force` — passes, no new errors.
- `npm test` — 577/580. The 3 failures are in `SandboxConfigEditorDrawer.network.test.mjs` and are
  pre-existing: reverting both files in this PR to their `main` content reproduces the same 3
  failures, so they are unrelated to this change.
- The 401 path itself was diagnosed from a production incident (server logs cross-checked against
  the `messages` table) rather than reproduced in a local browser session, so a maintainer sanity
  check of the refresh-and-replay flow in a running UI would be welcome.
