### PR TITLE
fix(feishu): preserve images embedded in post messages

### DIFF
--- a/internal/im/feishu/longconn.go
+++ b/internal/im/feishu/longconn.go
@@ -270,7 +270,8 @@ func convertImageEvent(
 }
 
 // convertPostEvent handles rich-text (post) message type.
-// Extracts all plain text content and treats it as a text query for QA.
+// Extracts plain text and the first embedded image so mixed posts can use the
+// same attachment pipeline as standalone image messages.
 func convertPostEvent(
 	region Region, msg *larkim.EventMessage,
 	openID, chatID string, chatType im.ChatType, messageID string,
@@ -279,7 +280,7 @@ func convertPostEvent(
 		return nil
 	}
 
-	// Post content structure: {"title":"...", "content":[[{"tag":"text","text":"..."},{"tag":"a","href":"...","text":"..."}]]}
+	// Post content structure: {"title":"...", "content":[[{"tag":"text","text":"..."},{"tag":"img","image_key":"..."}]]}
 	var postContent struct {
 		Title   string              `json:"title"`
 		Content [][]json.RawMessage `json:"content"`
@@ -289,6 +290,7 @@ func convertPostEvent(
 	}
 
 	var textParts []string
+	imageKey := ""
 	if postContent.Title != "" {
 		textParts = append(textParts, postContent.Title)
 	}
@@ -297,8 +299,9 @@ func convertPostEvent(
 		var lineText strings.Builder
 		for _, elem := range line {
 			var tag struct {
-				Tag  string `json:"tag"`
-				Text string `json:"text"`
+				Tag      string `json:"tag"`
+				Text     string `json:"text"`
+				ImageKey string `json:"image_key"`
 			}
 			if err := json.Unmarshal(elem, &tag); err != nil {
 				continue
@@ -306,6 +309,10 @@ func convertPostEvent(
 			switch tag.Tag {
 			case "text", "a":
 				lineText.WriteString(tag.Text)
+			case "img":
+				if imageKey == "" {
+					imageKey = tag.ImageKey
+				}
 			case "at":
 				// Skip @mentions
 			}
@@ -328,18 +335,27 @@ func convertPostEvent(
 	}
 
 	content = strings.TrimSpace(content)
-	if content == "" {
+	if content == "" && imageKey == "" {
 		return nil
+	}
+
+	messageType := im.MessageTypeText
+	fileName := ""
+	if imageKey != "" {
+		messageType = im.MessageTypeImage
+		fileName = imageKey + ".png"
 	}
 
 	return &im.IncomingMessage{
 		Platform:    region.Platform,
-		MessageType: im.MessageTypeText,
+		MessageType: messageType,
 		UserID:      openID,
 		ChatID:      chatID,
 		ChatType:    chatType,
 		Content:     content,
 		MessageID:   messageID,
+		FileKey:     imageKey,
+		FileName:    fileName,
 	}
 }
 

--- a/internal/im/feishu/longconn_test.go
+++ b/internal/im/feishu/longconn_test.go
@@ -1,0 +1,68 @@
+package feishu
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/im"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+)
+
+func TestConvertPostEventPreservesEmbeddedImage(t *testing.T) {
+	content := `{"title":"","content":[[{"tag":"at","user_id":"ou_bot"},{"tag":"text","text":"请描述这张图"},{"tag":"img","image_key":"img_v3_abc"}]]}`
+	msg := &larkim.EventMessage{Content: &content}
+
+	got := convertPostEvent(RegionFeishu, msg, "ou_user", "oc_group", im.ChatTypeGroup, "om_message")
+	if got == nil {
+		t.Fatal("convertPostEvent() returned nil")
+	}
+	if got.MessageType != im.MessageTypeImage {
+		t.Fatalf("MessageType = %q, want %q", got.MessageType, im.MessageTypeImage)
+	}
+	if got.Content != "请描述这张图" {
+		t.Fatalf("Content = %q, want %q", got.Content, "请描述这张图")
+	}
+	if got.FileKey != "img_v3_abc" {
+		t.Fatalf("FileKey = %q, want %q", got.FileKey, "img_v3_abc")
+	}
+	if got.FileName != "img_v3_abc.png" {
+		t.Fatalf("FileName = %q, want %q", got.FileName, "img_v3_abc.png")
+	}
+}
+
+func TestConvertPostEventPreservesImageWithoutText(t *testing.T) {
+	content := `{"title":"","content":[[{"tag":"at","user_id":"ou_bot"},{"tag":"img","image_key":"img_v3_only"}]]}`
+	msg := &larkim.EventMessage{Content: &content}
+
+	got := convertPostEvent(RegionFeishu, msg, "ou_user", "oc_group", im.ChatTypeGroup, "om_message")
+	if got == nil {
+		t.Fatal("convertPostEvent() returned nil")
+	}
+	if got.MessageType != im.MessageTypeImage {
+		t.Fatalf("MessageType = %q, want %q", got.MessageType, im.MessageTypeImage)
+	}
+	if got.Content != "" {
+		t.Fatalf("Content = %q, want empty", got.Content)
+	}
+	if got.FileKey != "img_v3_only" {
+		t.Fatalf("FileKey = %q, want %q", got.FileKey, "img_v3_only")
+	}
+}
+
+func TestConvertPostEventKeepsTextOnlyPostsAsText(t *testing.T) {
+	content := `{"title":"Status","content":[[{"tag":"text","text":"all systems go"}]]}`
+	msg := &larkim.EventMessage{Content: &content}
+
+	got := convertPostEvent(RegionFeishu, msg, "ou_user", "oc_group", im.ChatTypeGroup, "om_message")
+	if got == nil {
+		t.Fatal("convertPostEvent() returned nil")
+	}
+	if got.MessageType != im.MessageTypeText {
+		t.Fatalf("MessageType = %q, want %q", got.MessageType, im.MessageTypeText)
+	}
+	if got.Content != "Status\nall systems go" {
+		t.Fatalf("Content = %q, want %q", got.Content, "Status\\nall systems go")
+	}
+	if got.FileKey != "" {
+		t.Fatalf("FileKey = %q, want empty", got.FileKey)
+	}
+}


### PR DESCRIPTION
## Description

Feishu represents group messages containing an @mention and image as `post` messages with embedded `img` tags. `convertPostEvent` previously retained only the text elements, so the image never reached the existing attachment and VLM pipeline.

This change:

- extracts the first embedded `image_key` from a Feishu post;
- routes it through the existing image attachment path while preserving the text caption;
- supports image-only posts; and
- keeps text-only post behavior unchanged.

`IncomingMessage` currently carries one `FileKey`, so multi-image support is intentionally outside this focused fix.

The follow-up P2P image report is not claimed by this PR: current `main` already dispatches standalone image and file messages independently of chat type, so that symptom needs separate reproduction and tracing.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Addresses #3015

## Testing

- Go 1.26: `go test ./internal/im/feishu`
- Result: pass
- Covered mixed text/image posts, image-only posts, and text-only regression.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable
- [ ] Full-repository checks were run
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (not needed)
- [x] Breaking changes are clearly called out (none)

## Screenshots / Recordings

Not applicable; backend message conversion only.