### PR TITLE
fix(preview): stop routing legacy .doc/.ppt to the OOXML previewers

### DIFF
--- a/frontend/src/utils/filePreview.test.ts
+++ b/frontend/src/utils/filePreview.test.ts
@@ -27,6 +27,12 @@ test('resolvePreviewKind covers office, tables, html, media, and code', () => {
   assert.equal(resolvePreviewKind('pdf'), 'pdf')
   assert.equal(resolvePreviewKind('docx'), 'docx')
   assert.equal(resolvePreviewKind('pptx'), 'pptx')
+  // Legacy OLE2 formats are not parseable by the OOXML previewers and must
+  // degrade to the unsupported state instead of failing with a zip error.
+  assert.equal(resolvePreviewKind('doc'), 'unsupported')
+  assert.equal(resolvePreviewKind('ppt'), 'unsupported')
+  // SheetJS renders legacy .xls fine, so it stays previewable.
+  assert.equal(resolvePreviewKind('xls'), 'excel')
   assert.equal(resolvePreviewKind('png'), 'image')
   assert.equal(resolvePreviewKind('svg'), 'image')
   assert.equal(resolvePreviewKind('md'), 'markdown')

--- a/frontend/src/utils/filePreview.ts
+++ b/frontend/src/utils/filePreview.ts
@@ -36,8 +36,12 @@ function register(kind: FilePreviewKind, exts: string[]) {
 }
 
 register('pdf', ['pdf'])
-register('docx', ['docx', 'doc'])
-register('pptx', ['pptx', 'ppt'])
+// .doc (Word 97-2003) and .ppt (PowerPoint 97-2003) are legacy OLE2 binary
+// formats, while the docx/pptx previewers only parse OOXML (ZIP/XML) and
+// would fail with a raw zip error; leaving them unregistered degrades to the
+// unsupported-preview state with a download entry instead.
+register('docx', ['docx'])
+register('pptx', ['pptx'])
 register('image', [
   'jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'tiff', 'tif', 'svg', 'svgz',
   'ico', 'avif', 'apng', 'jfif', 'pjpeg', 'pjp', 'heic', 'heif',


### PR DESCRIPTION
## Description

`frontend/src/utils/filePreview.ts` registered `.doc` onto the `docx` preview kind:

```ts
register('docx', ['docx', 'doc'])
```

`.doc` is the legacy Word 97–2003 OLE2 binary format, while `docx-preview` only parses OOXML (ZIP/XML). Previewing a successfully parsed `.doc` therefore failed with the raw library error `Can't find end of central directory: is this a zip file?`, misleading users into thinking the file was broken. `@vue-office/pptx` has the same OOXML-only constraint, so `.ppt` had the identical latent bug.

This PR leaves `doc` / `ppt` unregistered, so `resolvePreviewKind` returns `unsupported` and every consumer degrades along its existing path:

- Knowledge detail: `doc-content.vue` hides the Preview tab and shows the parsed content + download (the mechanism the issue describes).
- Direct-mounted `DocumentPreview`: the friendly `preview.unsupported` panel (the byte sniffer returns `unsupported` for NUL-containing binaries, so no raw error is surfaced).
- Chat attachments: not clickable for preview, same as other unsupported types.
- Uploads and file-type icons are untouched (`fileTypeVerification.ts` / icon maps don't read the preview registry), so `.doc`/`.ppt` remain fully uploadable and parseable.

`.xls` intentionally stays registered to the `excel` kind: the bundled SheetJS renders legacy BIFF workbooks.

## Type of Change

- [x] 🐛 Bug fix

## Related Issue

Fixes #3037

## Testing

- `npx tsx --test src/utils/filePreview.test.ts src/utils/attachmentPreview.test.mjs` — 8/8 pass, including new assertions: `resolvePreviewKind('doc') === 'unsupported'`, `resolvePreviewKind('ppt') === 'unsupported'`, and `resolvePreviewKind('xls') === 'excel'` (pinning the intentional asymmetry).
- Verified from the installed packages that `docx-preview@0.3.7` and `@vue-office/pptx@1.0.1` both go through `JSZip.loadAsync` (ZIP-only, no OLE2 parsing), and that all four locales ship the `preview.unsupported` / `preview.unsupportedHint` strings used by the degrade path.
- Manual check of the degrade surfaces: knowledge detail tab gating, `DocumentPreview` unsupported panel, chat attachment drawer, MIME map retained for downloads.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (frontend tests; eslint not run — not available in this environment)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above (only the scoped frontend suites were run)
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (no docs describe the preview registry)

## Screenshots / Recordings

Before (from #3037): parsed `.doc` preview shows `Can't find end of central directory: is this a zip file?`.
After: `.doc`/`.ppt` show the unsupported-preview panel with a download entry; knowledge detail hides the Preview tab and shows the parsed content.
