### PR TITLE
feat(datasource): keep the source document's last-modified time through ingestion

### DIFF
--- a/internal/application/service/datasource_service.go
+++ b/internal/application/service/datasource_service.go
@@ -1251,6 +1251,12 @@ func (s *DataSourceService) ingestItem(ctx context.Context, ds *types.DataSource
 		"source_resource_id": item.SourceResourceID,
 		"datasource_id":      ds.ID,
 	}
+	// The source system's own last-modified time, when the connector supplied
+	// one. The knowledge row's UpdatedAt moves on every re-parse, so this is
+	// the only record of how old the document itself is.
+	if !item.UpdatedAt.IsZero() {
+		metadata["source_updated_at"] = item.UpdatedAt.UTC().Format(time.RFC3339)
+	}
 	for k, v := range item.Metadata {
 		metadata[k] = v
 	}

--- a/internal/application/service/datasource_service_test.go
+++ b/internal/application/service/datasource_service_test.go
@@ -501,6 +501,38 @@ func TestIngestItem_URLCreationAttachesDataSourceMetadata(t *testing.T) {
 	assert.Equal(t, "url:1", repo.metadataUpdates[0]["external_id"])
 }
 
+// TestIngestItem_PersistsSourceUpdatedAt verifies that the connector-supplied
+// last-modified time reaches the persisted metadata as an RFC3339 UTC string,
+// and that an item without one gets no key rather than a zero time.
+func TestIngestItem_PersistsSourceUpdatedAt(t *testing.T) {
+	ds := &types.DataSource{ID: "ds-1", TenantID: 1, KnowledgeBaseID: "kb-1"}
+	edited := time.Date(2023, 4, 5, 6, 7, 8, 0, time.FixedZone("CST", 8*3600))
+
+	repo := &deletionLookupKnowledgeRepo{}
+	ks := &sweepFakeKS{repo: repo, createURLKnowledge: &types.Knowledge{ID: "url-knowledge-1"}}
+	svc := &DataSourceService{knowledgeService: ks}
+	_, err := svc.ingestItem(context.Background(), ds, &types.FetchedItem{
+		ExternalID: "url:1",
+		URL:        "https://example.com/doc",
+		UpdatedAt:  edited,
+	}, nil)
+	require.NoError(t, err)
+	require.Len(t, repo.metadataUpdates, 1)
+	assert.Equal(t, "2023-04-04T22:07:08Z", repo.metadataUpdates[0]["source_updated_at"])
+
+	repo = &deletionLookupKnowledgeRepo{}
+	ks = &sweepFakeKS{repo: repo, createURLKnowledge: &types.Knowledge{ID: "url-knowledge-2"}}
+	svc = &DataSourceService{knowledgeService: ks}
+	_, err = svc.ingestItem(context.Background(), ds, &types.FetchedItem{
+		ExternalID: "url:2",
+		URL:        "https://example.com/doc2",
+	}, nil)
+	require.NoError(t, err)
+	require.Len(t, repo.metadataUpdates, 1)
+	_, present := repo.metadataUpdates[0]["source_updated_at"]
+	assert.False(t, present)
+}
+
 func TestProcessSync_SyncDeletionsDeletesMatchingKnowledge(t *testing.T) {
 	h := newSyncDeletionHarness(t, true, "ds-delete-characterization", "log-delete-characterization", nil, nil)
 	updated, err := h.run(t)


### PR DESCRIPTION
Refs #3016.

Connectors already fill `FetchedItem.UpdatedAt` (Feishu from the real edit time), but `ingestItem` drops it: the metadata map only carries `external_id`, `source_resource_id` and `datasource_id`, and the knowledge row's own `UpdatedAt` moves on every re-parse. This writes the value into metadata as `source_updated_at` (RFC3339, UTC) when the connector supplied one, and leaves the key out otherwise, so an absent time stays distinguishable from a zero one.

No schema change: it is the smallest step that makes the source time available downstream (summaries, sorting, supersession checks). Dedicated columns on `types.Knowledge` and a `CreatedAt` on `FetchedItem`, as proposed in the issue, can follow once the naming is settled.

Test: `TestIngestItem_PersistsSourceUpdatedAt`.
