### PR TITLE
fix: isolate agent editor dependency failures

### DIFF
--- a/frontend/src/views/agent/AgentEditorModal.test.mjs
+++ b/frontend/src/views/agent/AgentEditorModal.test.mjs
@@ -35,6 +35,19 @@ test('shows a post-create hint after the first successful save', () => {
   assert.match(source, /agent\.editor\.postCreateHint\.title/)
 })
 
+test('dependency failures do not discard successfully loaded editor resources', () => {
+  const loadDependencies = source.match(
+    /const loadDependencies = async \(\) => \{([\s\S]*?)^\};/m
+  )?.[1]
+
+  assert.ok(loadDependencies, 'expected to find loadDependencies')
+  assert.match(loadDependencies, /await Promise\.allSettled\(\[/)
+  assert.match(loadDependencies, /if \(result\.status === 'rejected'\)/)
+  assert.match(loadDependencies, /allModels\.value = chatResources\.allModels/)
+  assert.match(loadDependencies, /kbOptions\.value = \[\.\.\.myKbs, \.\.\.sharedKbs\]/)
+  assert.doesNotMatch(loadDependencies, /try\s*\{[\s\S]*await Promise\.all\(/)
+})
+
 // Locate a settings row by the i18n key of its label and return the attributes
 // that sit before class="setting-row" — i.e. whatever v-if guards that row.
 // Anchoring on the label keeps these assertions stable across reformatting.

--- a/frontend/src/views/agent/AgentEditorModal.vue
+++ b/frontend/src/views/agent/AgentEditorModal.vue
@@ -3878,46 +3878,48 @@ const applyPromptTemplateDefaults = (cfg: PromptTemplatesConfig | null) => {
 
 // 加载依赖数据（复用空间级缓存，避免重复请求）
 const loadDependencies = async () => {
-  try {
-    await Promise.all([
-      chatResources.ensureModels(),
-      chatResources.ensureKnowledgeBases(),
-      chatResources.ensureWebSearchProviders(),
-      chatResources.ensureSandboxConfigs(),
-      editorResources.prefetchAgentEditorDeps(),
-    ]);
+  const dependencyResults = await Promise.allSettled([
+    chatResources.ensureModels(),
+    chatResources.ensureKnowledgeBases(),
+    chatResources.ensureWebSearchProviders(),
+    chatResources.ensureSandboxConfigs(),
+    editorResources.prefetchAgentEditorDeps(),
+  ]);
 
-    if (chatResources.allModels.length > 0) {
-      allModels.value = chatResources.allModels;
+  for (const result of dependencyResults) {
+    if (result.status === 'rejected') {
+      console.warn('Failed to load an agent editor dependency', result.reason);
     }
-
-    const myKbs = chatResources.rawKnowledgeBases.map((kb: any) => mapKbToOption(kb, false));
-    const myKbIds = new Set(myKbs.map(kb => kb.value));
-    const sharedKbs = (orgStore.sharedKnowledgeBases || [])
-      .filter((shared: any) => shared.knowledge_base && !myKbIds.has(shared.knowledge_base.id))
-      .map((shared: any) => mapKbToOption(shared.knowledge_base, true, shared.org_name));
-    kbOptions.value = [...myKbs, ...sharedKbs];
-
-    agentTypePresets.value = editorResources.agentTypePresets as AgentTypePreset[];
-    applyPromptTemplateDefaults(editorResources.promptTemplates);
-
-    storageEngineStatus.value = editorResources.storageStatus;
-
-    webSearchProviderList.value = chatResources.webSearchProviders as WebSearchProviderEntity[];
-
-    if (editorResources.placeholders) {
-      placeholderData.value = editorResources.placeholders;
-    }
-
-    const rc = editorResources.tenantRetrievalConfig as Record<string, number> | null;
-    if (rc?.embedding_top_k) defaultEmbeddingTopK.value = rc.embedding_top_k;
-    if (rc?.keyword_threshold !== undefined) defaultKeywordThreshold.value = rc.keyword_threshold;
-    if (rc?.vector_threshold !== undefined) defaultVectorThreshold.value = rc.vector_threshold;
-    if (rc?.rerank_top_k) defaultRerankTopK.value = rc.rerank_top_k;
-    if (rc?.rerank_threshold !== undefined) defaultRerankThreshold.value = rc.rerank_threshold;
-  } catch (e) {
-    console.error('Failed to load dependencies', e);
   }
+
+  if (chatResources.allModels.length > 0) {
+    allModels.value = chatResources.allModels;
+  }
+
+  const myKbs = chatResources.rawKnowledgeBases.map((kb: any) => mapKbToOption(kb, false));
+  const myKbIds = new Set(myKbs.map(kb => kb.value));
+  const sharedKbs = (orgStore.sharedKnowledgeBases || [])
+    .filter((shared: any) => shared.knowledge_base && !myKbIds.has(shared.knowledge_base.id))
+    .map((shared: any) => mapKbToOption(shared.knowledge_base, true, shared.org_name));
+  kbOptions.value = [...myKbs, ...sharedKbs];
+
+  agentTypePresets.value = editorResources.agentTypePresets as AgentTypePreset[];
+  applyPromptTemplateDefaults(editorResources.promptTemplates);
+
+  storageEngineStatus.value = editorResources.storageStatus;
+
+  webSearchProviderList.value = chatResources.webSearchProviders as WebSearchProviderEntity[];
+
+  if (editorResources.placeholders) {
+    placeholderData.value = editorResources.placeholders;
+  }
+
+  const rc = editorResources.tenantRetrievalConfig as Record<string, number> | null;
+  if (rc?.embedding_top_k) defaultEmbeddingTopK.value = rc.embedding_top_k;
+  if (rc?.keyword_threshold !== undefined) defaultKeywordThreshold.value = rc.keyword_threshold;
+  if (rc?.vector_threshold !== undefined) defaultVectorThreshold.value = rc.vector_threshold;
+  if (rc?.rerank_top_k) defaultRerankTopK.value = rc.rerank_top_k;
+  if (rc?.rerank_threshold !== undefined) defaultRerankThreshold.value = rc.rerank_threshold;
 };
 
 // 跳转到模型管理页面添加模型


### PR DESCRIPTION
## Summary

- wait for agent editor dependencies independently instead of abandoning all loaded data after one rejection
- keep successful model, knowledge-base, provider, and preset results available when an unrelated privileged request fails
- add a regression assertion for the partial-success loading contract

## Problem

Contributor users can successfully read models and knowledge bases, but the editor also prefetches tenant storage configuration, which returns 403 for that role. The outer `Promise.all` rejects and skips every assignment below it, leaving the model and knowledge-base selectors empty even though those requests succeeded.

Using `Promise.allSettled` preserves concurrent loading and error visibility while allowing the editor to apply each resource that was loaded successfully. This does not relax backend permissions or fabricate data for failed requests.

## Verification

- `npm test` (600 tests pass)
- `npm run type-check`
- `npm run build`
- rollback proof: restoring the previous `Promise.all` implementation makes the new regression assertion fail
- `git diff --check`

Closes #2991
