### PR TITLE
fix(chat): never send max_tokens together with max_completion_tokens

### DIFF
--- a/internal/models/chat/openai_request.go
+++ b/internal/models/chat/openai_request.go
@@ -126,11 +126,17 @@ func (c *RemoteAPIChat) BuildChatCompletionRequest(
 		req.PresencePenalty = float32(opts.PresencePenalty)
 	}
 
-	if opts.MaxTokens > 0 {
-		req.MaxTokens = opts.MaxTokens
-	}
+	// max_tokens and max_completion_tokens are mutually exclusive per the
+	// OpenAI API; providers such as Volcano Ark reject requests carrying both
+	// with a 400 ("max_tokens and max_completion_tokens cannot be set at the
+	// same time"). Callers that set both (the agent engine budgets do) keep
+	// only the newer max_completion_tokens; adapters that need the legacy
+	// field migrate it themselves (e.g. shapeOpenAIReasoning, Anthropic's
+	// MaxCompletionTokens→MaxTokens mapping).
 	if opts.MaxCompletionTokens > 0 {
 		req.MaxCompletionTokens = opts.MaxCompletionTokens
+	} else if opts.MaxTokens > 0 {
+		req.MaxTokens = opts.MaxTokens
 	}
 
 	// 处理 Tools

--- a/internal/models/chat/openai_request_test.go
+++ b/internal/models/chat/openai_request_test.go
@@ -1,0 +1,50 @@
+package chat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The OpenAI API treats max_tokens and max_completion_tokens as mutually
+// exclusive, and providers such as Volcano Ark reject requests carrying both
+// with a 400. See Tencent/WeKnora#3014.
+func TestBuildChatCompletionRequest_MaxTokensMutuallyExclusive(t *testing.T) {
+	chat := newTestRemoteChat(t)
+	messages := []Message{{Role: "user", Content: "hello"}}
+
+	t.Run("both set keeps only max_completion_tokens", func(t *testing.T) {
+		opts := &ChatOptions{MaxTokens: 2048, MaxCompletionTokens: 4096}
+		req := chat.BuildChatCompletionRequest(messages, opts, false)
+		assert.Equal(t, 4096, req.MaxCompletionTokens)
+		assert.Zero(t, req.MaxTokens)
+
+		// Both the go-openai path and the raw-HTTP path serialize this struct,
+		// so the wire request must carry only the modern field.
+		body, err := json.Marshal(req)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), `"max_completion_tokens":4096`)
+		assert.NotContains(t, string(body), `"max_tokens"`)
+	})
+
+	t.Run("legacy max_tokens alone is preserved", func(t *testing.T) {
+		opts := &ChatOptions{MaxTokens: 2048}
+		req := chat.BuildChatCompletionRequest(messages, opts, false)
+		assert.Equal(t, 2048, req.MaxTokens)
+		assert.Zero(t, req.MaxCompletionTokens)
+
+		body, err := json.Marshal(req)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), `"max_tokens":2048`)
+		assert.NotContains(t, string(body), "max_completion_tokens")
+	})
+
+	t.Run("max_completion_tokens alone is preserved", func(t *testing.T) {
+		opts := &ChatOptions{MaxCompletionTokens: 4096}
+		req := chat.BuildChatCompletionRequest(messages, opts, false)
+		assert.Equal(t, 4096, req.MaxCompletionTokens)
+		assert.Zero(t, req.MaxTokens)
+	})
+}

--- a/internal/models/chat/openai_request_test.go
+++ b/internal/models/chat/openai_request_test.go
@@ -47,4 +47,20 @@ func TestBuildChatCompletionRequest_MaxTokensMutuallyExclusive(t *testing.T) {
 		assert.Equal(t, 4096, req.MaxCompletionTokens)
 		assert.Zero(t, req.MaxTokens)
 	})
+
+	// DeepSeek documents max_tokens only and silently ignores
+	// max_completion_tokens, so its adapter migrates the budget back onto the
+	// legacy field.
+	t.Run("deepseek adapter migrates the budget to max_tokens", func(t *testing.T) {
+		opts := &ChatOptions{MaxTokens: 2048, MaxCompletionTokens: 4096}
+		req := chat.BuildChatCompletionRequest(messages, opts, false)
+		deepseekProvider{}.ShapeRequest(&req, opts, false)
+		assert.Equal(t, 4096, req.MaxTokens)
+		assert.Zero(t, req.MaxCompletionTokens)
+
+		body, err := json.Marshal(req)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), `"max_tokens":4096`)
+		assert.NotContains(t, string(body), "max_completion_tokens")
+	})
 }

--- a/internal/models/chat/provider.go
+++ b/internal/models/chat/provider.go
@@ -154,6 +154,13 @@ func (deepseekProvider) ShapeRequest(req *openai.ChatCompletionRequest, opts *Ch
 	if opts != nil && opts.ToolChoice != "" {
 		req.ToolChoice = nil
 	}
+	// DeepSeek documents max_tokens only and silently ignores
+	// max_completion_tokens, so migrate the modern field back onto the legacy
+	// one to keep the completion budget effective for agent callers.
+	if req.MaxTokens == 0 && req.MaxCompletionTokens > 0 {
+		req.MaxTokens = req.MaxCompletionTokens
+		req.MaxCompletionTokens = 0
+	}
 }
 
 // --- Generic (vLLM) / NVIDIA / LiteLLM: thinking via chat_template_kwargs ---


### PR DESCRIPTION
## Description

`BuildChatCompletionRequest` serialized `max_tokens` and `max_completion_tokens` into the same wire request whenever a caller set both. The agent engine does exactly that — `internal/agent/think.go` and `internal/agent/finalize.go` both set `MaxTokens: budget, MaxCompletionTokens: budget` — so on Volcano Engine Ark every custom-agent round failed with HTTP 400:

```
"max_tokens and max_completion_tokens cannot be set at the same time"
```

This PR makes the two fields mutually exclusive at the single serialization boundary: when both are set, only the newer `max_completion_tokens` is sent; callers that set only `MaxTokens` keep the legacy field unchanged. Adapters that need the legacy field migrate it themselves, and this PR adds such a migration for DeepSeek (documented `max_tokens`-only, silently ignores `max_completion_tokens`), so the agent completion budget stays effective there.

Both the go-openai path and the raw-HTTP path (`deepseekProvider`/`geminiProvider`/`weKnoraCloudProvider` via `buildProviderOpenAIRequest`) serialize the same struct, so one guard covers every provider.

## Type of Change

- [x] 🐛 Bug fix

## Related Issue

Fixes #3014

## Testing

- `go build ./internal/models/chat/`
- `go test ./internal/models/chat/` — full package passes, including the new `TestBuildChatCompletionRequest_MaxTokensMutuallyExclusive` (both-set → only `max_completion_tokens` on the wire JSON; MaxTokens-only → unchanged; MaxCompletionTokens-only → unchanged; DeepSeek adapter migrates the budget to `max_tokens`)
- `go vet ./internal/handler/ ./internal/types/ ./internal/models/chat/`
- Environment: linux/amd64 (WSL Ubuntu 22.04), go1.26.0 per `go.mod`. Full-repository `go build ./...` was not run on this machine (the host is Windows without a C toolchain; the unrelated `internal/utils` pg_query CGO package cannot compile there) — all checks above are scoped to the changed package per the contributing guide.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted (gofmt)
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (`go vet` on changed packages; `golangci-lint` not available locally)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (no user-facing docs mention these fields)

## Screenshots / Recordings

Not applicable (no UI change).
