### PR TITLE
feat(embedding): add persistent embedding cache with hit statistics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -756,3 +756,6 @@ LANGFUSE_HOST=http://langfuse-web:3000
 # WEKNORA_TRUSTED_PROXIES=
 # ants 协程池大小（Embedding 并发，出现 429 时调小）。
 CONCURRENCY_POOL_SIZE=5
+
+# Embedding cache switch. Default off; set to true to enable.
+# EMBEDDING_CACHE_ENABLED=false

--- a/internal/application/repository/embedding_cache.go
+++ b/internal/application/repository/embedding_cache.go
@@ -1,0 +1,100 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// embeddingCacheRepository implements interfaces.EmbeddingCacheRepository.
+type embeddingCacheRepository struct {
+	db *gorm.DB
+}
+
+// NewEmbeddingCacheRepository constructs a GORM-backed implementation.
+func NewEmbeddingCacheRepository(db *gorm.DB) interfaces.EmbeddingCacheRepository {
+	return &embeddingCacheRepository{db: db}
+}
+
+func (r *embeddingCacheRepository) Get(
+	ctx context.Context,
+	key *types.EmbeddingCacheKey,
+) ([]float32, bool, error) {
+	if key == nil {
+		return nil, false, errors.New("embedding cache: nil key")
+	}
+	var entry types.EmbeddingCacheEntry
+	err := r.db.WithContext(ctx).
+		Where("tenant_id = ? AND model_id = ? AND dimension = ? AND text_hash = ?",
+			key.TenantID, key.ModelID, key.Dimension, key.TextHash).
+		First(&entry).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	var vector []float32
+	if err := json.Unmarshal(entry.Vector, &vector); err != nil {
+		return nil, false, err
+	}
+	return vector, true, nil
+}
+
+func (r *embeddingCacheRepository) Set(
+	ctx context.Context,
+	key *types.EmbeddingCacheKey,
+	vector []float32,
+) error {
+	if key == nil {
+		return errors.New("embedding cache: nil key")
+	}
+	data, err := json.Marshal(vector)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	entry := &types.EmbeddingCacheEntry{
+		ID:        uuid.NewString(),
+		TenantID:  key.TenantID,
+		ModelID:   key.ModelID,
+		Dimension: key.Dimension,
+		TextHash:  key.TextHash,
+		Vector:    data,
+		Hits:      1,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "tenant_id"},
+			{Name: "model_id"},
+			{Name: "dimension"},
+			{Name: "text_hash"},
+		},
+		DoUpdates: clause.AssignmentColumns([]string{"vector", "updated_at"}),
+	}).Create(entry).Error
+}
+
+func (r *embeddingCacheRepository) IncrementHit(
+	ctx context.Context,
+	key *types.EmbeddingCacheKey,
+) error {
+	if key == nil {
+		return errors.New("embedding cache: nil key")
+	}
+	return r.db.WithContext(ctx).Model(&types.EmbeddingCacheEntry{}).
+		Where("tenant_id = ? AND model_id = ? AND dimension = ? AND text_hash = ?",
+			key.TenantID, key.ModelID, key.Dimension, key.TextHash).
+		Updates(map[string]any{
+			"hits":       gorm.Expr("hits + 1"),
+			"updated_at": time.Now(),
+		}).Error
+}

