### PR TITLE
fix(azure): restore GPT-5/reasoning model calls broken since v0.8.0

### DIFF
--- a/internal/models/chat/prompt_cache.go
+++ b/internal/models/chat/prompt_cache.go
@@ -195,8 +195,10 @@ type promptCachePolicy struct {
 
 func promptCachePolicyFor(name provider.ProviderName, baseURL string) promptCachePolicy {
 	switch name {
-	case provider.ProviderOpenAI, provider.ProviderAzureOpenAI, provider.ProviderOpenRouter:
+	case provider.ProviderOpenAI, provider.ProviderOpenRouter:
 		return promptCachePolicy{sendKey: true, sendAffinity: true}
+	case provider.ProviderAzureOpenAI:
+		return promptCachePolicy{sendAffinity: true}
 	case provider.ProviderAliyun:
 		return promptCachePolicy{sendCacheControl: true}
 	case provider.ProviderAnthropic:

--- a/internal/models/chat/remote_api.go
+++ b/internal/models/chat/remote_api.go
@@ -58,10 +58,17 @@ func NewRemoteAPIChat(chatConfig *ChatConfig) (*RemoteAPIChat, error) {
 		config.AzureModelMapperFunc = func(model string) string {
 			return model
 		}
+		hasExplicitAPIVersion := false
 		if chatConfig.ExtraConfig != nil {
 			if v, ok := chatConfig.ExtraConfig["api_version"]; ok {
 				config.APIVersion = v
+				hasExplicitAPIVersion = true
 			}
+		}
+		// GPT-5 / reasoning 模型需要足够新的 API 版本；DefaultAzureConfig
+		// 默认的 2023-05-15 不支持这些模型。用户显式指定时保留原值。
+		if !hasExplicitAPIVersion && provider.IsOpenAIReasoningOrGPT5Model(chatConfig.ModelName) {
+			config.APIVersion = "2025-04-01-preview"
 		}
 	} else {
 		config = openai.DefaultConfig(apiKey)

--- a/internal/models/vlm/remote_api.go
+++ b/internal/models/vlm/remote_api.go
@@ -64,12 +64,19 @@ func NewRemoteAPIVLM(config *Config) (*RemoteAPIVLM, error) {
 		apiCfg.AzureModelMapperFunc = func(model string) string {
 			return model
 		}
+		hasExplicitAPIVersion := false
 		if config.Extra != nil {
 			if v, ok := config.Extra["api_version"]; ok {
 				if vs, ok := v.(string); ok && vs != "" {
 					apiCfg.APIVersion = vs
+					hasExplicitAPIVersion = true
 				}
 			}
+		}
+		// GPT-5 / reasoning 模型需要足够新的 API 版本；DefaultAzureConfig
+		// 默认的 2023-05-15 不支持这些模型。用户显式指定时保留原值。
+		if !hasExplicitAPIVersion && provider.IsOpenAIReasoningOrGPT5Model(config.ModelName) {
+			apiCfg.APIVersion = "2025-04-01-preview"
 		}
 	} else {
 		apiCfg = openai.DefaultConfig(config.APIKey)


### PR DESCRIPTION
Two issues exposed by v0.8.0 made Azure OpenAI GPT-5 and o-series deployments (e.g. gpt-5.x) fail with HTTP 404 "Resource not found".

1. Prompt-cache forces the wrong raw-HTTP URL.
`promptCachePolicyFor` grouped Azure OpenAI with OpenAI/OpenRouter under `sendKey=true`; `applyPromptCacheToJSONBody` then injects a non-standard `prompt_cache_key` and forces the raw-HTTP path, which builds `{baseURL}/chat/completions` instead of Azure's `{baseURL}/openai/deployments/{name}/chat/completions?api-version=...`. Azure is now split into its own policy that only sets `sendAffinity`, so the go-openai SDK path (which builds the correct URL) is used.

2. Default api-version too old for GPT-5.
`openai.DefaultAzureConfig` defaults api-version to `2023-05-15`, which does not support GPT-5/reasoning deployments. When no `api_version` is set in `extra_config`, default to `2025-04-01-preview` for models matched by `IsOpenAIReasoningOrGPT5Model` (Chat and VLM paths). An explicit user-set `api_version` is always honored.

Changed files: internal/models/chat/prompt_cache.go, internal/models/chat/remote_api.go, internal/models/vlm/remote_api.go