### PR TITLE
feat(session): show in-progress status in the sidebar

### DIFF
--- a/frontend/src/components/SessionSidebarRow.vue
+++ b/frontend/src/components/SessionSidebarRow.vue
@@ -1,84 +1,39 @@
 <template>
-  <div
-    :class="[
-      'submenu_item',
-      !batchMode && activePath === item.path ? 'submenu_item_active' : '',
-      batchMode && selectedIds.includes(item.id) ? 'submenu_item_selected' : '',
-      batchMode ? 'submenu_item_batch' : '',
-    ]"
-    @mouseenter="emit('hover-in')"
-    @mouseleave="emit('hover-out')"
-    @click="batchMode ? emit('toggle-select') : emit('navigate')"
-  >
-    <t-checkbox
-      v-if="batchMode"
-      class="batch-checkbox"
-      :checked="selectedIds.includes(item.id)"
-      @click.stop
-      @change="emit('toggle-select')"
-    />
-    <form
-      v-if="titleEditing"
-      class="session-title-edit"
-      @submit.prevent="submitTitleEdit"
-      @click.stop
-    >
-      <input
-        ref="titleInputRef"
-        v-model="titleDraft"
-        class="session-title-edit__input"
-        :maxlength="SESSION_TITLE_MAX_LENGTH"
-        @keydown.esc.prevent="cancelTitleEdit"
-        @blur="submitTitleEdit"
-      />
+  <div :class="[
+    'submenu_item',
+    !batchMode && activePath === item.path ? 'submenu_item_active' : '',
+    batchMode && selectedIds.includes(item.id) ? 'submenu_item_selected' : '',
+    batchMode ? 'submenu_item_batch' : '',
+  ]" @mouseenter="emit('hover-in')" @mouseleave="emit('hover-out')"
+    @click="batchMode ? emit('toggle-select') : emit('navigate')">
+    <t-checkbox v-if="batchMode" class="batch-checkbox" :checked="selectedIds.includes(item.id)" @click.stop
+      @change="emit('toggle-select')" />
+    <form v-if="titleEditing" class="session-title-edit" @submit.prevent="submitTitleEdit" @click.stop>
+      <input ref="titleInputRef" v-model="titleDraft" class="session-title-edit__input"
+        :maxlength="SESSION_TITLE_MAX_LENGTH" @keydown.esc.prevent="cancelTitleEdit" @blur="submitTitleEdit" />
     </form>
     <span v-else class="submenu_title" :class="batchMode ? 'submenu_title--batch' : ''" :title="item.title">
       <t-icon v-if="item.is_pinned" name="pin" class="submenu_pin_icon" />
       <span class="submenu_title-text">{{ item.title }}</span>
-      <span
-        v-if="apiOwnerTag"
-        class="session-owner-tag"
-        :class="`session-owner-tag--${apiOwnerTag.kind}`"
-        :title="apiOwnerTag.full"
-      >{{ apiOwnerTag.label }}</span>
+      <span v-if="apiOwnerTag" class="session-owner-tag" :class="`session-owner-tag--${apiOwnerTag.kind}`"
+        :title="apiOwnerTag.full">{{ apiOwnerTag.label }}</span>
     </span>
+    <span v-if="running" class="session-running-indicator" role="status" :aria-label="t('menu.sessionInProgress')"
+      :title="t('menu.sessionInProgress')"><span class="session-running-indicator__spinner" aria-hidden="true" /></span>
     <div v-if="!batchMode" class="session-row-menu-wrap" @click.stop>
-      <t-popup
-        v-model:visible="menuOpen"
-        :overlay-class-name="menuOverlayClass"
-        trigger="click"
-        destroy-on-close
-        placement="bottom-right"
-        @visible-change="onMenuVisibleChange"
-      >
-        <button
-          type="button"
-          class="menu-more-wrap"
-          aria-haspopup="menu"
-          :aria-expanded="menuOpen"
-          @click.stop
-        >
+      <t-popup v-model:visible="menuOpen" :overlay-class-name="menuOverlayClass" trigger="click" destroy-on-close
+        placement="bottom-right" @visible-change="onMenuVisibleChange">
+        <button type="button" class="menu-more-wrap" aria-haspopup="menu" :aria-expanded="menuOpen" @click.stop>
           <t-icon name="ellipsis" class="menu-more" />
         </button>
         <template #content>
           <div class="session-action-menu" @click.stop>
             <template v-if="menuMode === 'menu'">
               <template v-for="(option, index) in menuOptions" :key="option.value">