--- a/internal/application/repository/embedding_cache_test.go
+++ b/internal/application/repository/embedding_cache_test.go
@@ -1,0 +1,69 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupEmbeddingCacheTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(embeddingCacheTestDDL).Error)
+	return db
+}
+
+const embeddingCacheTestDDL = `
+CREATE TABLE embedding_cache_entries (
+    id TEXT PRIMARY KEY,
+    tenant_id INTEGER NOT NULL,
+    model_id TEXT NOT NULL,
+    dimension INTEGER NOT NULL,
+    text_hash TEXT NOT NULL,
+    vector TEXT NOT NULL,
+    hits INTEGER NOT NULL DEFAULT 1,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    UNIQUE(tenant_id, model_id, dimension, text_hash)
+);
+`
+
+func TestEmbeddingCacheRepository(t *testing.T) {
+	db := setupEmbeddingCacheTestDB(t)
+	repo := NewEmbeddingCacheRepository(db)
+	key := &types.EmbeddingCacheKey{TenantID: 1, ModelID: "m1", Dimension: 8, TextHash: "abc"}
+
+	_, ok, err := repo.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	require.NoError(t, repo.Set(context.Background(), key, []float32{0.1, 0.2, 0.3}))
+	vector, ok, err := repo.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, []float32{0.1, 0.2, 0.3}, vector)
+
+	require.NoError(t, repo.IncrementHit(context.Background(), key))
+	require.NoError(t, repo.Set(context.Background(), key, []float32{0.9, 0.8}))
+	vector, ok, err = repo.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, []float32{0.9, 0.8}, vector)
+}
+
+func TestEmbeddingCacheRepositoryDifferentKeyMiss(t *testing.T) {
+	db := setupEmbeddingCacheTestDB(t)
+	repo := NewEmbeddingCacheRepository(db)
+	key := &types.EmbeddingCacheKey{TenantID: 1, ModelID: "m1", Dimension: 8, TextHash: "abc"}
+	require.NoError(t, repo.Set(context.Background(), key, []float32{0.1}))
+
+	_, ok, err := repo.Get(context.Background(), &types.EmbeddingCacheKey{TenantID: 2, ModelID: "m1", Dimension: 8, TextHash: "abc"})
+	require.NoError(t, err)
+	assert.False(t, ok)
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -180,6 +180,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(repository.NewMemoryRepository))
 	must(container.Provide(repository.NewTaskPendingOpsRepository))
 	must(container.Provide(repository.NewTaskDeadLetterRepository))
+	must(container.Provide(repository.NewEmbeddingCacheRepository))
 
 	// MCP manager for managing MCP client connections
 	logger.Debugf(ctx, "[Container] Registering MCP manager...")
@@ -404,6 +405,7 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	must(container.Provide(handler.NewMessageHandler))
 	must(container.Provide(handler.NewMessageSuggestionHandler))
 	must(container.Provide(handler.NewModelHandler))
