### PR TITLE
feat(frontend): expose HTTP status on API responses via $httpStatus

### DIFF
--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -10,6 +10,40 @@ const t = (key: string) => i18n.global.t(key)
 // API基础URL
 const BASE_URL = getApiBaseUrl();
 
+/**
+ * Response payload augmented with the HTTP status code.
+ *
+ * `$httpStatus` lets callers distinguish outcomes that share a success shape.
+ * Defined as a non-enumerable property, so it stays invisible to object spread,
+ * JSON.stringify and Object.keys and never leaks into downstream payloads.
+ *
+ * Guaranteed only for JSON responses (objects/arrays). Blob, string and SSE
+ * stream responses do not carry it at runtime, so only read `$httpStatus`
+ * when the payload is known to be an object.
+ */
+export type WithStatus<T> = T & {
+  /** HTTP status code of the response. Non-enumerable. See {@link WithStatus}. */
+  readonly $httpStatus: number
+};
+
+const HTTP_STATUS_KEY = '$httpStatus';
+
+/**
+ * Attach the non-enumerable `$httpStatus` property to a response payload
+ * in place and return it. Primitives pass through untouched.
+ * See {@link WithStatus} for where the property is guaranteed.
+ */
+function withHttpStatus<T>(data: T, status: number): T {
+  if (data !== null && typeof data === 'object') {
+    Object.defineProperty(data, HTTP_STATUS_KEY, {
+      value: status,
+      enumerable: false,
+      configurable: true,
+      writable: false,
+    });
+  }
+  return data;
+}
 
 // 创建Axios实例
 const instance = axios.create({
@@ -115,9 +149,9 @@ instance.interceptors.response.use(
     // 根据业务状态码处理逻辑
     const { status, data } = response;
     if (status >= 200 && status < 300) {
-      return data;
+      return withHttpStatus(data, status);
     } else {
-      return Promise.reject(data);
+      return Promise.reject(withHttpStatus(data, status));
     }
   },
   async (error: any) => {
@@ -133,7 +167,7 @@ instance.interceptors.response.use(
       const msg = typeof data === 'object'
         ? (typeof data?.error === 'string' ? data.error : (data?.error?.message || data?.message))
         : data;
-      return Promise.reject({ status, message: msg || t('error.invalidCredentials') });
+      return Promise.reject(withHttpStatus({ status, message: msg || t('error.invalidCredentials') }, status));
     }
 
     // Embed 调试页/挂件：无 JWT 时直接拒绝，勿走 refresh → /login
@@ -142,7 +176,7 @@ instance.interceptors.response.use(
       const msg = typeof data === 'object'
         ? (typeof data?.error === 'string' ? data.error : (data?.error?.message || data?.message))
         : data;
-      return Promise.reject({ status, message: msg || t('error.invalidCredentials') });
+      return Promise.reject(withHttpStatus({ status, message: msg || t('error.invalidCredentials') }, status));
     }
 
     // 如果是401错误且不是刷新token的请求，尝试刷新token
@@ -215,15 +249,16 @@ instance.interceptors.response.use(
     }
     
     // 处理 Nginx 413 Request Entity Too Large
-    if (error.response.status === 413) {
+    const ERR_ENTITY_TOO_LARGE = 413;
+    if (error.response.status === ERR_ENTITY_TOO_LARGE) {
       const skillUpload = isSkillBundleUploadUrl(error.config?.url)
-      return Promise.reject({ 
-        status: 413, 
+      return Promise.reject(withHttpStatus({
+        status: ERR_ENTITY_TOO_LARGE,
         message: skillUpload
           ? i18n.global.t('settings.sandbox.skillBundleTooLarge', { size: MAX_SKILL_BUNDLE_SIZE_MB })
           : i18n.global.t('error.fileSizeExceeded', { size: MAX_FILE_SIZE_MB }),
         success: false
-      });
+      }, ERR_ENTITY_TOO_LARGE));
     }
 
     const { status, data } = error.response;
@@ -242,16 +277,16 @@ instance.interceptors.response.use(
     } else if (typeof data === 'string') {
       errorMessage = data;
     }
-    return Promise.reject({ 
-      status, 
+    return Promise.reject(withHttpStatus({
+      status,
       message: errorMessage,
       ...(typeof data === 'object' ? data : {}) 
-    });
+    }, status));
   }
 );
 
-export function get<T = any>(url: string, config?: any): Promise<T> {
-  return instance.get<T>(url, config) as unknown as Promise<T>;
+export function get<T = any>(url: string, config?: any): Promise<WithStatus<T>> {
+  return instance.get<T>(url, config) as unknown as Promise<WithStatus<T>>;
 }
 
 export async function getDown(url: string): Promise<Blob> {
@@ -266,7 +301,7 @@ export function postUpload(
   data = {},
   onUploadProgress?: (progressEvent: any) => void,
   config: any = {},
-): Promise<any> {
+): Promise<WithStatus<any>> {
   return instance.post(url, data, {
     ...config,
     headers: {
@@ -279,6 +314,7 @@ export function postUpload(
 }
 
 export function postChat<T = any>(url: string, data = {}): Promise<T> {
+  // SSE stream: body is a string, so no `$httpStatus` is attached (see WithStatus).
   return instance.post(url, data, {
     headers: {
       "Content-Type": "text/event-stream;charset=utf-8",
@@ -287,18 +323,18 @@ export function postChat<T = any>(url: string, data = {}): Promise<T> {
   }) as unknown as Promise<T>;
 }
 
-export function post<T = any>(url: string, data = {}, config?: any): Promise<T> {
-  return instance.post<T>(url, data, config) as unknown as Promise<T>;
+export function post<T = any>(url: string, data = {}, config?: any): Promise<WithStatus<T>> {
+  return instance.post<T>(url, data, config) as unknown as Promise<WithStatus<T>>;
 }
 
-export function put<T = any>(url: string, data = {}, config?: any): Promise<T> {
-  return instance.put<T>(url, data, config) as unknown as Promise<T>;
+export function put<T = any>(url: string, data = {}, config?: any): Promise<WithStatus<T>> {
+  return instance.put<T>(url, data, config) as unknown as Promise<WithStatus<T>>;
 }
 
-export function patch<T = any>(url: string, data = {}, config?: any): Promise<T> {
-  return instance.patch<T>(url, data, config) as unknown as Promise<T>;
+export function patch<T = any>(url: string, data = {}, config?: any): Promise<WithStatus<T>> {
+  return instance.patch<T>(url, data, config) as unknown as Promise<WithStatus<T>>;
 }
 
-export function del<T = any>(url: string, data?: any): Promise<T> {
-  return instance.delete<T>(url, { data }) as unknown as Promise<T>;
+export function del<T = any>(url: string, data?: any): Promise<WithStatus<T>> {
+  return instance.delete<T>(url, { data }) as unknown as Promise<WithStatus<T>>;
 }


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

前端请求封装（get/post/put/patch/del/postUpload）现以非枚举属性 `$httpStatus` 在 JSON 响应上附带 HTTP 状态码，并新增 `WithStatus<T>` 类型，便于调用方区分相同结构的响应。

属性对展开/序列化不可见，SSE、Blob 等非 JSON 响应不携带。

Follow up: #3034 ，这个合并后即可在 API 函数中获取状态，之后即可修复这个 PR 里面描述的问题（已知缺陷：后端 POST /system/admin/users/create 以 201 表示新建、200 表示幂等重试（身份已存在），但前端共享 axios 客户端（frontend/src/utils/request.ts）的响应拦截器将 response.data 全局解包并丢弃状态码，导致上层调用方无法区分这两条路径。）

## Type of Change
<!-- Check applicable items -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->

暂无关联测试，现有测试均通过（向前兼容）

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [ ] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