-                <div
-                  v-if="shouldShowDividerBefore(option.value, index)"
-                  class="session-action-menu__divider"
-                />
-                <button
-                  type="button"
-                  class="session-action-menu__item"
-                  :class="{ 'is-danger': option.theme === 'error' }"
-                  @click="handleMenuClick(option)"
-                >
-                  <component
-                    :is="option.prefixIcon"
-                    v-if="option.prefixIcon"
-                    class="session-action-menu__icon"
-                  />
+                <div v-if="shouldShowDividerBefore(option.value, index)" class="session-action-menu__divider" />
+                <button type="button" class="session-action-menu__item"
+                  :class="{ 'is-danger': option.theme === 'error' }" @click="handleMenuClick(option)">
+                  <component :is="option.prefixIcon" v-if="option.prefixIcon" class="session-action-menu__icon" />
                   <span>{{ option.content }}</span>
                 </button>
               </template>
@@ -95,11 +50,7 @@
                 <button type="button" class="session-action-confirm__btn" @click="backToMenu">
                   {{ t('common.cancel') }}
                 </button>
-                <button
-                  type="button"
-                  class="session-action-confirm__btn is-danger"
-                  @click="confirmDangerAction"
-                >
+                <button type="button" class="session-action-confirm__btn is-danger" @click="confirmDangerAction">
                   {{ menuMode === 'clear' ? t('common.clear') : t('common.delete') }}
                 </button>
               </div>
@@ -131,6 +82,7 @@ const props = defineProps<{
   activePath: string
   selectedIds: string[]
   menuOptions: SessionMenuOption[]
+  running?: boolean
   /** 渠道文件夹下的会话（样式与聊天区会话共用文案列对齐） */
   nested?: boolean
 }>()
