### PR TITLE
fix(message): log why chat history indexing was skipped

### DIFF
--- a/internal/application/service/message.go
+++ b/internal/application/service/message.go
@@ -384,6 +384,12 @@ func (s *messageService) IndexMessageToKB(ctx context.Context, userQuery string,
 
 	cfg := s.getChatHistoryConfig(ctx)
 	if cfg == nil {
+		// Say why, otherwise an operator who enabled indexing in the UI sees
+		// "indexed messages: 0" with nothing in the logs to explain it: the
+		// stats endpoint only checks Enabled, while indexing additionally
+		// requires an embedding model and an auto-created KB.
+		logger.Infof(ctx, "Skipping message index for message %s: %s",
+			messageID, describeChatHistorySkip(ctx))
 		return
 	}
 
@@ -408,6 +414,30 @@ func (s *messageService) IndexMessageToKB(ctx context.Context, userQuery string,
 	}
 
 	logger.Infof(ctx, "Message indexed to chat history KB: knowledge_id=%s, message_id=%s", knowledge.ID, messageID)
+}
+
+// describeChatHistorySkip reports which chat-history precondition is missing,
+// for the log line emitted when indexing is skipped. ChatHistoryConfig.
+// IsConfigured requires Enabled plus a selected embedding model plus an
+// auto-created KB, so "enabled" alone is not enough to index.
+func describeChatHistorySkip(ctx context.Context) string {
+	tenant, ok := types.TenantInfoFromContext(ctx)
+	if !ok {
+		return "no tenant in context"
+	}
+	cfg := tenant.ChatHistoryConfig
+	switch {
+	case cfg == nil:
+		return "chat history config not set"
+	case !cfg.Enabled:
+		return "chat history indexing disabled"
+	case cfg.EmbeddingModelID == "":
+		return "enabled but no embedding model selected"
+	case cfg.KnowledgeBaseID == "":
+		return "enabled but chat history knowledge base not created yet"
+	default:
+		return "chat history config incomplete"
+	}
 }
 
 // DeleteMessageKnowledge deletes the Knowledge entry associated with a message from the chat history KB.

