### PR TITLE
fix: persist cleared IM knowledge bases

### DIFF
--- a/frontend/src/components/IMChannelPanel.vue
+++ b/frontend/src/components/IMChannelPanel.vue
@@ -585,6 +585,7 @@ import { ref, onMounted, watch, onUnmounted, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { MessagePlugin } from 'tdesign-vue-next';
 import { copyWithToast } from '@/utils/clipboard';
+import { normalizeOptionalString } from '@/utils/optionalString';
 import {
   listIMChannels, createIMChannel, updateIMChannel, deleteIMChannel, toggleIMChannel,
   getWeChatQRCode, pollWeChatQRCodeStatus, listAllIMChannels, listAgents,
@@ -1037,7 +1038,7 @@ async function handleSave() {
         mode: formData.value.mode,
         output_mode: formData.value.output_mode,
         session_mode: formData.value.session_mode,
-        knowledge_base_id: formData.value.knowledge_base_id,
+        knowledge_base_id: normalizeOptionalString(formData.value.knowledge_base_id),
         credentials: formData.value.credentials,
         enabled: editingEnabled.value,
         ...(formData.value.target_agent_id ? { agent_id: formData.value.target_agent_id } : {}),
@@ -1055,7 +1056,7 @@ async function handleSave() {
         mode: formData.value.mode,
         output_mode: formData.value.output_mode,
         session_mode: formData.value.session_mode,
-        knowledge_base_id: formData.value.knowledge_base_id,
+        knowledge_base_id: normalizeOptionalString(formData.value.knowledge_base_id),
         credentials: formData.value.credentials,
       });
       MessagePlugin.success(t('common.createSuccess'));

--- a/frontend/src/utils/optionalString.test.ts
+++ b/frontend/src/utils/optionalString.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { normalizeOptionalString } from './optionalString'
+
+test('preserves a selected optional string', () => {
+  assert.equal(normalizeOptionalString('kb-1'), 'kb-1')
+})
+
+test('serializes cleared optional strings as an explicit empty value', () => {
+  assert.equal(normalizeOptionalString(undefined), '')
+  assert.equal(normalizeOptionalString(null), '')
+  assert.equal(
+    JSON.stringify({ knowledge_base_id: normalizeOptionalString(undefined) }),
+    '{"knowledge_base_id":""}',
+  )
+})

--- a/frontend/src/utils/optionalString.ts
+++ b/frontend/src/utils/optionalString.ts
@@ -1,0 +1,3 @@
+export function normalizeOptionalString(value: string | null | undefined): string {
+  return value ?? '';
+}


### PR DESCRIPTION
## Summary

- normalize cleared optional knowledge-base selections to an explicit empty string before creating or updating an IM channel
- preserve selected knowledge-base IDs unchanged
- add a regression test that verifies cleared values remain present in serialized JSON

## Problem

The clearable knowledge-base selector can produce `undefined` or `null`. JSON serialization omits `undefined`, while Go binds JSON `null` to a nil `*string`. The update handler interprets nil as “field not provided”, so the previous knowledge-base association remains after the user clears it.

## Verification

- `npm test` (all frontend tests pass)
- `npm run type-check`
- `npm run build`
- regression rollback proof: restoring the old undefined-preserving behavior makes the new serialization test fail
- `git diff --check`

Closes #3032