@@ -251,6 +203,40 @@ const confirmDangerAction = (): void => {
 <style scoped lang="less">
 .submenu_item {
   position: relative;
+}
+
+.session-running-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 16px;
+  width: 16px;
+  height: 16px;
+  margin-left: 4px;
+  color: var(--td-brand-color);
+}
+
+.session-running-indicator__spinner {
+  display: block;
+  box-sizing: border-box;
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid var(--td-component-stroke);
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: session-running-spin 0.8s linear infinite;
+}
+
+@keyframes session-running-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .session-running-indicator__spinner {
+    animation: none;
+  }
 }
 
 .session-row-menu-wrap {

--- a/frontend/src/components/menu.vue
+++ b/frontend/src/components/menu.vue
@@ -147,6 +147,7 @@
                                 <div class="session-list-row session-list-row--flat">
                                     <div class="session-list-row__body">
                                         <SessionSidebarRow :item="subitem" :batch-mode="batchMode"
+                                            :running="Boolean(sessionActivityEntries[subitem.id])"
                                             :active-path="currentSecondpath" :selected-ids="batchSelectedIds"
                                             :menu-options="buildSessionMenuOptions(subitem)"
                                             @navigate="gotopage(subitem.path)"
@@ -246,6 +247,7 @@ import {
 } from './sessionSidebarSourceFilter';
 import { logout as logoutApi } from '@/api/auth';
 import { useMenuStore } from '@/stores/menu';
+import { useSessionActivityStore } from '@/stores/sessionActivity';
 import { useAuthStore } from '@/stores/auth';
 import { useDeploymentCapabilitiesStore } from '@/stores/deploymentCapabilities';
 import { useOrganizationStore } from '@/stores/organization';
@@ -286,6 +288,9 @@ const platformLogo = (p: string): string => (p ? PLATFORM_LOGO[p] || '' : '');
 
 const { t } = useI18n();
 const usemenuStore = useMenuStore();
+const sessionActivity = useSessionActivityStore();
+const { entries: sessionActivityEntries } = storeToRefs(sessionActivity);
+let sessionActivityTimer: ReturnType<typeof setInterval> | undefined;
 const authStore = useAuthStore();
 const deploymentCapabilities = useDeploymentCapabilitiesStore();
 const orgStore = useOrganizationStore();
@@ -952,6 +957,7 @@ const loadSessionOriginMeta = async () => {
 const handleSessionMutation = (event: Event) => {
     const detail = (event as CustomEvent<SessionMutationDetail>).detail;
     if (!detail?.sessionId) return;
+    if (detail.removed || detail.messagesCleared) sessionActivity.update(detail.sessionId, false);
     if (detail.patch) {
         updateSessionInBuckets(detail.sessionId, {
             ...detail.patch,
@@ -968,6 +974,7 @@ const handleSessionMutation = (event: Event) => {
 };
 
 onMounted(async () => {
+    sessionActivityTimer = setInterval(() => { void sessionActivity.refresh(); }, 5000);
     const routeName = typeof route.name === 'string' ? route.name : (route.name ? String(route.name) : '')
     currentpath.value = routeName;
     if (route.params.chatid) {
@@ -1000,6 +1007,8 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+    clearInterval(sessionActivityTimer);
+    sessionActivity.clear();
     window.removeEventListener(SESSION_MUTATION_EVENT, handleSessionMutation);
 });
 
@@ -1663,6 +1672,11 @@ const onDragHandleMouseDown = (e: MouseEvent) => {
             flex: 1 1 auto;
             min-width: 0;
             overflow: hidden;
+        }
+
+        .session-running-indicator {
+            flex: 0 0 16px;
+            flex-shrink: 0;
         }
 
         .submenu_title-text {

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1,5 +1,6 @@
 export default {
   menu: {
+    sessionInProgress: 'Conversation in progress',
     knowledgeBase: 'Knowledge Base',
     agents: 'Agents',
     organizations: 'Shared Spaces',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -6745,6 +6745,7 @@ export default {
     }
   },
   menu: {
+    sessionInProgress: '대화 진행 중',
     knowledgeBase: '지식베이스',
     agents: '에이전트',
     organizations: '공유 공간',

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -6745,6 +6745,7 @@ export default {
     }
   },
   menu: {
+    sessionInProgress: 'Диалог выполняется',
     knowledgeBase: 'База знаний',
     agents: 'Агенты',
     organizations: 'Общие пространства',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -6747,6 +6747,7 @@ export default {
     }
   },
   menu: {
+    sessionInProgress: '会话进行中',
     knowledgeBase: '知识库',
     agents: '智能体',
     organizations: '共享空间',

--- a/frontend/src/stores/sessionActivity.ts
+++ b/frontend/src/stores/sessionActivity.ts
@@ -1,0 +1,16 @@
+import { reactive, watch } from 'vue'
+import { defineStore } from 'pinia'
+import { getMessageList } from '@/api/chat/index'
+import { useAuthStore } from './auth'
+import { createSessionActivityState, type SessionActivity } from './sessionActivityState'
+
+export const useSessionActivityStore = defineStore('sessionActivity', () => {
+  const entries = reactive<Record<string, SessionActivity>>({})
+  const activity = createSessionActivityState(entries, async sessionId => {
+    const result = await getMessageList({ session_id: sessionId, limit: 20, created_at: '' })
+    return result.data || []
+  })
+  const auth = useAuthStore()
+  watch(() => [auth.user?.id, auth.effectiveTenantId], activity.clear, { flush: 'sync' })
+  return { entries, ...activity }
+})

--- a/frontend/src/stores/sessionActivityState.test.ts
+++ b/frontend/src/stores/sessionActivityState.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { reactive } from 'vue'
+import { createSessionActivityState, type SessionActivity } from './sessionActivityState.ts'
+
+test('tracks multiple sessions and keeps detached replies until completion', async () => {
+  const entries = reactive<Record<string, SessionActivity>>({})
+  let completed = false
+  const requested: string[] = []
+  const state = createSessionActivityState(entries, async id => {
+    requested.push(id)
+    return [{ id: 'reply-a', role: 'assistant', is_completed: completed }]
+  })
+  state.update('a', true, 'reply-a')
+  state.update('b', true, 'reply-b')
+  state.detach('a')
+  await state.refresh()
+  assert.deepEqual(requested, ['a'])
+  assert.ok(entries.a)
+  assert.ok(entries.b)
+  completed = true
+  await state.refresh()
+  assert.equal(entries.a, undefined)
+  state.update('b', false)
+  assert.deepEqual(Object.keys(entries), [])
+})
+
+test('a stale poll cannot clear a reattached stream or a new turn', async () => {
+  const entries = reactive<Record<string, SessionActivity>>({})
+  let resolve!: (messages: any[]) => void
+  const state = createSessionActivityState(entries, () => new Promise(done => { resolve = done }))
+  state.update('a', true, 'old')
+  state.detach('a')
+  const poll = state.refresh()
+  state.update('a', true, 'new')
+  resolve([{ id: 'old', role: 'assistant', is_completed: true }])
+  await poll
+  assert.equal(entries.a?.messageId, 'new')
+  assert.equal(entries.a?.detached, false)
+})
+
+test('handles navigation before the assistant message arrives and clears deleted sessions', async () => {
+  const entries = reactive<Record<string, SessionActivity>>({})
+  let messages: any[] = []
+  const state = createSessionActivityState(entries, async () => messages)
+  state.update('a', true)
+  state.detach('a')
+  await state.refresh()
+  assert.ok(entries.a)
+  messages = [{ id: 'reply', role: 'assistant', is_completed: false }]
+  await state.refresh()
+  assert.equal(entries.a?.messageId, 'reply')
+  messages = []
+  await state.refresh()
+  assert.equal(entries.a, undefined)
+})
+
+test('transient failures preserve the marker and repeated failures clear it', async () => {
+  const entries = reactive<Record<string, SessionActivity>>({})
+  const state = createSessionActivityState(entries, async () => { throw new Error('offline') })
+  state.update('a', true)
+  state.detach('a')
+  await state.refresh()
+  assert.ok(entries.a)
+  await state.refresh()
+  await state.refresh()
+  assert.equal(entries.a, undefined)
+})
+
+test('clearing activity while a poll is in flight cannot restore old account state', async () => {
+  const entries = reactive<Record<string, SessionActivity>>({})
+  let resolve!: (messages: any[]) => void
+  const state = createSessionActivityState(entries, () => new Promise(done => { resolve = done }))
+  state.update('a', true, 'reply')
+  state.detach('a')
+  const poll = state.refresh()
+  state.clear()
+  resolve([{ id: 'reply', role: 'assistant', is_completed: false }])
+  await poll
+  assert.deepEqual(Object.keys(entries), [])
+})

--- a/frontend/src/stores/sessionActivityState.ts
+++ b/frontend/src/stores/sessionActivityState.ts
@@ -1,0 +1,67 @@
+export interface SessionActivity {
+  messageId: string
+  detached: boolean
+  failures: number
+}
+
+interface ActivityMessage {
+  id: string
+  role: string
+  is_completed: boolean
+}
+
+// Entries are replaced on every local update so stale polling responses cannot
+// clear a newer turn or a stream that has since reattached.
+export function createSessionActivityState(
+  entries: Record<string, SessionActivity>,
+  fetchMessages: (sessionId: string) => Promise<ActivityMessage[]>,
+) {
+  const pending = new Set<string>()
+
+  function update(sessionId: string, running: boolean, messageId = '') {
+    if (!sessionId) return
+    if (running) entries[sessionId] = { messageId, detached: false, failures: 0 }
+    else delete entries[sessionId]
+  }
+
+  function detach(sessionId: string) {
+    const entry = entries[sessionId]
+    if (entry) entries[sessionId] = { ...entry, detached: true }
+  }
+
+  async function refresh() {
+    await Promise.all(Object.entries(entries).map(async ([sessionId, entry]) => {
+      if (!entry.detached || pending.has(sessionId)) return
+      pending.add(sessionId)
+      try {
+        const messages = await fetchMessages(sessionId)
+        if (entries[sessionId] !== entry) return
+        const message = entry.messageId
+          ? messages.find(message => message.id === entry.messageId)
+          : messages.find(message => message.role === 'assistant' && !message.is_completed)
+        if (message?.is_completed || (!message && entry.messageId)) {
+          delete entries[sessionId]
+        } else if (message) {
+          entries[sessionId] = { messageId: message.id, detached: true, failures: 0 }
+        } else if (++entry.failures >= 3) {
+          // A request abandoned before creating its assistant message.
+          delete entries[sessionId]
+        }
+      } catch (error) {
+        if (entries[sessionId] !== entry) return
+        const status = (error as { status?: number })?.status
+        if (status === 403 || status === 404 || ++entry.failures >= 3) {
+          delete entries[sessionId]
+        }
+      } finally {
+        pending.delete(sessionId)
+      }
+    }))
+  }
+
+  function clear() {
+    for (const sessionId of Object.keys(entries)) delete entries[sessionId]
+  }
+
+  return { update, detach, refresh, clear }
+}

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -8,65 +8,71 @@
         <div class="chat_thread">
             <div ref="scrollContainer" class="chat_scroll_box" @scroll="handleScroll">
                 <div class="msg_list" :class="{ 'is-embedded': embeddedMode }">
-                <!-- 消息列表骨架屏 -->
-                <div v-if="historyLoading && messagesList.length === 0" class="msg-skeleton-list">
-                    <div class="msg-skeleton msg-skeleton-user">
-                        <t-skeleton animation="gradient" :row-col="[{ width: '45%', height: '36px', type: 'rect' }]" />
-                    </div>
-                    <div class="msg-skeleton msg-skeleton-bot">
-                        <t-skeleton animation="gradient"
-                            :row-col="[{ width: '80%', height: '16px' }, { width: '100%', height: '16px' }, { width: '60%', height: '16px' }]" />
-                    </div>
-                    <div class="msg-skeleton msg-skeleton-user">
-                        <t-skeleton animation="gradient" :row-col="[{ width: '35%', height: '36px', type: 'rect' }]" />
-                    </div>
-                    <div class="msg-skeleton msg-skeleton-bot">
-                        <t-skeleton animation="gradient"
-                            :row-col="[{ width: '70%', height: '16px' }, { width: '90%', height: '16px' }]" />
-                    </div>
-                </div>
-                <!-- 推荐问题卡片 - 仅在新会话（无消息）时展示 -->
-                <div v-if="!embeddedMode && messagesList.length === 0 && !loading" class="suggested-questions-container"
-                    :class="{ 'has-questions': suggestedQuestions.length > 0 || suggestedQuestionsLoading }">
-                    <!-- 骨架屏占位 -->
-                    <div v-if="suggestedQuestionsLoading && suggestedQuestions.length === 0"
-                        class="suggested-questions-inner">
-                        <div class="suggested-questions-title"><t-skeleton animation="gradient"
-                                :row-col="[{ width: '120px', height: '14px' }]" /></div>
-                        <div class="suggested-questions-grid">
-                            <div v-for="n in 6" :key="'sq-skel-' + n" class="suggested-question-card sq-card-skeleton">
-                                <t-skeleton animation="gradient"
-                                    :row-col="[{ width: '100%', height: '14px', type: 'rect' }]" />
-                            </div>
+                    <!-- 消息列表骨架屏 -->
+                    <div v-if="historyLoading && messagesList.length === 0" class="msg-skeleton-list">
+                        <div class="msg-skeleton msg-skeleton-user">
+                            <t-skeleton animation="gradient"
+                                :row-col="[{ width: '45%', height: '36px', type: 'rect' }]" />
+                        </div>
+                        <div class="msg-skeleton msg-skeleton-bot">
+                            <t-skeleton animation="gradient"
+                                :row-col="[{ width: '80%', height: '16px' }, { width: '100%', height: '16px' }, { width: '60%', height: '16px' }]" />
+                        </div>
+                        <div class="msg-skeleton msg-skeleton-user">
+                            <t-skeleton animation="gradient"
+                                :row-col="[{ width: '35%', height: '36px', type: 'rect' }]" />
+                        </div>
+                        <div class="msg-skeleton msg-skeleton-bot">
+                            <t-skeleton animation="gradient"
+                                :row-col="[{ width: '70%', height: '16px' }, { width: '90%', height: '16px' }]" />
                         </div>
                     </div>
-                    <transition v-else appear name="sq-fade">
-                        <div v-if="suggestedQuestions.length > 0" class="suggested-questions-inner">
-                            <div class="suggested-questions-title-row">
-                                <p class="suggested-questions-caption">
-                                    <span class="suggested-questions-title">{{ t('chat.suggestedQuestions') }}</span>
-                                    <button type="button" class="suggested-questions-refresh"
-                                        :disabled="suggestedQuestionsLoading"
-                                        :title="t('chat.refreshSuggestedQuestions')"
-                                        :aria-label="t('chat.refreshSuggestedQuestions')"
-                                        @click="fetchSuggestedQuestions">
-                                        <t-icon :name="suggestedQuestionsLoading ? 'loading' : 'refresh'"
-                                            :class="{ 'sq-refresh-spin': suggestedQuestionsLoading }" />
-                                    </button>
-                                </p>
-                            </div>
+                    <!-- 推荐问题卡片 - 仅在新会话（无消息）时展示 -->
+                    <div v-if="!embeddedMode && messagesList.length === 0 && !loading"
+                        class="suggested-questions-container"
+                        :class="{ 'has-questions': suggestedQuestions.length > 0 || suggestedQuestionsLoading }">
+                        <!-- 骨架屏占位 -->
+                        <div v-if="suggestedQuestionsLoading && suggestedQuestions.length === 0"
+                            class="suggested-questions-inner">
+                            <div class="suggested-questions-title"><t-skeleton animation="gradient"
+                                    :row-col="[{ width: '120px', height: '14px' }]" /></div>
                             <div class="suggested-questions-grid">
-                                <div v-for="(item, index) in suggestedQuestions" :key="item.question"
-                                    class="suggested-question-card"
-                                    @click="handleSuggestedQuestionClick(item.question)">
-                                    <span class="suggested-question-text">{{ item.question }}</span>
-                                    <span v-if="item.source === 'faq'" class="suggested-question-badge faq">FAQ</span>
+                                <div v-for="n in 6" :key="'sq-skel-' + n"
+                                    class="suggested-question-card sq-card-skeleton">
+                                    <t-skeleton animation="gradient"
+                                        :row-col="[{ width: '100%', height: '14px', type: 'rect' }]" />
                                 </div>
                             </div>
                         </div>
-                    </transition>
-                </div>
-                <!--
+                        <transition v-else appear name="sq-fade">
+                            <div v-if="suggestedQuestions.length > 0" class="suggested-questions-inner">
+                                <div class="suggested-questions-title-row">
+                                    <p class="suggested-questions-caption">
+                                        <span class="suggested-questions-title">{{ t('chat.suggestedQuestions')
+                                            }}</span>
+                                        <button type="button" class="suggested-questions-refresh"
+                                            :disabled="suggestedQuestionsLoading"
+                                            :title="t('chat.refreshSuggestedQuestions')"
+                                            :aria-label="t('chat.refreshSuggestedQuestions')"
+                                            @click="fetchSuggestedQuestions">
+                                            <t-icon :name="suggestedQuestionsLoading ? 'loading' : 'refresh'"
+                                                :class="{ 'sq-refresh-spin': suggestedQuestionsLoading }" />
+                                        </button>
+                                    </p>
+                                </div>
+                                <div class="suggested-questions-grid">
+                                    <div v-for="(item, index) in suggestedQuestions" :key="item.question"
+                                        class="suggested-question-card"
+                                        @click="handleSuggestedQuestionClick(item.question)">
+                                        <span class="suggested-question-text">{{ item.question }}</span>
+                                        <span v-if="item.source === 'faq'"
+                                            class="suggested-question-badge faq">FAQ</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </transition>
+                    </div>
+                    <!--
                   关键：必须用 session.id 作为 key，不能用 v-for 的索引。
                   向上滚动加载历史时会插入一批消息（push/unshift）到列表，
                   若用索引作 key 会让所有已渲染消息的 key 漂移，触发整个列表的销毁重建
@@ -96,8 +102,7 @@
                                 @render-complete-change="(ready) => handleAnswerRenderComplete(session, ready)">
                             </botmsg>
                             <FollowUpSuggestions v-if="session.answerFullyRendered && !session.suggestionsDismissed"
-                                :suggestion-set="session.suggestionSet"
-                                :loading="session.suggestionLoading"
+                                :suggestion-set="session.suggestionSet" :loading="session.suggestionLoading"
                                 :allow-regenerate="session.suggestionSet?.allow_regenerate"
                                 @select="(item) => handleFollowUpSelect(session, item)"
                                 @regenerate="loadFollowUpSuggestions(session, true, true)"
@@ -111,12 +116,8 @@
                     </div>
                 </div>
             </div>
-            <ChatQuestionMinimap
-                v-if="!embeddedMode"
-                :scroll-container="scrollContainer"
-                :messages="messagesList"
-                @jump="jumpToQuestion"
-            />
+            <ChatQuestionMinimap v-if="!embeddedMode" :scroll-container="scrollContainer" :messages="messagesList"
+                @jump="jumpToQuestion" />
         </div>
         <transition name="scroll-btn-fade">
             <div v-show="userHasScrolledUp" class="scroll-to-bottom-btn" @click="onClickScrollToBottom">
@@ -175,6 +176,7 @@ import {
 } from '@/api/message-suggestion';
 import { provideChatReferencesDrawer } from '@/composables/useChatReferencesDrawer';
 import { provideChatAttachmentPreviewDrawer } from '@/composables/useChatAttachmentPreviewDrawer';
+import { useSessionActivityStore } from '@/stores/sessionActivity';
 const referencesDrawer = provideChatReferencesDrawer();
 provideChatAttachmentPreviewDrawer();
 const { visible: referencesDrawerVisible } = referencesDrawer;
@@ -201,7 +203,7 @@ const uiStore = useUIStore();
 const { navigateToKnowledgeBaseList } = useKnowledgeBaseCreationNavigation();
 const { t } = useI18n();
 const { firstQuery, firstMentionedItems, firstModelId, firstImageFiles, firstAttachmentFiles } = storeToRefs(usemenuStore);
-const { onChunk, error, startStream, stopStream, lastStreamRequest } = useStream();
+const { onChunk, error, isStreaming, startStream, stopStream, lastStreamRequest } = useStream();
 /** Snapshot of the in-flight HTTP request for attaching to the next assistant message. */
 const pendingStreamDebug = ref(null);
 
@@ -271,6 +273,12 @@ const isImRecovering = ref(false);
 const scrollLock = ref(false);
 const isFirstEnter = ref(true);
 const loading = ref(false);
+const sessionActivity = useSessionActivityStore();
+const activitySessionId = ref('');
+watch([activitySessionId, isReplying, isStreaming, isImRecovering, currentAssistantMessageId], () => {
+    if (props.embeddedMode || !activitySessionId.value) return;
+    sessionActivity.update(activitySessionId.value, isReplying.value || isStreaming.value || isImRecovering.value, currentAssistantMessageId.value);
+}, { flush: 'sync' });
 const historyLoading = ref(true);
 const historyLoadingMore = ref(false);
 const hasMoreHistory = ref(true);
@@ -596,12 +604,20 @@ const {
     scrollContainer,
     debug: import.meta.env.DEV,
     onAfterMsgList: async () => {
+        activitySessionId.value = String(session_id.value);
         for (const message of messagesList) {
             if (message.role === 'assistant' && message.is_completed && message.suggestionSet === undefined) {
                 void loadFollowUpSuggestions(message, false);
             }
         }
         const lastMessage = messagesList[messagesList.length - 1];
+        const locallyRunning = isReplying.value || isStreaming.value || isImRecovering.value;
+        // History reload can finish after sendMsg already marked this session
+        // running. Do not clear that marker just because the snapshot's last
+        // message still looks completed.
+        if (!props.embeddedMode && !locallyRunning && (!lastMessage || lastMessage.is_completed)) {
+            sessionActivity.update(activitySessionId.value, false);
+        }
         if (lastMessage && !lastMessage.is_completed) {
             isReplying.value = true;
             if (lastMessage.role === 'assistant') {
@@ -698,6 +714,8 @@ const handleStopGeneration = () => {
     stopStream();
     loading.value = false;
     isReplying.value = false;
+    if (recoverPollTimer) { clearTimeout(recoverPollTimer); recoverPollTimer = null; }
+    isImRecovering.value = false;
     // 标记当前 assistant 为已结束，避免下一条 query 复用该消息行
     markInFlightAssistantStopped(currentAssistantMessageId.value);
     // 保留 currentAssistantMessageId，Input-field 仍需用它调用 stop API
@@ -706,6 +724,7 @@ const handleStopGeneration = () => {
 const sendMsg = async (value, modelId = '', mentionedItems = [], imageFiles = [], attachmentFiles = []) => {
     stopStream();
     prepareForNewOutgoingMessage();
+    activitySessionId.value = String(session_id.value);
     isReplying.value = true;
     loading.value = true;
     const selectedAgentId = props.embeddedMode ? props.agentId : (useSettingsStoreInstance.selectedAgentId || '');
@@ -783,8 +802,8 @@ const sendMsg = async (value, modelId = '', mentionedItems = [], imageFiles = []
         .filter(attachment => attachment.documentId && attachment.status !== 'failed')
         .map(attachment => attachment.documentId);
     attachmentIds.push(...imageAttachmentIds);
-	// Embedded public routes do not expose the authenticated session upload API;
-	// keep their existing inline payload for compatibility.
+    // Embedded public routes do not expose the authenticated session upload API;
+    // keep their existing inline payload for compatibility.
     const legacyAttachmentFiles = props.embeddedMode
         ? (attachmentFiles || []).filter(attachment => !attachment.documentId)
         : [];
@@ -1041,6 +1060,8 @@ onMounted(async () => {
     }
 })
 const clearData = () => {
+    if (!props.embeddedMode) sessionActivity.detach(activitySessionId.value);
+    activitySessionId.value = '';
     stopStream();
     referencesDrawer.close();
     isReplying.value = false;
@@ -1051,6 +1072,8 @@ const clearData = () => {
     isImRecovering.value = false;
 }
 onUnmounted(() => {
+    if (!props.embeddedMode) sessionActivity.detach(activitySessionId.value);
+    activitySessionId.value = '';
     window.removeEventListener(SESSION_MUTATION_EVENT, handleSessionMutation);
     clearMinimapFlash();
     if (recoverPollTimer) { clearTimeout(recoverPollTimer); recoverPollTimer = null; }


### PR DESCRIPTION
## Summary
- Show a spinner on sidebar sessions that are still generating, including after you leave the thread.
- Keep detached replies marked until they finish, and do not let a late history reload clear a turn that is still streaming.
- Draw the spinner with theme tokens that exist, so the in-progress state is actually visible.

## Test plan
- Send a message and confirm the current session row shows a green spinner next to the title.
- Switch to another chat while the first reply is still running; the original row should keep spinning until that reply completes.
- Stop generation or wait for completion and confirm the spinner disappears.
- Reload the session mid-reply and confirm the spinner stays until the stream ends.