--- a/internal/application/service/message_index_skip_test.go
+++ b/internal/application/service/message_index_skip_test.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// The stats endpoint reports the feature as enabled based on
+// ChatHistoryConfig.Enabled alone, but IndexMessageToKB only indexes when
+// IsConfigured() holds - which also requires an embedding model and an
+// auto-created KB. When those disagree the operator sees "indexed messages: 0"
+// with no log line explaining it. These cases pin the reason string so each
+// skip is attributable from the logs.
+func TestDescribeChatHistorySkip(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  func() context.Context
+		want string
+	}{
+		{
+			name: "no tenant in context",
+			ctx:  func() context.Context { return context.Background() },
+			want: "no tenant in context",
+		},
+		{
+			name: "config not set",
+			ctx: func() context.Context {
+				return contextWithTenant(&types.Tenant{})
+			},
+			want: "chat history config not set",
+		},
+		{
+			name: "disabled",
+			ctx: func() context.Context {
+				return contextWithTenant(&types.Tenant{
+					ChatHistoryConfig: &types.ChatHistoryConfig{Enabled: false},
+				})
+			},
+			want: "chat history indexing disabled",
+		},
+		{
+			name: "enabled without embedding model",
+			ctx: func() context.Context {
+				return contextWithTenant(&types.Tenant{
+					ChatHistoryConfig: &types.ChatHistoryConfig{
+						Enabled:         true,
+						KnowledgeBaseID: "kb-1",
+					},
+				})
+			},
+			want: "enabled but no embedding model selected",
+		},
+		{
+			name: "enabled without knowledge base",
+			ctx: func() context.Context {
+				return contextWithTenant(&types.Tenant{
+					ChatHistoryConfig: &types.ChatHistoryConfig{
+						Enabled:          true,
+						EmbeddingModelID: "emb-1",
+					},
+				})
+			},
+			want: "enabled but chat history knowledge base not created yet",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := describeChatHistorySkip(tt.ctx()); got != tt.want {
+				t.Errorf("describeChatHistorySkip() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A fully configured tenant must not be reported as a skip reason: it is the
+// one case where IndexMessageToKB proceeds, so the fallback string here would
+// mean the helper and IsConfigured() disagree.
+func TestDescribeChatHistorySkipFullyConfigured(t *testing.T) {
+	cfg := &types.ChatHistoryConfig{
+		Enabled:          true,
+		EmbeddingModelID: "emb-1",
+		KnowledgeBaseID:  "kb-1",
+	}
+	if !cfg.IsConfigured() {
+		t.Fatal("fixture is not fully configured; test cannot check the agreement")
+	}
+	got := describeChatHistorySkip(contextWithTenant(&types.Tenant{ChatHistoryConfig: cfg}))
+	if got != "chat history config incomplete" {
+		t.Errorf("unexpected reason for a configured tenant: %q", got)
+	}
+}
+
+func contextWithTenant(tenant *types.Tenant) context.Context {
+	return context.WithValue(context.Background(), types.TenantInfoContextKey, tenant)
+}


### PR DESCRIPTION
## 问题

`IndexMessageToKB` 在 `getChatHistoryConfig` 返回 nil 时直接静默 return，不打任何日志。结果是：在「设置 → 消息管理」里开启了消息索引的用户，看到「已索引消息」始终为 0，而日志里找不到任何线索。

根因是两条路径对「已启用」的判据不一致：

| 路径 | 判据 |
| --- | --- |
| `GetChatHistoryKBStats`（统计/UI） | `cfg != nil && cfg.Enabled` |
| `IndexMessageToKB`（实际写入） | `cfg.IsConfigured()`，额外要求 `EmbeddingModelID != ""` 且 `KnowledgeBaseID != ""` |

枚举 `Enabled=true` 下的组合：

| 配置状态 | `IsConfigured()` | 写入行为 | 统计接口显示 |
| --- | --- | --- | --- |
| 模型 + KB 都有 | true | 索引 | 已启用 |
| 有模型，KB 未创建 | false | **静默跳过** | 已启用 |
| 有 KB，模型 ID 为空 | false | **静默跳过** | 已启用 |
| 只开了开关 | false | **静默跳过** | 已启用 |

后三种组合下，UI 报告功能已开启，但每条消息都被跳过，且不产生任何日志。

## 改动

跳过时记录具体缺失的前置条件，区分：无 tenant 上下文 / 未配置 / 已禁用 / 缺 embedding 模型 / KB 未创建。

**行为不变**，只是让一条已存在的静默路径变得可归因。

## 关于 #2706

Related to #2706，但**这个 PR 不声称修复它**。

我无法在本地复现 #2706：它需要 Docker Compose + 可用的 Embedding 模型 + 向量库运行环境。我能确证的只是「为什么排查不到日志」这一半——报告人明确写了「暂未找到与消息索引直接相关的错误日志」，上表说明了原因。

排查过程中我验证并**排除**了两个猜测，记录在此以免他人重复：

- `bgCtx` 丢失 tenant 信息 → 不成立。`qa.go:1442` 用的是 `context.WithoutCancel(ctx)`，会保留全部 value。
- `IndexedMessageCount` 取值有误 → 不成立。`GetChatHistoryKBStats` 已正确调用 `FillKnowledgeBaseCounts`（`KnowledgeCount` 是 `gorm:"-"`）。

真实根因仍需该环境下的日志确认。有了这条日志，报告人重启后即可直接看到究竟是哪个前置条件没满足，或者确认三项都满足、从而把排查范围收窄到 `CreateKnowledgeFromPassage` 之后。

统计接口是否也该把「已启用但未就绪」暴露给前端（让 UI 显示原因而不只是 0），涉及 API 契约与前端改动，属于产品决策，留给维护者判断。

## 验证

```bash
go test ./internal/application/service/ -run TestDescribeChatHistorySkip -v
```

6 个子测试全部通过，覆盖每一种跳过原因。其中 `TestDescribeChatHistorySkipFullyConfigured` 是护栏：它先断言 fixture 确实满足 `IsConfigured()`，再确认完整配置不会落进任何「跳过原因」分支——若 helper 与 `IsConfigured()` 今后出现分歧，这条会先红。

```bash
go build ./...                          # exit 0
go vet ./internal/application/service/  # 干净
go test ./internal/application/service/ # ok  7.749s（全包，无回归）
gofmt -l <改动文件>                      # 无输出
```