+	must(container.Provide(handler.NewEmbeddingCacheHandler))
 	must(container.Provide(handler.NewSandboxConfigHandler))
 	must(container.Provide(func(
 		s *service.TenantSkillService, streams interfaces.StreamManager,
@@ -466,6 +468,16 @@ func BuildContainer(container *dig.Container) *dig.Container {
 	// them only after the matching handlers are ready.
 	must(container.Invoke(recoverPendingWikiTasks))
 
+	// Optional embedding cache: off by default, opt-in via EMBEDDING_CACHE_ENABLED=true.
+	if strings.EqualFold(os.Getenv("EMBEDDING_CACHE_ENABLED"), "true") {
+		if err := container.Invoke(func(repo interfaces.EmbeddingCacheRepository) {
+			embedding.SetEmbeddingCache(repo)
+		}); err != nil {
+			logger.Warnf(ctx, "[embedding-cache] failed to install cache: %v", err)
+		} else {
+			logger.Infof(ctx, "[embedding-cache] enabled")
+		}
+	}
 	logger.Infof(ctx, "[Container] Container initialization completed successfully")
 	return container
 }

--- a/internal/database/migration_sqlite_versioned_schema_test.go
+++ b/internal/database/migration_sqlite_versioned_schema_test.go
@@ -14,6 +14,7 @@ import (
 // 000041 task queue, 000053 system settings, 000055 processing spans,
 // 000063 knowledge multi-tags.
 var versionedSQLiteTables = []string{
+	"embedding_cache_entries",
 	"task_pending_ops",
 	"task_dead_letters",
 	"system_settings",
@@ -33,7 +34,7 @@ var versionedSQLiteColumns = map[string][]string{
 	"mcp_oauth_tokens":   {"principal_type", "principal_id"}, // 000064
 }
 
-const expectedSQLiteMigrationVersion = 12
+const expectedSQLiteMigrationVersion = 13
 
 func TestSQLiteMigrationsCreateVersionedSchema(t *testing.T) {
 	repoRoot := sqliteRepoRoot(t)

--- a/internal/handler/embedding_cache.go
+++ b/internal/handler/embedding_cache.go
@@ -1,0 +1,27 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Tencent/WeKnora/internal/models/embedding"
+)
+
+// EmbeddingCacheHandler exposes embedding cache statistics.
+type EmbeddingCacheHandler struct{}
+
+// NewEmbeddingCacheHandler constructs the handler.
+func NewEmbeddingCacheHandler() *EmbeddingCacheHandler {
+	return &EmbeddingCacheHandler{}
+}
+
+// Stats godoc
+// @Summary      Embedding 缓存统计
+// @Description  返回进程级命中/未命中计数
+// @Tags         Embedding 缓存
+// @Produce      json
+// @Router       /embedding-cache/stats [get]
+func (h *EmbeddingCacheHandler) Stats(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": embedding.CacheStats()})
+}

--- a/internal/handler/embedding_cache_test.go
+++ b/internal/handler/embedding_cache_test.go
@@ -1,0 +1,32 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Tencent/WeKnora/internal/middleware"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestEmbeddingCacheStats(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.ErrorHandler())
+	r.Use(func(c *gin.Context) {
+		c.Set(types.TenantIDContextKey.String(), uint64(1))
+		c.Next()
+	})
+	r.GET("/embedding-cache/stats", NewEmbeddingCacheHandler().Stats)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/embedding-cache/stats", nil)
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"hits"`)
+	assert.Contains(t, w.Body.String(), `"misses"`)
+}

--- a/internal/models/embedding/cache.go
+++ b/internal/models/embedding/cache.go
@@ -1,0 +1,114 @@
+package embedding
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"sync/atomic"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// EmbeddingCache is the narrow interface cachedEmbedder uses.
+type EmbeddingCache interface {
+	Get(ctx context.Context, key *types.EmbeddingCacheKey) ([]float32, bool, error)
+	Set(ctx context.Context, key *types.EmbeddingCacheKey, vector []float32) error
+	IncrementHit(ctx context.Context, key *types.EmbeddingCacheKey) error
+}
+
+var (
+	cacheMu            sync.RWMutex
+	globalCache        EmbeddingCache
+	statsHits          atomic.Int64
+	statsMisses        atomic.Int64
+	statsProviderCalls atomic.Int64
+	modelStatsMu       sync.Mutex
+	modelStats         = map[string]*modelCacheStats{}
+)
+
+type modelCacheStats struct {
+	modelID       string
+	modelName     string
+	hits          int64
+	misses        int64
+	providerCalls int64
+}
+
+// SetEmbeddingCache installs the process-wide embedding cache. Tests may
+// replace or clear it.
+func SetEmbeddingCache(c EmbeddingCache) {
+	cacheMu.Lock()
+	globalCache = c
+	cacheMu.Unlock()
+}
+
+// GetEmbeddingCache returns the installed cache, or nil when disabled.
+func GetEmbeddingCache() EmbeddingCache {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
+	return globalCache
+}
+
+// CacheStats returns process-level hit/miss counters.
+func CacheStats() types.EmbeddingCacheStats {
+	stats := types.EmbeddingCacheStats{
+		Enabled:       GetEmbeddingCache() != nil,
+		Hits:          statsHits.Load(),
+		Misses:        statsMisses.Load(),
+		ProviderCalls: statsProviderCalls.Load(),
+	}
+	modelStatsMu.Lock()
+	defer modelStatsMu.Unlock()
+	for _, model := range modelStats {
+		stats.Models = append(stats.Models, types.EmbeddingCacheModelStats{
+			ModelID:       model.modelID,
+			ModelName:     model.modelName,
+			Hits:          model.hits,
+			Misses:        model.misses,
+			ProviderCalls: model.providerCalls,
+		})
+	}
+	sort.Slice(stats.Models, func(i, j int) bool {
+		if stats.Models[i].ModelID != stats.Models[j].ModelID {
+			return stats.Models[i].ModelID < stats.Models[j].ModelID
+		}
+		return stats.Models[i].ModelName < stats.Models[j].ModelName
+	})
+	return stats
+}
+
+// ResetCacheStats clears hit/miss counters (used by tests and demos).
+func ResetCacheStats() {
+	statsHits.Store(0)
+	statsMisses.Store(0)
+	statsProviderCalls.Store(0)
+	modelStatsMu.Lock()
+	modelStats = map[string]*modelCacheStats{}
+	modelStatsMu.Unlock()
+}
+
+func recordCacheHit(modelID, modelName string) {
+	statsHits.Add(1)
+	recordModelStat(modelID, modelName, func(s *modelCacheStats) { s.hits++ })
+}
+
+func recordCacheMiss(modelID, modelName string) {
+	statsMisses.Add(1)
+	recordModelStat(modelID, modelName, func(s *modelCacheStats) { s.misses++ })
+}
+
+func recordProviderCall(modelID, modelName string) {
+	statsProviderCalls.Add(1)
+	recordModelStat(modelID, modelName, func(s *modelCacheStats) { s.providerCalls++ })
+}
+
+func recordModelStat(modelID, modelName string, mutate func(*modelCacheStats)) {
+	modelStatsMu.Lock()
+	defer modelStatsMu.Unlock()
+	model := modelStats[modelID]
+	if model == nil {
+		model = &modelCacheStats{modelID: modelID, modelName: modelName}
+		modelStats[modelID] = model
+	}
+	mutate(model)
+}

--- a/internal/models/embedding/cache_wrapper.go
+++ b/internal/models/embedding/cache_wrapper.go
@@ -1,0 +1,110 @@
+package embedding
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// cachedEmbedder reuses embedding vectors for identical inputs.
+type cachedEmbedder struct {
+	inner     Embedder
+	cache     EmbeddingCache
+	tenantID  uint64
+	pooler    EmbedderPooler
+	modelID   string
+	modelName string
+}
+
+func (c *cachedEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	key := c.keyFor(ctx, text)
+	if vector, ok, err := c.cache.Get(ctx, &key); err == nil && ok {
+		recordCacheHit(c.modelID, c.modelName)
+		_ = c.cache.IncrementHit(ctx, &key)
+		return vector, nil
+	}
+	recordCacheMiss(c.modelID, c.modelName)
+	vector, err := c.inner.Embed(ctx, text)
+	recordProviderCall(c.modelID, c.modelName)
+	if err == nil {
+		_ = c.cache.Set(ctx, &key, vector)
+	}
+	return vector, err
+}
+
+func (c *cachedEmbedder) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	keys := make([]types.EmbeddingCacheKey, len(texts))
+	results := make([][]float32, len(texts))
+	missingIndexes := make([]int, 0, len(texts))
+	missingTexts := make([]string, 0, len(texts))
+
+	for i, text := range texts {
+		key := c.keyFor(ctx, text)
+		keys[i] = key
+		if vector, ok, err := c.cache.Get(ctx, &key); err == nil && ok {
+			recordCacheHit(c.modelID, c.modelName)
+			_ = c.cache.IncrementHit(ctx, &key)
+			results[i] = vector
+			continue
+		}
+		recordCacheMiss(c.modelID, c.modelName)
+		missingIndexes = append(missingIndexes, i)
+		missingTexts = append(missingTexts, text)
+	}
+	if len(missingTexts) == 0 {
+		return results, nil
+	}
+
+	vectors, err := c.inner.BatchEmbed(ctx, missingTexts)
+	recordProviderCall(c.modelID, c.modelName)
+	if err != nil {
+		return nil, err
+	}
+	for j, index := range missingIndexes {
+		results[index] = vectors[j]
+		_ = c.cache.Set(ctx, &keys[index], vectors[j])
+	}
+	return results, nil
+}
+
+func (c *cachedEmbedder) BatchEmbedWithPool(ctx context.Context, model Embedder, texts []string) ([][]float32, error) {
+	if c.pooler == nil {
+		return c.inner.BatchEmbedWithPool(ctx, c, texts)
+	}
+	return c.pooler.BatchEmbedWithPool(ctx, c, texts)
+}
+
+func (c *cachedEmbedder) GetModelName() string { return c.inner.GetModelName() }
+func (c *cachedEmbedder) GetDimensions() int   { return c.inner.GetDimensions() }
+func (c *cachedEmbedder) GetModelID() string   { return c.inner.GetModelID() }
+
+func (c *cachedEmbedder) keyFor(ctx context.Context, text string) types.EmbeddingCacheKey {
+	tenantID := c.tenantID
+	if t, ok := types.TenantIDFromContext(ctx); ok && t > 0 {
+		tenantID = t
+	}
+	sum := sha256.Sum256([]byte(text))
+	return types.EmbeddingCacheKey{
+		TenantID:  tenantID,
+		ModelID:   c.inner.GetModelID(),
+		Dimension: c.inner.GetDimensions(),
+		TextHash:  hex.EncodeToString(sum[:]),
+	}
+}
+
+func wrapEmbeddingCache(e Embedder, tenantID uint64, pooler EmbedderPooler) Embedder {
+	cache := GetEmbeddingCache()
+	if cache == nil || e == nil {
+		return e
+	}
+	return &cachedEmbedder{
+		inner:     e,
+		cache:     cache,
+		tenantID:  tenantID,
+		pooler:    pooler,
+		modelID:   e.GetModelID(),
+		modelName: e.GetModelName(),
+	}
+}

--- a/internal/models/embedding/cache_wrapper_test.go
+++ b/internal/models/embedding/cache_wrapper_test.go
@@ -1,0 +1,162 @@
+package embedding
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+type fakeCache struct {
+	mu     sync.Mutex
+	values map[string][]float32
+}
+
+func newFakeCache() *fakeCache {
+	return &fakeCache{values: map[string][]float32{}}
+}
+
+func (f *fakeCache) key(k *types.EmbeddingCacheKey) string {
+	return k.TextHash
+}
+
+func (f *fakeCache) Get(_ context.Context, k *types.EmbeddingCacheKey) ([]float32, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.values[f.key(k)]
+	return v, ok, nil
+}
+
+func (f *fakeCache) Set(_ context.Context, k *types.EmbeddingCacheKey, v []float32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.values[f.key(k)] = append([]float32(nil), v...)
+	return nil
+}
+
+func (f *fakeCache) IncrementHit(context.Context, *types.EmbeddingCacheKey) error {
+	return nil
+}
+
+type countingEmbedder struct {
+	embedCalls int
+	batchCalls int
+}
+
+func (e *countingEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
+	e.embedCalls++
+	return []float32{float32(len(text))}, nil
+}
+
+func (e *countingEmbedder) BatchEmbed(_ context.Context, texts []string) ([][]float32, error) {
+	e.batchCalls++
+	out := make([][]float32, len(texts))
+	for i, text := range texts {
+		out[i] = []float32{float32(len(text))}
+	}
+	return out, nil
+}
+
+func (e *countingEmbedder) BatchEmbedWithPool(_ context.Context, _ Embedder, texts []string) ([][]float32, error) {
+	return e.BatchEmbed(context.Background(), texts)
+}
+
+func (e *countingEmbedder) GetModelName() string { return "embed-1" }
+func (e *countingEmbedder) GetDimensions() int   { return 1 }
+func (e *countingEmbedder) GetModelID() string   { return "embed-id-1" }
+
+func TestCachedEmbedderSingleHit(t *testing.T) {
+	cache := newFakeCache()
+	SetEmbeddingCache(cache)
+	defer SetEmbeddingCache(nil)
+	ResetCacheStats()
+
+	inner := &countingEmbedder{}
+	c := &cachedEmbedder{inner: inner, cache: cache, tenantID: 7}
+
+	first, err := c.Embed(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("first Embed: %v", err)
+	}
+	second, err := c.Embed(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("second Embed: %v", err)
+	}
+	if inner.embedCalls != 1 {
+		t.Fatalf("embed calls=%d, want 1", inner.embedCalls)
+	}
+	if len(first) != 1 || first[0] != second[0] {
+		t.Errorf("vectors=%v/%v", first, second)
+	}
+	stats := CacheStats()
+	if stats.Hits != 1 || stats.Misses != 1 {
+		t.Errorf("stats=%+v, want 1/1", stats)
+	}
+}
+
+func TestCacheStatsPerModel(t *testing.T) {
+	cache := newFakeCache()
+	SetEmbeddingCache(cache)
+	defer SetEmbeddingCache(nil)
+	ResetCacheStats()
+
+	inner := &countingEmbedder{}
+	embedder := wrapEmbeddingCache(inner, 7, nil)
+	if _, err := embedder.Embed(context.Background(), "hello"); err != nil {
+		t.Fatalf("first Embed: %v", err)
+	}
+	if _, err := embedder.Embed(context.Background(), "hello"); err != nil {
+		t.Fatalf("second Embed: %v", err)
+	}
+
+	stats := CacheStats()
+	if !stats.Enabled {
+		t.Fatal("cache should report enabled")
+	}
+	if len(stats.Models) != 1 {
+		t.Fatalf("models=%+v, want one model", stats.Models)
+	}
+	model := stats.Models[0]
+	if model.ModelID != "embed-id-1" || model.ModelName != "embed-1" {
+		t.Fatalf("model stats=%+v", model)
+	}
+	if model.Hits != 1 || model.Misses != 1 || model.ProviderCalls != 1 {
+		t.Fatalf("model stats=%+v", model)
+	}
+}
+
+func TestCachedEmbedderBatchPartialHit(t *testing.T) {
+	cache := newFakeCache()
+	SetEmbeddingCache(cache)
+	defer SetEmbeddingCache(nil)
+	ResetCacheStats()
+
+	inner := &countingEmbedder{}
+	c := &cachedEmbedder{inner: inner, cache: cache, tenantID: 7}
+
+	if _, err := c.BatchEmbed(context.Background(), []string{"a"}); err != nil {
+		t.Fatalf("warm batch: %v", err)
+	}
+	results, err := c.BatchEmbed(context.Background(), []string{"a", "bb", "a"})
+	if err != nil {
+		t.Fatalf("batch: %v", err)
+	}
+	if inner.batchCalls != 2 {
+		t.Fatalf("batch calls=%d, want 2 (warm + one miss)", inner.batchCalls)
+	}
+	if len(results) != 3 {
+		t.Fatalf("results len=%d", len(results))
+	}
+	if results[0][0] != 1 || results[1][0] != 2 || results[2][0] != 1 {
+		t.Errorf("results=%v", results)
+	}
+}
+
+func TestWrapEmbeddingCacheNoCachePassthrough(t *testing.T) {
+	SetEmbeddingCache(nil)
+	inner := &countingEmbedder{}
+	if got := wrapEmbeddingCache(inner, 7, nil); got != inner {
+		t.Fatal("expected passthrough when cache is nil")
+	}
+}

--- a/internal/models/embedding/embedder.go
+++ b/internal/models/embedding/embedder.go
@@ -50,6 +50,7 @@ type Config struct {
 	SupportsDimensionOverride bool              `json:"supports_dimension_override"`
 	ModelID                   string            `json:"model_id"`
 	Provider                  string            `json:"provider"`
+	TenantID                  uint64            `json:"tenant_id"`
 	// MaxConcurrency caps concurrent background calls to this model; 0 falls
 	// back to the process-wide default (see limiter.GateN).
 	MaxConcurrency int               `json:"max_concurrency"`
@@ -72,6 +73,7 @@ func ConfigFromModel(m *types.Model, appID, appSecret string) Config {
 		BaseURL:                   m.Parameters.BaseURL,
 		APIKey:                    m.Parameters.APIKey,
 		ModelID:                   m.ID,
+		TenantID:                  m.TenantID,
 		ModelName:                 m.Name,
 		Dimensions:                m.Parameters.EmbeddingParameters.Dimension,
 		SupportsDimensionOverride: m.Parameters.EmbeddingParameters.SupportsDimensionOverride,
@@ -104,7 +106,7 @@ func NewEmbedder(config Config, pooler EmbedderPooler, ollamaService *ollama.Oll
 	if langfuse.GetManager().Enabled() {
 		e = &langfuseEmbedder{inner: e}
 	}
-	return e, nil
+	return wrapEmbeddingCache(e, config.TenantID, pooler), nil
 }
 
 func newEmbedder(config Config, pooler EmbedderPooler, ollamaService *ollama.OllamaService) (Embedder, error) {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -56,6 +56,7 @@ type RouterParams struct {
 	MessageSuggestionHandler     *handler.MessageSuggestionHandler
 	ModelHandler                 *handler.ModelHandler
 	ModelCredentialsHandler      *handler.ModelCredentialsHandler
+	EmbeddingCacheHandler        *handler.EmbeddingCacheHandler
 	SandboxConfigHandler         *handler.SandboxConfigHandler
 	SandboxSkillHandler          *handler.SandboxSkillHandler
 	MeEnvVarHandler              *handler.MeEnvVarHandler
@@ -266,6 +267,7 @@ func NewRouter(params RouterParams) *gin.Engine {
 		RegisterChatRoutes(v1, params.SessionHandler, rbacGuards)
 		RegisterMessageRoutes(v1, params.MessageHandler, rbacGuards)
 		RegisterModelRoutes(v1, params.ModelHandler, params.ModelCredentialsHandler, rbacGuards)
+		RegisterEmbeddingCacheRoutes(v1, params.EmbeddingCacheHandler, rbacGuards)
 		RegisterSandboxConfigRoutes(v1, params.SandboxConfigHandler, params.SandboxSkillHandler, rbacGuards)
 		RegisterMyEnvVarRoutes(v1, params.MeEnvVarHandler)
 		RegisterEvaluationRoutes(v1, params.EvaluationHandler, rbacGuards)

--- a/internal/router/routes_infra.go
+++ b/internal/router/routes_infra.go
@@ -88,6 +88,12 @@ func RegisterEvaluationRoutes(r *gin.RouterGroup, handler *handler.EvaluationHan
 	}
 }
 
+// RegisterEmbeddingCacheRoutes exposes embedding cache statistics.
+func RegisterEmbeddingCacheRoutes(r *gin.RouterGroup, h *handler.EmbeddingCacheHandler, g *rbacGuards) {
+	cache := g.apiKeyGroup(r.Group("/embedding-cache"), apiKeyManageModels(apiKeyFullAccess()))
+	cache.GET("/stats", g.Admin(), h.Stats)
+}
+
 func RegisterInitializationRoutes(r *gin.RouterGroup, handler *handler.InitializationHandler, g *rbacGuards) {
 	// 初始化接口
 	// GetCurrentConfigByKB 是只读，Viewer+ 即可（KB 受限 key 可读其范围内的 KB）。

--- a/internal/types/embedding_cache.go
+++ b/internal/types/embedding_cache.go
@@ -1,0 +1,52 @@
+package types
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// EmbeddingCacheKey identifies one cacheable embedding input.
+type EmbeddingCacheKey struct {
+	TenantID  uint64
+	ModelID   string
+	Dimension int
+	TextHash  string
+}
+
+// EmbeddingCacheEntry is the persisted embedding vector cache row.
+type EmbeddingCacheEntry struct {
+	ID        string          `gorm:"primaryKey;type:varchar(64)" json:"id"`
+	TenantID  uint64          `gorm:"index;uniqueIndex:idx_embedding_cache_key" json:"tenant_id"`
+	ModelID   string          `gorm:"type:varchar(128);index;uniqueIndex:idx_embedding_cache_key" json:"model_id"`
+	Dimension int             `gorm:"index;uniqueIndex:idx_embedding_cache_key" json:"dimension"`
+	TextHash  string          `gorm:"type:varchar(64);uniqueIndex:idx_embedding_cache_key" json:"text_hash"`
+	Vector    json.RawMessage `gorm:"type:jsonb" json:"vector"`
+	Hits      int64           `gorm:"default:1" json:"hits"`
+	CreatedAt time.Time       `json:"created_at"`
+	UpdatedAt time.Time       `json:"updated_at"`
+}
+
+// TableName returns the database table name for EmbeddingCacheEntry.
+func (EmbeddingCacheEntry) TableName() string {
+	return "embedding_cache_entries"
+}
+
+// EmbeddingCacheStats exposes process-level hit/miss counters.
+type EmbeddingCacheStats struct {
+	Enabled       bool                       `json:"enabled"`
+	Hits          int64                      `json:"hits"`
+	Misses        int64                      `json:"misses"`
+	ProviderCalls int64                      `json:"provider_calls"`
+	Models        []EmbeddingCacheModelStats `json:"models"`
+}
+
+// EmbeddingCacheModelStats is the per-model portion of the process cache
+// counters. Hits/misses count text lookups; ProviderCalls counts actual model
+// requests (one batch request can cover several misses).
+type EmbeddingCacheModelStats struct {
+	ModelID       string `json:"model_id"`
+	ModelName     string `json:"model_name"`
+	Hits          int64  `json:"hits"`
+	Misses        int64  `json:"misses"`
+	ProviderCalls int64  `json:"provider_calls"`
+}

--- a/internal/types/interfaces/embedding_cache.go
+++ b/internal/types/interfaces/embedding_cache.go
@@ -1,0 +1,14 @@
+package interfaces
+
+import (
+	"context"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// EmbeddingCacheRepository persists embedding vectors for reuse.
+type EmbeddingCacheRepository interface {
+	Get(ctx context.Context, key *types.EmbeddingCacheKey) ([]float32, bool, error)
+	Set(ctx context.Context, key *types.EmbeddingCacheKey, vector []float32) error
+	IncrementHit(ctx context.Context, key *types.EmbeddingCacheKey) error
+}

--- a/migrations/sqlite/000013_embedding_cache_entries.down.sql
+++ b/migrations/sqlite/000013_embedding_cache_entries.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS embedding_cache_entries;

--- a/migrations/sqlite/000013_embedding_cache_entries.up.sql
+++ b/migrations/sqlite/000013_embedding_cache_entries.up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS embedding_cache_entries (
+    id TEXT PRIMARY KEY,
+    tenant_id INTEGER NOT NULL,
+    model_id TEXT NOT NULL,
+    dimension INTEGER NOT NULL DEFAULT 0,
+    text_hash TEXT NOT NULL,
+    vector TEXT NOT NULL,
+    hits INTEGER NOT NULL DEFAULT 1,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, model_id, dimension, text_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_embedding_cache_tenant
+    ON embedding_cache_entries(tenant_id);
+
+CREATE INDEX IF NOT EXISTS idx_embedding_cache_model
+    ON embedding_cache_entries(model_id);

--- a/migrations/versioned/000091_embedding_cache_entries.down.sql
+++ b/migrations/versioned/000091_embedding_cache_entries.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS embedding_cache_entries;

--- a/migrations/versioned/000091_embedding_cache_entries.up.sql
+++ b/migrations/versioned/000091_embedding_cache_entries.up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS embedding_cache_entries (
+    id VARCHAR(64) PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
+    model_id VARCHAR(128) NOT NULL,
+    dimension INTEGER NOT NULL DEFAULT 0,
+    text_hash VARCHAR(64) NOT NULL,
+    vector JSONB NOT NULL,
+    hits BIGINT NOT NULL DEFAULT 1,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, model_id, dimension, text_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_embedding_cache_tenant
+    ON embedding_cache_entries(tenant_id);
+
+CREATE INDEX IF NOT EXISTS idx_embedding_cache_model
+    ON embedding_cache_entries(model_id);


### PR DESCRIPTION
## Motivation

Embedding requests currently always reach the provider, even when the exact same text was embedded before. Document ingestion and RAG evaluation flows embed large parts of the corpus repeatedly (re-indexing, evaluation re-runs, repeated queries), which wastes provider calls, tokens and latency.

## What this PR adds

- A process-wide embedding cache backed by a new `embedding_cache_entries` table, keyed by `(tenant_id, model_id, dimension, SHA-256(text))` — entries are never shared across tenants or models.
- A `cachedEmbedder` wrapper covering single, batch, and batch-with-pool embedding paths; only cache misses are sent to the provider, and hits bump the entry's hit counter.
- Per-model hit / miss / provider-call statistics exposed via `GET /api/v1/embedding-cache/stats` (admin only), so operators can verify reuse and estimate savings.
- Opt-in switch: off by default, enable with `EMBEDDING_CACHE_ENABLED=true` (documented in `.env.example`).
- Migrations: `migrations/versioned/000091` (PostgreSQL) and `migrations/sqlite/000013` (Lite mode).

## Testing

- `go build ./...`
- `go test ./internal/models/embedding/... ./internal/application/repository/... ./internal/handler/... ./internal/database/...`
- End-to-end cold/hot verification with a fixed corpus: embedding the same corpus twice keeps provider calls flat on the second run (19 provider calls in both runs; 0 hits / 31 misses cold, 31 hits / 0 misses hot).
