### PR TITLE
fix(knowledge): show all chunk types by default in the chunks list

### DIFF
--- a/frontend/src/components/doc-content.vue
+++ b/frontend/src/components/doc-content.vue
@@ -588,12 +588,19 @@ const appendChunkContent = (acc: string, next: string, positionOverlap: number):
 
 /**
  * 合并分块内容，还原完整文档。chunks 按 start_at 排序后逐段用文本重叠匹配拼接。
+ *
+ * 分块列表接口现在默认返回全部 chunk_type（image_ocr / parent_text / summary
+ * 等）。全文视图沿用仅合并 text 分块的历史语义：parent_text 与其子块内容重叠，
+ * image_ocr/caption 的 start_at 恒为 0，纳入合并会造成内容重复或错位拼接。
  */
 const mergeChunks = (chunks: any[]): string => {
   if (!chunks || chunks.length === 0) return '';
 
+  const mergeable = chunks.filter(c => !c.chunk_type || c.chunk_type === 'text');
+  if (mergeable.length === 0) return '';
+
   // 按 start_at 排序
-  const sortedChunks = [...chunks].sort((a, b) => {
+  const sortedChunks = [...mergeable].sort((a, b) => {
     const startA = a.start_at ?? a.chunk_index ?? 0;
     const startB = b.start_at ?? b.chunk_index ?? 0;
     return startA - startB;

--- a/internal/handler/chunk.go
+++ b/internal/handler/chunk.go
@@ -124,14 +124,11 @@ func (h *ChunkHandler) ListKnowledgeChunks(c *gin.Context) {
 		pagination.PageSize = 100
 	}
 
-	// Default to text chunks; callers may override via ?chunk_type=image_caption etc.
-	chunkType := []types.ChunkType{types.ChunkTypeText}
-	if queryTypes := c.QueryArray("chunk_type"); len(queryTypes) > 0 {
-		chunkType = make([]types.ChunkType, 0, len(queryTypes))
-		for _, qt := range queryTypes {
-			chunkType = append(chunkType, types.ChunkType(qt))
-		}
-	}
+	// Return every chunk type unless the caller narrows the result via
+	// ?chunk_type=image_caption etc. A text-only default silently hid
+	// multimodal chunks (image_ocr / image_caption) from the chunks page
+	// and made the reported total diverge from the database.
+	chunkType := chunkTypeFilter(c.QueryArray("chunk_type"))
 
 	// The route-level guard has rewritten the request's tenant context
 	// to the effective tenant for shared KBs.
@@ -149,6 +146,21 @@ func (h *ChunkHandler) ListKnowledgeChunks(c *gin.Context) {
 		"page":      result.Page,
 		"page_size": result.PageSize,
 	})
+}
+
+// chunkTypeFilter builds the chunk-type filter for list requests. Without an
+// explicit ?chunk_type= list it defaults to every chunk type; a text-only
+// default made the chunks page hide multimodal chunks. See
+// Tencent/WeKnora#2857.
+func chunkTypeFilter(queryTypes []string) []types.ChunkType {
+	if len(queryTypes) == 0 {
+		return types.AllChunkTypes()
+	}
+	filter := make([]types.ChunkType, 0, len(queryTypes))
+	for _, qt := range queryTypes {
+		filter = append(filter, types.ChunkType(qt))
+	}
+	return filter
 }
 
 // UpdateChunkRequest defines the request structure for updating a chunk

--- a/internal/handler/chunk_test.go
+++ b/internal/handler/chunk_test.go
@@ -1,0 +1,51 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func TestChunkTypeFilterDefaultsToAllTypes(t *testing.T) {
+	got := chunkTypeFilter(nil)
+	all := types.AllChunkTypes()
+	if len(got) != len(all) {
+		t.Fatalf("chunkTypeFilter(nil) = %#v, want all %d types", got, len(all))
+	}
+	// Multimodal chunks must be visible by default; a text-only default hid
+	// them from the chunks page (#2857).
+	for _, want := range []types.ChunkType{
+		types.ChunkTypeText,
+		types.ChunkTypeImageOCR,
+		types.ChunkTypeImageCaption,
+		types.ChunkTypeFAQ,
+	} {
+		found := false
+		for _, ct := range got {
+			if ct == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("chunkTypeFilter(nil) missing %q: %#v", want, got)
+		}
+	}
+}
+
+func TestChunkTypeFilterRespectsExplicitQuery(t *testing.T) {
+	got := chunkTypeFilter([]string{"text", "image_ocr"})
+	if len(got) != 2 || got[0] != types.ChunkTypeText || got[1] != types.ChunkTypeImageOCR {
+		t.Fatalf("chunkTypeFilter([text image_ocr]) = %#v, want [text image_ocr]", got)
+	}
+}
+
+func TestAllChunkTypesHasNoDuplicates(t *testing.T) {
+	seen := make(map[types.ChunkType]bool)
+	for _, ct := range types.AllChunkTypes() {
+		if seen[ct] {
+			t.Fatalf("AllChunkTypes contains duplicate %q", ct)
+		}
+		seen[ct] = true
+	}
+}

--- a/internal/types/chunk.go
+++ b/internal/types/chunk.go
@@ -39,6 +39,25 @@ const (
 	ChunkTypeWikiPage ChunkType = "wiki_page"
 )
 
+// AllChunkTypes 返回全部 Chunk 类型。列表类接口在调用方未显式筛选类型时以
+// 它作为默认集合，新增 Chunk 类型后无需改动调用方即可保持可见。
+func AllChunkTypes() []ChunkType {
+	return []ChunkType{
+		ChunkTypeText,
+		ChunkTypeParentText,
+		ChunkTypeImageOCR,
+		ChunkTypeImageCaption,
+		ChunkTypeSummary,
+		ChunkTypeEntity,
+		ChunkTypeRelationship,
+		ChunkTypeFAQ,
+		ChunkTypeWebSearch,
+		ChunkTypeTableSummary,
+		ChunkTypeTableColumn,
+		ChunkTypeWikiPage,
+	}
+}
+
 // ChunkStatus 定义了不同状态的 Chunk
 type ChunkStatus int
 


### PR DESCRIPTION
## Description

`ListKnowledgeChunks` hardcoded a text-only default chunk-type filter:

```go
chunkType := []types.ChunkType{types.ChunkTypeText}
```

The frontend chunks page never sends `chunk_type`, so multimodal chunks (`image_ocr` / `image_caption`) were invisible there and the reported total diverged from the database (e.g. 135 stored chunks shown as 38).

This PR defaults to every chunk type via a new `types.AllChunkTypes()` helper (defined next to the `ChunkType` enum, so future types stay visible without changes elsewhere) whenever the request carries no `chunk_type` parameter; explicit `?chunk_type=` filters keep their previous behavior. The selection logic lives in a small pure helper `chunkTypeFilter` for testability.

Follow-up consideration from review: the merged full-text view (`doc-content.vue` `mergeChunks`) previously only ever received text chunks. It now filters to text chunks explicitly — `parent_text` rows duplicate their children and `image_ocr`/`image_caption` rows carry `start_at = 0`, which would have produced duplicated or misplaced content in that view.

## Type of Change

- [x] 🐛 Bug fix

## Related Issue

Fixes #2857

## Testing

- `go build ./internal/handler/ ./internal/types/`
- `go test ./internal/handler/ -run 'TestChunkTypeFilter|TestAllChunkTypes'` — 3/3 pass (nil → all types incl. `text`/`image_ocr`/`image_caption`/`faq`; explicit multi-param order preserved; no duplicates in `AllChunkTypes()`)
- `go vet ./internal/handler/ ./internal/types/ ./internal/models/chat/`
- Environment: linux/amd64 (WSL Ubuntu 22.04), go1.26.0 per `go.mod`. Full-repository `go build ./...` was not run on this machine (Windows host without a C toolchain; the unrelated `internal/utils` pg_query CGO package cannot compile there) — checks above are scoped to the changed packages per the contributing guide.
- Verified all other callers of `ListPagedChunksByKnowledgeID` pass explicit non-empty type lists, so the new default affects only the handler path; frontend pagination is driven by the server `total`, so extra rows only create more pages.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted (gofmt)
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (`go vet` on changed packages; `golangci-lint` not available locally)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (no docs describe the chunks list default)

## Screenshots / Recordings

Reproduction from #2857: a PDF with multimodal parsing stored 135 chunks (`text: 38, image_ocr: 48, image_caption: 49`); the chunks page showed only 38 rows. After this change all 135 rows appear and `total` matches the database.
