### PR TITLE
feat(opencode-weknora): opencode plugin exposing WeKnora retrieval tools

### DIFF
--- a/.github/workflows/opencode-plugin.yml
+++ b/.github/workflows/opencode-plugin.yml
@@ -1,0 +1,162 @@
+name: Build & Publish (opencode-weknora)
+
+# Build, test, and publish the opencode plugin (packages/opencode-weknora/) to npm.
+#
+# Two jobs:
+#   test      typecheck, unit and contract tests (both halves: the plugin's
+#             emitted calls and WeKnora's Go request/response types), and a
+#             packaging check
+#   publish   on an `opencode-weknora-v*` tag only, publish to npm with provenance
+#
+# An end-to-end job that drives the plugin through opencode's agent loop (the
+# way dsh-plugin.yml does inside dsh) is a planned follow-up; until then the
+# plugin is verified against a live deployment through the documented manual
+# procedure (see packages/opencode-weknora/README.md, "Development").
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - "opencode-weknora-v*"
+    paths:
+      - "packages/opencode-weknora/**"
+      - ".github/workflows/opencode-plugin.yml"
+  pull_request:
+    paths:
+      - "packages/opencode-weknora/**"
+      - ".github/workflows/opencode-plugin.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # The contract's Go half lives in this repository's module. app.yml runs it
+  # only for a Go diff, so a change to the fixture or to the plugin alone would
+  # otherwise skip the side that checks WeKnora still serves those calls.
+  GO_VERSION: "1.26"
+
+jobs:
+  test:
+    name: Typecheck, test, pack
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: packages/opencode-weknora
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: packages/opencode-weknora/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Unit and contract tests
+        run: node --test "test/*.test.mjs"
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Contract tests against WeKnora's Go types
+        working-directory: ${{ github.workspace }}
+        run: go test ./packages/opencode-weknora/contract/...
+
+      - name: Pack and verify the published file list
+        run: |
+          set -e
+          npm pack --dry-run --json > pack.json
+          node -e "
+            const files = require('./pack.json')[0].files.map(f => f.path);
+            const required = ['dist/index.js', 'dist/index.d.ts', 'README.md', 'package.json'];
+            const missing = required.filter(name => !files.includes(name));
+            if (missing.length > 0) {
+              console.error('missing from the tarball: ' + missing.join(', '));
+              process.exit(1);
+            }
+            const leaked = files.filter(name => name.startsWith('test/') || name.startsWith('src/'));
+            if (leaked.length > 0) {
+              console.error('unexpected files in the tarball: ' + leaked.join(', '));
+              process.exit(1);
+            }
+            console.log('tarball contents verified: ' + files.length + ' files');
+          "
+          rm pack.json
+
+  publish:
+    name: Publish to npm
+    needs: [test]
+    if: startsWith(github.ref, 'refs/tags/opencode-weknora-v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: npm-publish
+      url: https://www.npmjs.com/package/@wxg-prc-cpg/opencode-weknora
+    defaults:
+      run:
+        working-directory: packages/opencode-weknora
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+          cache-dependency-path: packages/opencode-weknora/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Check the tag names the packaged version
+        run: |
+          set -e
+          version="$(node -p "require('./package.json').version")"
+          expected="opencode-weknora-v${version}"
+          if [ "$GITHUB_REF_NAME" != "$expected" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not name the packaged version $version (expected $expected)."
+            echo "::error::Bump packages/opencode-weknora/package.json, or retag — publishing here would ship a version the tag does not name."
+            exit 1
+          fi
+
+      - name: Check whether this version is already published
+        id: check_npm
+        run: |
+          set -e
+          name="$(node -p "require('./package.json').name")"
+          version="$(node -p "require('./package.json').version")"
+          echo "packaged: $name@$version"
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::$name $version is already on npm; skipping publish. Bump package.json to release."
+          else
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish
+        if: steps.check_npm.outputs.should_publish == 'true'
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ The [WeKnora Mini Program](./miniprogram/README.md) provides a lightweight mobil
 - **`weknora_ask`** — WeKnora's own composed answer with citations, over the RAG or the ReAct pipeline
 - **`weknora_list_knowledge_bases`** — knowledge base names and ids, so the agent can scope its own search
 
+## 📦 opencode Plugin
+
+[**`@wxg-prc-cpg/opencode-weknora`**](https://www.npmjs.com/package/@wxg-prc-cpg/opencode-weknora) is the official [opencode](https://opencode.ai) plugin ([docs](./packages/opencode-weknora/README.md)), ported from dsh-weknora with the same four read-only tools. opencode's own tools read the workspace and the internet; this one adds your knowledge bases: put `"plugin": [["@wxg-prc-cpg/opencode-weknora", { "baseUrl": "https://weknora.example.com", "apiKey": "sk-..." }]]` in `opencode.json`, and the agent can search passages, read whole documents and ask cited questions over your deployment.
+
 ## ⌨️ Command-Line Interface
 
 `weknora` is the official CLI for driving the API from a terminal or an AI

--- a/README_CN.md
+++ b/README_CN.md
@@ -201,6 +201,10 @@
 - **`weknora_ask`** — WeKnora 自己带引用的成稿答案，走 RAG 或 ReAct 流水线
 - **`weknora_list_knowledge_bases`** — 知识库名称与 id，便于 Agent 自己缩小检索范围
 
+## 📦 opencode 插件
+
+[**`@wxg-prc-cpg/opencode-weknora`**](https://www.npmjs.com/package/@wxg-prc-cpg/opencode-weknora) 是官方的 [opencode](https://opencode.ai) 插件（[说明](./packages/opencode-weknora/README_CN.md)），从 dsh-weknora 移植而来，提供同样的四个只读工具。opencode 自身的工具只读工作区和互联网，这个插件补上你的知识库：在 `opencode.json` 中加入 `"plugin": [["@wxg-prc-cpg/opencode-weknora", { "baseUrl": "https://weknora.example.com", "apiKey": "sk-..." }]]`，Agent 就能对你的部署做段落检索、整篇阅读和带引用的问答。
+
 ## 🚀 快速开始
 
 ### 🛠 环境要求

--- a/README_JA.md
+++ b/README_JA.md
@@ -193,6 +193,9 @@ Feishu、GitLab、Tencent IMA、Notion、Yuqueなどの外部プラットフォ�
 - **`weknora_ask`** — WeKnora 自身が引用付きで作成した回答（RAG または ReAct パイプライン）
 - **`weknora_list_knowledge_bases`** — ナレッジベースの名前と id。エージェントが自分で検索範囲を絞れる
 
+## 📦 opencode プラグイン
+
+[**`@wxg-prc-cpg/opencode-weknora`**](https://www.npmjs.com/package/@wxg-prc-cpg/opencode-weknora) は公式の [opencode](https://opencode.ai) プラグインです（[ドキュメント](./packages/opencode-weknora/README.md)）。dsh-weknora から移植した同じ 4 つの読み取り専用ツールを提供します。opencode 自体のツールはワークスペースとインターネットのみを読みますが、このプラグインはナレッジベースを追加します。`opencode.json` に `"plugin": [["@wxg-prc-cpg/opencode-weknora", { "baseUrl": "https://weknora.example.com", "apiKey": "sk-..." }]]` を追加すると、エージェントがデプロイ先に対して段落検索・全文読み取り・引用付き質問応答を行えるようになります。
 
 ## 🚀 クイックスタート
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -203,6 +203,9 @@ Feishu, GitLab, Tencent IMA, Notion, Yuque 등 외부 플랫폼에서 지식 자
 - **`weknora_ask`** — WeKnora가 직접 작성한 인용 포함 답변(RAG 또는 ReAct 파이프라인)
 - **`weknora_list_knowledge_bases`** — 지식베이스 이름과 id로 에이전트가 검색 범위를 스스로 좁힘
 
+## 📦 opencode 플러그인
+
+[**`@wxg-prc-cpg/opencode-weknora`**](https://www.npmjs.com/package/@wxg-prc-cpg/opencode-weknora)는 공식 [opencode](https://opencode.ai) 플러그인입니다([문서](./packages/opencode-weknora/README.md)). dsh-weknora에서 포팅한 동일한 네 개의 읽기 전용 도구를 제공합니다. opencode 자체 도구는 워크스페이스와 인터넷만 읽지만, 이 플러그인은 지식베이스를 추가합니다. `opencode.json`에 `"plugin": [["@wxg-prc-cpg/opencode-weknora", { "baseUrl": "https://weknora.example.com", "apiKey": "sk-..." }]]`를 추가하면 에이전트가 배포 대상에 대해 구절 검색, 전체 문서 읽기, 인용 포함 질의응답을 수행할 수 있습니다.
 
 ## 🚀 시작하기
 

--- a/packages/opencode-weknora/.gitignore
+++ b/packages/opencode-weknora/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.log

--- a/packages/opencode-weknora/README.md
+++ b/packages/opencode-weknora/README.md
@@ -1,0 +1,119 @@
+# @wxg-prc-cpg/opencode-weknora
+
+[简体中文](./README_CN.md)
+
+[npm](https://www.npmjs.com/package/@wxg-prc-cpg/opencode-weknora)
+
+An [opencode](https://opencode.ai) plugin that gives the coding agent first-class access to a
+[WeKnora](https://github.com/Tencent/WeKnora) knowledge base: hybrid retrieval, full document reading, and WeKnora's
+own composed answers with citations.
+
+opencode ships no retrieval or knowledge-base capability of its own — its tools read the workspace and the internet.
+This plugin fills that gap with your organization's documents, ported from WeKnora's own
+[`dsh-weknora`](https://github.com/Tencent/WeKnora/tree/main/packages/dsh-weknora) (DeepSeek Harness plugin).
+
+## Install
+
+In your opencode config (`opencode.json`), add the plugin and point it at your deployment:
+
+```json
+{
+  "plugin": [
+    ["@wxg-prc-cpg/opencode-weknora", { "baseUrl": "https://weknora.example.com", "apiKey": "sk-..." }]
+  ]
+}
+```
+
+The quickest start is environment variables (options override them):
+
+```sh
+export WEKNORA_BASE_URL=https://weknora.example.com   # or http://localhost:8080
+export WEKNORA_API_KEY=sk-...                          # a WeKnora API key with `retrieve` (+ `chat` for ask)
+export WEKNORA_KNOWLEDGE_BASE_IDS=kb-123,kb-456        # optional default scope
+```
+
+Mounting two deployments side by side is two rows with two prefixes:
+
+```json
+{
+  "plugin": [
+    ["@wxg-prc-cpg/opencode-weknora", { "baseUrl": "https://kb.internal.example.com", "toolPrefix": "internal_kb" }],
+    ["@wxg-prc-cpg/opencode-weknora", { "baseUrl": "https://kb.public.example.com", "toolPrefix": "public_kb" }]
+  ]
+}
+```
+
+## Tools
+
+| Tool | WeKnora endpoint | What the model gets |
+|---|---|---|
+| `weknora_list_knowledge_bases` | `GET /knowledge-bases` | Knowledge base names and ids, to report what exists or to narrow a later search |
+| `weknora_search` | `POST /knowledge-search` + `GET /knowledge/search` | Ranked passages verbatim, each with a `knowledge_id`, score and chunk index, plus any document the query names |
+| `weknora_read_document` | `GET /chunks/:knowledge_id` + `GET /knowledge/:id` | One document's passages reassembled in order, led by its title and summary, with paging |
+| `weknora_ask` | `POST /sessions` + `POST /knowledge-chat/:id` or `POST /agent-chat/:id` | WeKnora's own answer, its citations, the server-side tools it used, and a resumable `session_id` |
+
+`weknora_search` is the workhorse: it returns the source text for the agent to reason over, which keeps the agent's own
+reasoning auditable. When `knowledgeBaseIds` is empty the plugin resolves every knowledge base the credential can see
+and uses all of them — knowledge bases are frequently named too poorly for the model to choose between.
+
+`weknora_ask` delegates the whole question to WeKnora's RAG pipeline. Reserve it for broad or synthesis questions
+spanning many documents — it runs another model server-side, so it is slow, and it returns a conclusion rather than the
+evidence behind it. With `agentId` set it sends the question to a WeKnora custom agent (ReAct pipeline) instead.
+
+## Permissions and data flow
+
+The plugin only reads. It never writes to WeKnora: no ingestion, no chunk edits, no deletion. A WeKnora API key scoped
+to `retrieve` is enough for three of the four tools; `weknora_ask` additionally needs `chat`, because it creates a
+session and streams an answer.
+
+The key is sent as `X-API-Key`. Set `tenantId` as well if you use a platform-scoped key, which needs `X-Tenant-ID` to
+select a workspace. Errors are reported with the HTTP status and WeKnora's own reason, never with the key.
+
+Passage content is clipped to `maxChunkChars` before it reaches the model, so one oversized document cannot eat the
+context window. The clip is reported (`truncated: true`) instead of silently hiding text.
+
+## Configuration reference
+
+| Field | Default | Notes |
+|---|---|---|
+| `baseUrl` | `http://localhost:8080/api/v1` | `/api/v1` is appended when missing |
+| `apiKey` | unset | `X-API-Key`; unset means an unauthenticated deployment |
+| `tenantId` | unset | `X-Tenant-ID`, required for platform-scoped keys |
+| `knowledgeBaseIds` | `[]` | Default scope when a call names none; empty means every knowledge base the credential can see |
+| `agentId` | unset | Sends `weknora_ask` to the ReAct pipeline |
+| `maxResults` | `8` | Also the ceiling for `max_results` and for cited references |
+| `maxChunkChars` | `1200` | Per-passage character budget |
+| `requestTimeoutMs` | `30000` | Retrieval and document reads |
+| `chatTimeoutMs` | `300000` | `weknora_ask`, which waits on WeKnora's own model calls |
+| `resourceUrls` | `public` | `public` returns directly loadable file URLs; `handle` keeps internal `resource://` refs |
+| `toolPrefix` | `weknora` | Tool-name prefix, `^[a-z][a-z0-9_]*$` |
+| `tools.*` | all `true` | Register fewer tools to spend fewer prompt tokens |
+
+Environment variables: `WEKNORA_BASE_URL`, `WEKNORA_API_KEY`, `WEKNORA_TENANT_ID`, `WEKNORA_KNOWLEDGE_BASE_IDS`,
+`WEKNORA_AGENT_ID`, `WEKNORA_RESOURCE_URLS`, `WEKNORA_TOOL_PREFIX`. Plugin options take precedence over the
+environment.
+
+## Development
+
+```sh
+npm install
+npm test          # build + unit and contract tests against the mock backend
+```
+
+The API contract is asserted from both sides: `test/contract.test.mjs` pins the exact WeKnora calls this plugin makes,
+and `contract/contract_test.go` (run from the repository root: `go test ./packages/opencode-weknora/contract/...`)
+checks the WeKnora server still accepts those request bodies and still serves the response fields the plugin reads.
+
+A live integration suite runs against a real deployment when given credentials:
+
+```sh
+WEKNORA_LIVE_URL=http://localhost:8080 \
+WEKNORA_LIVE_API_KEY=sk-... \
+WEKNORA_LIVE_ASK=1 \
+  node --test test/live.integration.test.mjs
+```
+
+## License
+
+MIT — as is [`dsh-weknora`](https://github.com/Tencent/WeKnora/tree/main/packages/dsh-weknora), whose client and
+tool design this plugin ports.

--- a/packages/opencode-weknora/README_CN.md
+++ b/packages/opencode-weknora/README_CN.md
@@ -1,0 +1,61 @@
+# @wxg-prc-cpg/opencode-weknora
+
+[English](./README.md)
+
+[npm](https://www.npmjs.com/package/@wxg-prc-cpg/opencode-weknora)
+
+一个 [opencode](https://opencode.ai) 插件：把 WeKnora 知识库能力（混合检索、整篇阅读、带引用的 RAG 问答）一等公民地接入编码智能体。
+
+opencode 自身没有知识库检索能力——它的工具只读工作区和互联网。本插件用你组织的文档补上这块，移植自 WeKnora 官方的 [`dsh-weknora`](https://github.com/Tencent/WeKnora/tree/main/packages/dsh-weknora)（DeepSeek Harness 插件）。
+
+## 安装
+
+在 opencode 配置（`opencode.json`）中添加插件并指向你的部署：
+
+```json
+{
+  "plugin": [
+    ["@wxg-prc-cpg/opencode-weknora", { "baseUrl": "https://weknora.example.com", "apiKey": "sk-..." }]
+  ]
+}
+```
+
+最快上手是环境变量（插件选项优先于环境变量）：
+
+```sh
+export WEKNORA_BASE_URL=https://weknora.example.com   # 或 http://localhost:8080
+export WEKNORA_API_KEY=sk-...                          # 需要 retrieve 权限的 WeKnora API key（ask 需再加 chat）
+export WEKNORA_KNOWLEDGE_BASE_IDS=kb-123,kb-456        # 可选的默认检索范围
+```
+
+## 工具
+
+| 工具 | WeKnora 端点 | 模型得到什么 |
+|---|---|---|
+| `weknora_list_knowledge_bases` | `GET /knowledge-bases` | 知识库名称与 id |
+| `weknora_search` | `POST /knowledge-search` + `GET /knowledge/search` | 按序排列的原文段落（含 knowledge_id、得分、chunk 序号），查询像标题时还会返回命名的文档 |
+| `weknora_read_document` | `GET /chunks/:knowledge_id` + `GET /knowledge/:id` | 整篇文档段落按序重组，首页带头部摘要，支持翻页 |
+| `weknora_ask` | `POST /sessions` + `POST /knowledge-chat/:id` / `agent-chat/:id` | WeKnora 自己组织的回答、引用、服务端用过的工具、可续问的 session_id |
+
+## 权限与数据流
+
+插件只读不写。`retrieve` 权限的 API key 足够前三个工具；`weknora_ask` 需要再加 `chat`。密钥通过 `X-API-Key` 发送，平台级 key 需配 `tenantId`。错误信息只含 HTTP 状态与 WeKnora 的原因，绝不回显密钥。段落内容按 `maxChunkChars` 裁剪并显式标注 `truncated`。
+
+## 配置参考
+
+字段与默认值与 dsh-weknora 完全一致，见 [English README](./README.md#configuration-reference)。
+
+环境变量：`WEKNORA_BASE_URL`、`WEKNORA_API_KEY`、`WEKNORA_TENANT_ID`、`WEKNORA_KNOWLEDGE_BASE_IDS`、`WEKNORA_AGENT_ID`、`WEKNORA_RESOURCE_URLS`、`WEKNORA_TOOL_PREFIX`。
+
+## 开发
+
+```sh
+npm install
+npm test   # 构建 + 针对模拟后端的单元与契约测试
+```
+
+API 契约由两侧共同固化：`test/contract.test.mjs` 锁定插件发出的 WeKnora 调用；`contract/contract_test.go`（在仓库根目录执行 `go test ./packages/opencode-weknora/contract/...`）校验 WeKnora 服务端仍接受这些请求体、仍返回插件读取的响应字段。
+
+## 许可
+
+MIT——同 [`dsh-weknora`](https://github.com/Tencent/WeKnora/tree/main/packages/dsh-weknora)，本插件移植了其客户端与工具设计。

--- a/packages/opencode-weknora/contract/contract_test.go
+++ b/packages/opencode-weknora/contract/contract_test.go
@@ -1,0 +1,245 @@
+// Package contract asserts that the WeKnora API surface the opencode-weknora plugin
+// speaks still exists on this server: the request bodies it sends must decode
+// into the real handler request structs with no unknown fields, and the response
+// fields it reads must still be produced by the real response types.
+//
+// The fixture is shared with the plugin's own JavaScript tests
+// (packages/opencode-weknora/test/contract.test.mjs), which assert that the plugin
+// still emits exactly these calls. Together the two sides catch a rename on
+// either side at CI time instead of inside a user's agent.
+package contract
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/handler/session"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+type contractCall struct {
+	Tool          string            `json:"tool"`
+	Method        string            `json:"method"`
+	Path          string            `json:"path"`
+	Query         map[string]string `json:"query"`
+	Body          json.RawMessage   `json:"body"`
+	GoRequestType *string           `json:"goRequestType"`
+}
+
+type contractFixture struct {
+	Calls               []contractCall      `json:"calls"`
+	ResponseFieldsRead  map[string][]string `json:"responseFieldsRead"`
+	StreamResponseTypes []string            `json:"streamResponseTypes"`
+}
+
+func loadFixture(t *testing.T) contractFixture {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "test", "fixtures", "api-contract.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var fixture contractFixture
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	if len(fixture.Calls) == 0 {
+		t.Fatal("fixture declares no calls")
+	}
+	return fixture
+}
+
+// newRequestTarget returns an empty instance of the handler request struct the
+// named call decodes into.
+func newRequestTarget(t *testing.T, name string) any {
+	t.Helper()
+	switch name {
+	case "session.SearchKnowledgeRequest":
+		return &session.SearchKnowledgeRequest{}
+	case "session.CreateSessionRequest":
+		return &session.CreateSessionRequest{}
+	case "session.CreateKnowledgeQARequest":
+		return &session.CreateKnowledgeQARequest{}
+	case "types.Pagination":
+		return &types.Pagination{}
+	default:
+		t.Fatalf("fixture names an unknown Go request type %q", name)
+		return nil
+	}
+}
+
+// TestPluginRequestBodiesDecodeIntoHandlerTypes: every body the plugin sends is
+// accepted by the struct its handler binds, with no field the server would drop.
+func TestPluginRequestBodiesDecodeIntoHandlerTypes(t *testing.T) {
+	fixture := loadFixture(t)
+	decoded := 0
+	for _, call := range fixture.Calls {
+		if call.GoRequestType == nil || len(call.Body) == 0 || string(call.Body) == "null" {
+			continue
+		}
+		target := newRequestTarget(t, *call.GoRequestType)
+		decoder := json.NewDecoder(bytes.NewReader(call.Body))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(target); err != nil {
+			t.Errorf("%s %s (%s) body rejected by %s: %v",
+				call.Method, call.Path, call.Tool, *call.GoRequestType, err)
+			continue
+		}
+		decoded++
+	}
+	if decoded == 0 {
+		t.Fatal("no request body was checked; the fixture lost its bodies")
+	}
+}
+
+// TestRetrievalRequestCarriesRequiredFields: the search body binds the fields
+// the handler validates, so the plugin cannot send a request the handler rejects
+// with 400 at runtime.
+func TestRetrievalRequestCarriesRequiredFields(t *testing.T) {
+	fixture := loadFixture(t)
+	for _, call := range fixture.Calls {
+		if call.Path != "/api/v1/knowledge-search" {
+			continue
+		}
+		var request session.SearchKnowledgeRequest
+		if err := json.Unmarshal(call.Body, &request); err != nil {
+			t.Fatalf("decode search body: %v", err)
+		}
+		if request.Query == "" {
+			t.Error("the plugin must always send a non-empty query; the handler rejects an empty one")
+		}
+		if len(request.KnowledgeBaseIDs) == 0 && len(request.KnowledgeIDs) == 0 {
+			t.Error("the plugin must scope retrieval; the handler rejects a request with no target")
+		}
+		return
+	}
+	t.Fatal("the fixture no longer covers /knowledge-search")
+}
+
+// TestChatRequestSelectsThePipeline: the agent route must carry both the agent id
+// and the agent-enabled flag, since the RAG and ReAct pipelines are selected by
+// the same struct.
+func TestChatRequestSelectsThePipeline(t *testing.T) {
+	fixture := loadFixture(t)
+	var sawRAG, sawAgent bool
+	for _, call := range fixture.Calls {
+		if call.GoRequestType == nil || *call.GoRequestType != "session.CreateKnowledgeQARequest" {
+			continue
+		}
+		var request session.CreateKnowledgeQARequest
+		if err := json.Unmarshal(call.Body, &request); err != nil {
+			t.Fatalf("decode chat body: %v", err)
+		}
+		if request.Query == "" {
+			t.Errorf("%s must send a query", call.Path)
+		}
+		if request.Channel != "api" {
+			t.Errorf("%s must declare channel \"api\", got %q", call.Path, request.Channel)
+		}
+		switch {
+		case request.AgentID != "":
+			sawAgent = true
+			if !request.AgentEnabled {
+				t.Errorf("%s names an agent but leaves agent_enabled false", call.Path)
+			}
+		default:
+			sawRAG = true
+		}
+	}
+	if !sawRAG || !sawAgent {
+		t.Fatal("the fixture must cover both the RAG and the agent chat route")
+	}
+}
+
+// TestResponseFieldsThePluginReadsStillExist: marshal the real response types and
+// confirm every JSON key the plugin depends on is present, so a renamed or
+// dropped json tag fails here.
+func TestResponseFieldsThePluginReadsStillExist(t *testing.T) {
+	fixture := loadFixture(t)
+	samples := map[string]any{
+		"types.SearchResult": types.SearchResult{
+			ID:                "chunk-1",
+			Content:           "默认的 vector_threshold 是 0.5",
+			KnowledgeID:       "doc-1",
+			ChunkIndex:        3,
+			KnowledgeTitle:    "检索流程.md",
+			KnowledgeFilename: "检索流程.md",
+			Score:             0.83,
+		},
+		"types.Knowledge": types.Knowledge{
+			ID:                "doc-1",
+			Title:             "检索流程.md",
+			FileName:          "检索流程.md",
+			Description:       "讲解 WeKnora 混合检索的召回与阈值。",
+			KnowledgeBaseID:   "kb-product",
+			KnowledgeBaseName: "Product docs",
+		},
+		"types.Chunk": types.Chunk{
+			ID:          "chunk-1",
+			Content:     "默认的 vector_threshold 是 0.5",
+			ChunkIndex:  3,
+			KnowledgeID: "doc-1",
+		},
+		"types.StreamResponse": types.StreamResponse{
+			ID:                  "event-1",
+			ResponseType:        types.ResponseTypeAnswer,
+			Content:             "答案",
+			SessionID:           "session-1",
+			KnowledgeReferences: types.References{{ID: "chunk-1"}},
+			ToolCalls:           []types.LLMToolCall{{ID: "call-1", Type: "function"}},
+		},
+		"types.LLMToolCall": types.LLMToolCall{ID: "call-1", Type: "function"},
+		"types.FunctionCall": types.FunctionCall{
+			Name:      "knowledge_search",
+			Arguments: "{}",
+		},
+	}
+
+	for typeName, fields := range fixture.ResponseFieldsRead {
+		sample, ok := samples[typeName]
+		if !ok {
+			t.Errorf("fixture names %s but this test has no sample for it", typeName)
+			continue
+		}
+		raw, err := json.Marshal(sample)
+		if err != nil {
+			t.Errorf("marshal %s: %v", typeName, err)
+			continue
+		}
+		var asMap map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &asMap); err != nil {
+			t.Errorf("re-decode %s: %v", typeName, err)
+			continue
+		}
+		for _, field := range fields {
+			if _, ok := asMap[field]; !ok {
+				t.Errorf("%s no longer serializes %q, which opencode-weknora reads", typeName, field)
+			}
+		}
+	}
+}
+
+// TestStreamResponseTypesThePluginHandlesStillExist: the SSE event names the
+// plugin switches on must still be the server's constants.
+func TestStreamResponseTypesThePluginHandlesStillExist(t *testing.T) {
+	fixture := loadFixture(t)
+	known := map[string]types.ResponseType{
+		"answer":     types.ResponseTypeAnswer,
+		"references": types.ResponseTypeReferences,
+		"tool_call":  types.ResponseTypeToolCall,
+		"error":      types.ResponseTypeError,
+		"complete":   types.ResponseTypeComplete,
+	}
+	for _, name := range fixture.StreamResponseTypes {
+		constant, ok := known[name]
+		if !ok {
+			t.Errorf("fixture handles stream event %q, which this test does not map to a server constant", name)
+			continue
+		}
+		if string(constant) != name {
+			t.Errorf("stream event %q is now spelled %q on the server", name, string(constant))
+		}
+	}
+}

--- a/packages/opencode-weknora/package-lock.json
+++ b/packages/opencode-weknora/package-lock.json
@@ -1,0 +1,476 @@
+{
+  "name": "@wxg-prc-cpg/opencode-weknora",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@wxg-prc-cpg/opencode-weknora",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@opencode-ai/plugin": "*",
+        "@types/node": "^22.13.0",
+        "typescript": "^5.7.3"
+      },
+      "engines": {
+        "node": ">=20.11"
+      },
+      "peerDependencies": {
+        "@opencode-ai/plugin": ">=0.1.0"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.29.tgz",
+      "integrity": "sha512-IhF83EU4I/ASgWwvm0FIh1O3a8ZVuCLqPrCbmSHdSYq7GHxIYe773i6dHqcbrzCzvlG/lP2H+dyTQ+xPAwFpbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@opencode-ai/sdk": "1.18.29",
+        "effect": "4.0.0-beta.83",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.4.5",
+        "@opentui/keymap": ">=0.4.5",
+        "@opentui/solid": ">=0.4.5"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.29.tgz",
+      "integrity": "sha512-4CS+FoLPkymTlcga8jxivGDDb2AbWMIIl3b8+myoe2wtv/1ANYCErslgz1xy5hTVHymWE6CtVNKzRuPU0ED57A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.83",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.83.tgz",
+      "integrity": "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.8.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^7.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^2.0.1",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^14.0.0",
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ini": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/msgpackr": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.1.0.tgz",
+      "integrity": "sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz",
+      "integrity": "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
+      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/opencode-weknora/package.json
+++ b/packages/opencode-weknora/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@wxg-prc-cpg/opencode-weknora",
+  "version": "0.1.0",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "description": "WeKnora knowledge retrieval tools for opencode: semantic search, document reading and RAG answers over your own knowledge bases.",
+  "keywords": [
+    "opencode",
+    "opencode-plugin",
+    "weknora",
+    "rag",
+    "retrieval",
+    "knowledge-base"
+  ],
+  "license": "MIT",
+  "author": "WeKnora",
+  "homepage": "https://github.com/Tencent/WeKnora/tree/main/packages/opencode-weknora",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Tencent/WeKnora.git",
+    "directory": "packages/opencode-weknora"
+  },
+  "bugs": {
+    "url": "https://github.com/Tencent/WeKnora/issues"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "README_CN.md"
+  ],
+  "engines": {
+    "node": ">=20.11"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "prepare": "npm run build",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "npm run build && node --test \"test/*.test.mjs\""
+  },
+  "peerDependencies": {
+    "@opencode-ai/plugin": ">=0.1.0"
+  },
+  "devDependencies": {
+    "@opencode-ai/plugin": "*",
+    "@types/node": "^22.13.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/opencode-weknora/src/client.ts
+++ b/packages/opencode-weknora/src/client.ts
@@ -1,0 +1,433 @@
+/** Minimal WeKnora REST client: JSON endpoints plus the SSE chat streams. */
+
+import type { ResolvedConfig } from './config.ts'
+
+/** One retrieval hit, as returned by WeKnora's `SearchResult`. */
+export interface SearchResult {
+  id?: string
+  content?: string
+  knowledge_id?: string
+  chunk_index?: number
+  knowledge_title?: string
+  knowledge_filename?: string
+  score?: number
+  match_type?: number | string
+  [key: string]: unknown
+}
+
+/** A knowledge base as listed by `GET /knowledge-bases`. */
+export interface KnowledgeBaseSummary {
+  id?: string
+  name?: string
+  description?: string
+  [key: string]: unknown
+}
+
+/** One stored chunk as returned by `GET /chunks/:knowledge_id`. */
+export interface ChunkRecord {
+  id?: string
+  content?: string
+  chunk_index?: number
+  knowledge_id?: string
+  [key: string]: unknown
+}
+
+/** A document as returned by the by-name search and by `GET /knowledge/:id`. */
+export interface DocumentRecord {
+  id?: string
+  title?: string
+  file_name?: string
+  file_type?: string
+  description?: string
+  knowledge_base_id?: string
+  knowledge_base_name?: string
+  [key: string]: unknown
+}
+
+/** A page of chunks plus its pagination envelope. */
+export interface ChunkPage {
+  chunks: ChunkRecord[]
+  total: number
+  page: number
+  pageSize: number
+}
+
+/** The assembled outcome of one streamed answer. */
+export interface StreamedAnswer {
+  answer: string
+  references: SearchResult[]
+  sessionId: string
+  toolCalls: string[]
+}
+
+/** Raised for any non-2xx response or transport failure, with the key redacted. */
+export class WeknoraApiError extends Error {
+  readonly status: number | undefined
+
+  constructor(message: string, status?: number) {
+    super(message)
+    this.name = 'WeknoraApiError'
+    this.status = status
+  }
+}
+
+interface Envelope<T> {
+  success?: boolean
+  data?: T
+  error?: unknown
+  message?: string
+  total?: number
+  page?: number
+  page_size?: number
+}
+
+/** Trim a response body for an error message without leaking a whole page. */
+function snippet(body: string): string {
+  const collapsed = body.replace(/\s+/g, ' ').trim()
+  return collapsed.length > 300 ? `${collapsed.slice(0, 300)}…` : collapsed
+}
+
+/** Extract a human-readable reason from WeKnora's error envelope. */
+function reasonOf(body: string): string {
+  try {
+    const parsed = JSON.parse(body) as { error?: { message?: string } | string, message?: string }
+    if (typeof parsed.error === 'string') return parsed.error
+    if (parsed.error?.message !== undefined) return parsed.error.message
+    if (parsed.message !== undefined) return parsed.message
+  } catch {
+    // Fall through to the raw snippet: a proxy may answer with HTML.
+  }
+  return snippet(body)
+}
+
+/**
+ * Combine the caller's cancellation with this call's deadline. The tool body
+ * must abort when the harness aborts, and a hung backend must not hold a turn
+ * open forever.
+ */
+function deadline(signal: AbortSignal, timeoutMs: number): AbortSignal {
+  return AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)])
+}
+
+export class WeknoraClient {
+  /**
+   * A knowledge-base-restricted API key rejects `resource_urls=public` with
+   * 403. After the first such refusal this client stays on handle mode so
+   * later calls do not pay the same round trip.
+   */
+  private publicModeBlocked = false
+
+  constructor(private readonly config: ResolvedConfig) {}
+
+  private headers(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    }
+    if (this.config.apiKey !== undefined) headers['X-API-Key'] = this.config.apiKey
+    if (this.config.tenantId !== undefined) headers['X-Tenant-ID'] = this.config.tenantId
+    return headers
+  }
+
+  private resourceMode(): 'handle' | 'public' {
+    return this.config.resourceUrls === 'public' && !this.publicModeBlocked ? 'public' : 'handle'
+  }
+
+  private url(path: string, query?: Record<string, string | number | undefined>): string {
+    const url = new URL(`${this.config.baseUrl}${path}`)
+    for (const [key, value] of Object.entries(query ?? {})) {
+      if (value !== undefined) url.searchParams.set(key, String(value))
+    }
+    if (this.resourceMode() === 'public') url.searchParams.set('resource_urls', 'public')
+    return url.toString()
+  }
+
+  private isPublicModeForbidden(error: unknown): boolean {
+    return error instanceof WeknoraApiError
+      && this.config.resourceUrls === 'public'
+      && !this.publicModeBlocked
+      && error.status === 403
+      && error.message.includes('resource_urls=public')
+  }
+
+  private async fetchJson<T>(
+    path: string,
+    init: { method: 'GET' | 'POST', body?: unknown, query?: Record<string, string | number | undefined> },
+    signal: AbortSignal,
+  ): Promise<Envelope<T>> {
+    try {
+      return await this.fetchJsonOnce(path, init, signal)
+    } catch (error) {
+      if (!this.isPublicModeForbidden(error)) throw error
+      this.publicModeBlocked = true
+      return await this.fetchJsonOnce(path, init, signal)
+    }
+  }
+
+  private async fetchJsonOnce<T>(
+    path: string,
+    init: { method: 'GET' | 'POST', body?: unknown, query?: Record<string, string | number | undefined> },
+    signal: AbortSignal,
+  ): Promise<Envelope<T>> {
+    const url = this.url(path, init.query)
+    let response: Response
+    try {
+      response = await fetch(url, {
+        method: init.method,
+        headers: this.headers(),
+        ...init.body === undefined ? {} : { body: JSON.stringify(init.body) },
+        signal: deadline(signal, this.config.requestTimeoutMs),
+      })
+    } catch (cause) {
+      throw new WeknoraApiError(`${init.method} ${path} failed: ${describeTransportFailure(cause, signal)}`)
+    }
+    const text = await response.text()
+    if (!response.ok) {
+      throw new WeknoraApiError(`${init.method} ${path} failed with HTTP ${response.status}: ${reasonOf(text)}`, response.status)
+    }
+    try {
+      return JSON.parse(text) as Envelope<T>
+    } catch {
+      throw new WeknoraApiError(`${init.method} ${path} returned a non-JSON body: ${snippet(text)}`, response.status)
+    }
+  }
+
+  /** List the knowledge bases this credential can retrieve from. */
+  async listKnowledgeBases(signal: AbortSignal): Promise<KnowledgeBaseSummary[]> {
+    const envelope = await this.fetchJson<KnowledgeBaseSummary[]>('/knowledge-bases', { method: 'GET' }, signal)
+    return Array.isArray(envelope.data) ? envelope.data : []
+  }
+
+  /** Hybrid (vector + keyword) retrieval across one or more knowledge bases. */
+  async search(
+    input: { query: string, knowledgeBaseIds: string[], knowledgeIds: string[] },
+    signal: AbortSignal,
+  ): Promise<SearchResult[]> {
+    const envelope = await this.fetchJson<SearchResult[]>('/knowledge-search', {
+      method: 'POST',
+      body: {
+        query: input.query,
+        ...input.knowledgeBaseIds.length > 0 ? { knowledge_base_ids: input.knowledgeBaseIds } : {},
+        ...input.knowledgeIds.length > 0 ? { knowledge_ids: input.knowledgeIds } : {},
+      },
+    }, signal)
+    return Array.isArray(envelope.data) ? envelope.data : []
+  }
+
+  /**
+   * Find documents by title or filename. Unlike `search` this spans every
+   * knowledge base the credential can see and needs no scope, so it is what
+   * answers "where is the document called X".
+   */
+  async findDocuments(
+    input: { keyword: string, limit: number },
+    signal: AbortSignal,
+  ): Promise<DocumentRecord[]> {
+    const envelope = await this.fetchJson<DocumentRecord[]>('/knowledge/search', {
+      method: 'GET',
+      query: { keyword: input.keyword, limit: input.limit },
+    }, signal)
+    return Array.isArray(envelope.data) ? envelope.data : []
+  }
+
+  /** A document's metadata, including the generated summary WeKnora stores as `description`. */
+  async getDocument(knowledgeId: string, signal: AbortSignal): Promise<DocumentRecord> {
+    const envelope = await this.fetchJson<DocumentRecord>(
+      `/knowledge/${encodeURIComponent(knowledgeId)}`,
+      { method: 'GET' },
+      signal,
+    )
+    return envelope.data ?? {}
+  }
+
+  /** One page of a document's stored chunks, in storage order. */
+  async listChunks(
+    input: { knowledgeId: string, page: number, pageSize: number },
+    signal: AbortSignal,
+  ): Promise<ChunkPage> {
+    const envelope = await this.fetchJson<ChunkRecord[]>(`/chunks/${encodeURIComponent(input.knowledgeId)}`, {
+      method: 'GET',
+      query: { page: input.page, page_size: input.pageSize },
+    }, signal)
+    const chunks = Array.isArray(envelope.data) ? envelope.data : []
+    return {
+      chunks,
+      total: typeof envelope.total === 'number' ? envelope.total : chunks.length,
+      page: typeof envelope.page === 'number' ? envelope.page : input.page,
+      pageSize: typeof envelope.page_size === 'number' ? envelope.page_size : input.pageSize,
+    }
+  }
+
+  /** Create a conversation container to hold one or more asked questions. */
+  async createSession(title: string, signal: AbortSignal): Promise<string> {
+    const envelope = await this.fetchJson<{ id?: string }>('/sessions', {
+      method: 'POST',
+      body: { title },
+    }, signal)
+    const id = envelope.data?.id
+    if (typeof id !== 'string' || id === '') {
+      throw new WeknoraApiError('POST /sessions returned no session id')
+    }
+    return id
+  }
+
+  /**
+   * Ask a question and assemble the streamed answer. `agentId` selects the
+   * ReAct pipeline (`/agent-chat`); without it the RAG pipeline answers
+   * (`/knowledge-chat`).
+   */
+  async ask(
+    input: {
+      sessionId: string
+      query: string
+      knowledgeBaseIds: string[]
+      agentId: string | undefined
+      webSearch: boolean
+    },
+    signal: AbortSignal,
+  ): Promise<StreamedAnswer> {
+    const route = input.agentId === undefined ? 'knowledge-chat' : 'agent-chat'
+    const path = `/${route}/${encodeURIComponent(input.sessionId)}`
+    const body = {
+      query: input.query,
+      channel: 'api',
+      ...input.knowledgeBaseIds.length > 0 ? { knowledge_base_ids: input.knowledgeBaseIds } : {},
+      ...input.agentId === undefined ? {} : { agent_id: input.agentId, agent_enabled: true },
+      ...input.webSearch ? { web_search_enabled: true } : {},
+    }
+    const open = async (): Promise<Response> => {
+      const combined = deadline(signal, this.config.chatTimeoutMs)
+      try {
+        return await fetch(this.url(path), {
+          method: 'POST',
+          headers: { ...this.headers(), Accept: 'text/event-stream' },
+          body: JSON.stringify(body),
+          signal: combined,
+        })
+      } catch (cause) {
+        throw new WeknoraApiError(`POST ${path} failed: ${describeTransportFailure(cause, signal)}`)
+      }
+    }
+    let response = await open()
+    if (!response.ok) {
+      const text = await response.text()
+      const error = new WeknoraApiError(`POST ${path} failed with HTTP ${response.status}: ${reasonOf(text)}`, response.status)
+      if (!this.isPublicModeForbidden(error)) throw error
+      this.publicModeBlocked = true
+      response = await open()
+    }
+    if (!response.ok) {
+      const text = await response.text()
+      throw new WeknoraApiError(`POST ${path} failed with HTTP ${response.status}: ${reasonOf(text)}`, response.status)
+    }
+    if (response.body === null) {
+      throw new WeknoraApiError(`POST ${path} returned no response body`)
+    }
+    return await assembleStream(response.body, input.sessionId, path, signal)
+  }
+}
+
+/** Turn an aborted or refused fetch into a message that names the real cause. */
+function describeTransportFailure(cause: unknown, callerSignal: AbortSignal): string {
+  if (cause instanceof Error && cause.name === 'AbortError') {
+    return callerSignal.aborted ? 'the call was cancelled' : 'the request timed out'
+  }
+  if (cause instanceof Error && cause.name === 'TimeoutError') return 'the request timed out'
+  return cause instanceof Error ? cause.message : String(cause)
+}
+
+/** One decoded `data:` payload of the WeKnora stream. */
+interface StreamEvent {
+  response_type?: string
+  content?: string
+  knowledge_references?: SearchResult[]
+  session_id?: string
+  tool_calls?: { function?: { name?: string }, name?: string }[]
+}
+
+/**
+ * Consume WeKnora's `text/event-stream` and assemble the parts a tool result
+ * needs: the answer text, its citations, and the tool names the agent used.
+ * Server-side `error` events become a thrown failure so the model is never
+ * handed a silently empty answer.
+ */
+async function assembleStream(
+  body: ReadableStream<Uint8Array>,
+  sessionId: string,
+  path: string,
+  callerSignal: AbortSignal,
+): Promise<StreamedAnswer> {
+  const decoder = new TextDecoder()
+  const reader = body.getReader()
+  const answer: string[] = []
+  const toolCalls: string[] = []
+  let references: SearchResult[] = []
+  let resolvedSessionId = sessionId
+  let buffer = ''
+  let completed = false
+
+  const consumeLine = (line: string): void => {
+    if (!line.startsWith('data:')) return
+    const payload = line.slice(5).trim()
+    if (payload === '' || payload === '[DONE]') return
+    let event: StreamEvent
+    try {
+      event = JSON.parse(payload) as StreamEvent
+    } catch {
+      return
+    }
+    if (typeof event.session_id === 'string' && event.session_id !== '') resolvedSessionId = event.session_id
+    switch (event.response_type) {
+      case 'answer':
+        if (typeof event.content === 'string') answer.push(event.content)
+        break
+      case 'references':
+        if (Array.isArray(event.knowledge_references)) references = event.knowledge_references
+        break
+      case 'tool_call':
+        for (const call of event.tool_calls ?? []) {
+          const name = call.function?.name ?? call.name
+          if (typeof name === 'string' && name !== '' && !toolCalls.includes(name)) toolCalls.push(name)
+        }
+        break
+      case 'error':
+        throw new WeknoraApiError(`POST ${path} streamed an error: ${event.content ?? 'unknown error'}`)
+      case 'complete':
+        completed = true
+        break
+      default:
+        break
+    }
+  }
+
+  try {
+    while (!completed) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      let newline = buffer.indexOf('\n')
+      while (newline >= 0) {
+        consumeLine(buffer.slice(0, newline).replace(/\r$/, ''))
+        buffer = buffer.slice(newline + 1)
+        if (completed) break
+        newline = buffer.indexOf('\n')
+      }
+    }
+    if (!completed && buffer !== '') consumeLine(buffer.replace(/\r$/, ''))
+  } catch (cause) {
+    if (cause instanceof WeknoraApiError) throw cause
+    throw new WeknoraApiError(`POST ${path} stream failed: ${describeTransportFailure(cause, callerSignal)}`)
+  } finally {
+    await reader.cancel().catch(() => undefined)
+  }
+
+  // WeKnora ends every answer with a `complete` event. Without it the stream was
+  // cut short, and handing the model the partial text would present a truncated
+  // answer as a whole one.
+  if (!completed) {
+    throw new WeknoraApiError(`POST ${path} ended before WeKnora completed the answer; `
+      + `${answer.join('').length} character(s) had streamed`)
+  }
+
+  return { answer: answer.join(''), references, sessionId: resolvedSessionId, toolCalls }
+}

--- a/packages/opencode-weknora/src/config.ts
+++ b/packages/opencode-weknora/src/config.ts
@@ -1,0 +1,195 @@
+/** Plugin configuration: shape, defaults, and load-time validation.
+ *
+ * Mirrors the configuration layer of `dsh-weknora` (WeKnora's DeepSeek Harness
+ * plugin): the same fields, defaults and validation, so deployments can run
+ * both agents against one set of environment variables.
+ */
+
+/** Which tools the plugin registers. Omitted entries keep their default. */
+export interface ToolToggles {
+  listKnowledgeBases?: boolean
+  search?: boolean
+  readDocument?: boolean
+  ask?: boolean
+}
+
+/** User-supplied configuration, as written in the opencode plugin options. */
+export interface Config {
+  /** WeKnora API root, with or without the `/api/v1` suffix. */
+  baseUrl?: string
+  /** Tenant or platform API key, sent as `X-API-Key`. */
+  apiKey?: string
+  /** Workspace id, required only for platform-scoped API keys (`X-Tenant-ID`). */
+  tenantId?: string
+  /** Default knowledge-base scope when a call names none. */
+  knowledgeBaseIds?: string[]
+  /** Default custom agent for `weknora_ask`; omitted uses the RAG pipeline. */
+  agentId?: string
+  /** Default and maximum number of chunks a search returns. */
+  maxResults?: number
+  /** Per-chunk character budget before the plugin truncates content. */
+  maxChunkChars?: number
+  /** Timeout for non-streaming requests. */
+  requestTimeoutMs?: number
+  /** Timeout for a streamed answer, which includes model and tool time. */
+  chatTimeoutMs?: number
+  /**
+   * `public` asks WeKnora for directly loadable file URLs in answers and
+   * citations. `handle` keeps the internal `resource://` references.
+   */
+  resourceUrls?: 'handle' | 'public'
+  /** Tool-name prefix, so two instances can serve two deployments. */
+  toolPrefix?: string
+  /** Per-tool registration switches. */
+  tools?: ToolToggles
+}
+
+/** Configuration after defaults and validation. */
+export interface ResolvedConfig {
+  baseUrl: string
+  apiKey: string | undefined
+  tenantId: string | undefined
+  knowledgeBaseIds: string[]
+  agentId: string | undefined
+  maxResults: number
+  maxChunkChars: number
+  requestTimeoutMs: number
+  chatTimeoutMs: number
+  resourceUrls: 'handle' | 'public'
+  toolPrefix: string
+  tools: Required<ToolToggles>
+}
+
+const DEFAULTS = {
+  baseUrl: 'http://localhost:8080/api/v1',
+  maxResults: 8,
+  maxChunkChars: 1200,
+  requestTimeoutMs: 30_000,
+  chatTimeoutMs: 300_000,
+  resourceUrls: 'public',
+  toolPrefix: 'weknora',
+} as const
+
+/** Thrown when a plugin row configures this plugin in a way it cannot serve. */
+export class ConfigError extends Error {
+  constructor(violations: string[]) {
+    super(`opencode-weknora configuration is invalid:\n  - ${violations.join('\n  - ')}`)
+    this.name = 'ConfigError'
+  }
+}
+
+const API_ROOT = /\/api\/v\d+$/
+const TOOL_PREFIX = /^[a-z][a-z0-9_]*$/
+
+/** Append the API root when a bare deployment URL was given. */
+export function normalizeBaseUrl(raw: string): string {
+  const trimmed = raw.trim().replace(/\/+$/, '')
+  if (trimmed === '') return DEFAULTS.baseUrl
+  return API_ROOT.test(trimmed) ? trimmed : `${trimmed}/api/v1`
+}
+
+function positiveInt(value: unknown, field: string, violations: string[]): number | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0 || Math.floor(value) !== value) {
+    violations.push(`${field} must be a positive integer`)
+    return undefined
+  }
+  return value
+}
+
+function stringList(value: unknown, field: string, violations: string[]): string[] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value) || !value.every(entry => typeof entry === 'string' && entry.trim() !== '')) {
+    violations.push(`${field} must be an array of non-empty strings`)
+    return undefined
+  }
+  return value.map(entry => entry.trim())
+}
+
+function optionalString(value: unknown, field: string, violations: string[]): string | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'string' || value.trim() === '') {
+    violations.push(`${field} must be a non-empty string`)
+    return undefined
+  }
+  return value.trim()
+}
+
+function toggle(value: unknown, field: string, fallback: boolean, violations: string[]): boolean {
+  if (value === undefined) return fallback
+  if (typeof value !== 'boolean') {
+    violations.push(`tools.${field} must be a boolean`)
+    return fallback
+  }
+  return value
+}
+
+/** Validate a user-supplied config and fill in the defaults. */
+export function resolveConfig(raw: Config | undefined): ResolvedConfig {
+  const violations: string[] = []
+  const source = raw ?? {}
+  const baseUrlRaw = optionalString(source.baseUrl, 'baseUrl', violations)
+  const apiKey = optionalString(source.apiKey, 'apiKey', violations)
+  const tenantId = optionalString(source.tenantId, 'tenantId', violations)
+  const knowledgeBaseIds = stringList(source.knowledgeBaseIds, 'knowledgeBaseIds', violations)
+  const agentId = optionalString(source.agentId, 'agentId', violations)
+  const maxResults = positiveInt(source.maxResults, 'maxResults', violations)
+  const maxChunkChars = positiveInt(source.maxChunkChars, 'maxChunkChars', violations)
+  const requestTimeoutMs = positiveInt(source.requestTimeoutMs, 'requestTimeoutMs', violations)
+  const chatTimeoutMs = positiveInt(source.chatTimeoutMs, 'chatTimeoutMs', violations)
+  const toolPrefix = optionalString(source.toolPrefix, 'toolPrefix', violations)
+  if (toolPrefix !== undefined && !TOOL_PREFIX.test(toolPrefix)) {
+    violations.push('toolPrefix must match ^[a-z][a-z0-9_]*$')
+  }
+  let resourceUrls: 'handle' | 'public' | undefined
+  if (source.resourceUrls !== undefined) {
+    if (source.resourceUrls === 'handle' || source.resourceUrls === 'public') {
+      resourceUrls = source.resourceUrls
+    } else {
+      violations.push("resourceUrls must be 'public' or 'handle'")
+    }
+  }
+  const tools = source.tools ?? {}
+  const toolToggles = {
+    listKnowledgeBases: toggle(tools.listKnowledgeBases, 'listKnowledgeBases', true, violations),
+    search: toggle(tools.search, 'search', true, violations),
+    readDocument: toggle(tools.readDocument, 'readDocument', true, violations),
+    ask: toggle(tools.ask, 'ask', true, violations),
+  }
+  if (violations.length > 0) throw new ConfigError(violations)
+  return {
+    baseUrl: normalizeBaseUrl(baseUrlRaw ?? DEFAULTS.baseUrl),
+    apiKey,
+    tenantId,
+    knowledgeBaseIds: knowledgeBaseIds ?? [],
+    agentId,
+    maxResults: maxResults ?? DEFAULTS.maxResults,
+    maxChunkChars: maxChunkChars ?? DEFAULTS.maxChunkChars,
+    requestTimeoutMs: requestTimeoutMs ?? DEFAULTS.requestTimeoutMs,
+    chatTimeoutMs: chatTimeoutMs ?? DEFAULTS.chatTimeoutMs,
+    resourceUrls: resourceUrls ?? DEFAULTS.resourceUrls,
+    toolPrefix: toolPrefix ?? DEFAULTS.toolPrefix,
+    tools: toolToggles,
+  }
+}
+
+/**
+ * Read the `WEKNORA_*` environment variables. opencode plugin options take
+ * precedence (they are merged over this), so one environment can serve many
+ * agents while a single project overrides just what differs.
+ */
+export function configFromEnv(env: Record<string, string | undefined> = process.env): Config {
+  const config: Config = {}
+  if (env.WEKNORA_BASE_URL !== undefined) config.baseUrl = env.WEKNORA_BASE_URL
+  if (env.WEKNORA_API_KEY !== undefined) config.apiKey = env.WEKNORA_API_KEY
+  if (env.WEKNORA_TENANT_ID !== undefined) config.tenantId = env.WEKNORA_TENANT_ID
+  if (env.WEKNORA_AGENT_ID !== undefined) config.agentId = env.WEKNORA_AGENT_ID
+  if (env.WEKNORA_TOOL_PREFIX !== undefined) config.toolPrefix = env.WEKNORA_TOOL_PREFIX
+  if (env.WEKNORA_KNOWLEDGE_BASE_IDS !== undefined) {
+    config.knowledgeBaseIds = env.WEKNORA_KNOWLEDGE_BASE_IDS.split(',').map(entry => entry.trim()).filter(entry => entry !== '')
+  }
+  if (env.WEKNORA_RESOURCE_URLS === 'handle' || env.WEKNORA_RESOURCE_URLS === 'public') {
+    config.resourceUrls = env.WEKNORA_RESOURCE_URLS
+  }
+  return config
+}

--- a/packages/opencode-weknora/src/index.ts
+++ b/packages/opencode-weknora/src/index.ts
@@ -1,0 +1,57 @@
+/**
+ * opencode-weknora: an opencode plugin that gives the agent retrieval,
+ * document reading and composed answers from a WeKnora knowledge base.
+ *
+ * Ported from WeKnora's `dsh-weknora` (DeepSeek Harness plugin); see
+ * https://github.com/Tencent/WeKnora/tree/main/packages/dsh-weknora
+ *
+ * This module exports ONLY the plugin: opencode's plugin loader treats every
+ * function export of the entry module as a plugin and calls it, so the
+ * library surface (client, config, tools) stays in sibling modules that are
+ * not re-exported here.
+ * @module @wxg-prc-cpg/opencode-weknora
+ */
+
+import type { Plugin } from '@opencode-ai/plugin'
+
+import { WeknoraClient } from './client.ts'
+import { configFromEnv, resolveConfig, type Config } from './config.ts'
+import { createTools } from './tools.ts'
+
+export type { Config } from './config.ts'
+
+/**
+ * Register the configured tools.
+ *
+ * Configuration precedence: opencode plugin options over the `WEKNORA_*`
+ * environment variables over the defaults — so one environment serves many
+ * agents while a single project overrides just what differs:
+ *
+ * ```json
+ * { "plugin": [["opencode-weknora", { "baseUrl": "https://weknora.example.com", "knowledgeBaseIds": ["kb-docs"] }]] }
+ * ```
+ *
+ * The merged configuration is validated here so a typo fails the plugin load
+ * with a message naming every violation, rather than failing inside the first
+ * tool call.
+ */
+export const WeknoraPlugin: Plugin = async (input, options) => {
+  const config = resolveConfig({ ...configFromEnv(), ...(options as Config | undefined) })
+  const client = new WeknoraClient(config)
+  const tools = createTools(client, config)
+  const registered = Object.keys(tools)
+  try {
+    await input.client.app.log({
+      body: {
+        service: 'opencode-weknora',
+        level: 'info',
+        message: `registered ${registered.join(', ')} against ${config.baseUrl}`,
+      },
+    })
+  } catch {
+    // Logging is best-effort; registration does not depend on it.
+  }
+  return { tool: tools }
+}
+
+export default WeknoraPlugin

--- a/packages/opencode-weknora/src/render.ts
+++ b/packages/opencode-weknora/src/render.ts
@@ -1,0 +1,25 @@
+/** Pure projections from a tool's canonical value to model-facing text. */
+
+/** Clip text to a character budget, reporting whether anything was dropped. */
+export function clip(text: string, maxChars: number): { text: string, truncated: boolean } {
+  const normalized = text.replace(/\r\n/g, '\n').trim()
+  if (normalized.length <= maxChars) return { text: normalized, truncated: false }
+  return { text: `${normalized.slice(0, maxChars).trimEnd()}…`, truncated: true }
+}
+
+/** Human-readable score, tolerant of a backend that omits it. */
+export function formatScore(score: number): string {
+  return Number.isFinite(score) ? score.toFixed(3) : 'n/a'
+}
+
+/**
+ * Name a retrieval scope without spending the model's context on it. A
+ * deployment can hold dozens of knowledge bases, and spelling out every id on
+ * every search costs far more than the count is worth; the ids stay in the
+ * tool's canonical value for anything that needs them.
+ */
+export function describeScope(ids: string[]): string {
+  if (ids.length === 0) return '(deployment default)'
+  if (ids.length <= 3) return ids.join(', ')
+  return `${ids.length} knowledge bases`
+}

--- a/packages/opencode-weknora/src/tools.ts
+++ b/packages/opencode-weknora/src/tools.ts
@@ -1,0 +1,394 @@
+/** The model-facing tools this plugin contributes to opencode.
+ *
+ * Ported from `dsh-weknora` (WeKnora's DeepSeek Harness plugin): the same four
+ * tools, the same scope resolution and clipping behaviour, rendered into
+ * opencode's tool registration shape — Zod argument schemas, an abort signal
+ * from the agent, and an `output` + `metadata` result envelope.
+ */
+
+import { tool } from '@opencode-ai/plugin'
+
+import type { ChunkRecord, DocumentRecord, SearchResult, WeknoraClient } from './client.ts'
+import type { ResolvedConfig } from './config.ts'
+import { clip, describeScope, formatScore } from './render.ts'
+
+/** A retrieval hit projected onto the fields the model and follow-up calls need. */
+interface SearchHit {
+  rank: number
+  chunk_id: string
+  knowledge_id: string
+  document: string
+  chunk_index: number
+  score: number
+  content: string
+  truncated: boolean
+}
+
+/** A document whose name matched, which passage retrieval alone would miss. */
+interface DocumentMatch {
+  knowledge_id: string
+  title: string
+  knowledge_base_id: string
+  knowledge_base: string
+}
+
+interface SearchValue {
+  query: string
+  knowledge_base_ids: string[]
+  count: number
+  results: SearchHit[]
+  documents: DocumentMatch[]
+}
+
+interface KnowledgeBasesValue {
+  count: number
+  knowledge_bases: { id: string, name: string, description: string }[]
+}
+
+interface DocumentValue {
+  knowledge_id: string
+  title: string
+  summary: string
+  page: number
+  page_size: number
+  total_chunks: number
+  returned_chunks: number
+  has_more: boolean
+  truncated: boolean
+  content: string
+}
+
+interface AskValue {
+  answer: string
+  session_id: string
+  pipeline: 'rag' | 'agent'
+  tool_calls: string[]
+  references: { knowledge_id: string, document: string, chunk_index: number, content: string }[]
+}
+
+/** Prefer a human title, then the source filename, then the opaque id. */
+function documentLabel(result: SearchResult): string {
+  const title = typeof result.knowledge_title === 'string' ? result.knowledge_title.trim() : ''
+  if (title !== '') return title
+  const filename = typeof result.knowledge_filename === 'string' ? result.knowledge_filename.trim() : ''
+  if (filename !== '') return filename
+  return typeof result.knowledge_id === 'string' && result.knowledge_id !== '' ? result.knowledge_id : '(untitled)'
+}
+
+function projectHit(result: SearchResult, rank: number, maxChunkChars: number): SearchHit {
+  const clipped = clip(typeof result.content === 'string' ? result.content : '', maxChunkChars)
+  return {
+    rank,
+    chunk_id: typeof result.id === 'string' ? result.id : '',
+    knowledge_id: typeof result.knowledge_id === 'string' ? result.knowledge_id : '',
+    document: documentLabel(result),
+    chunk_index: typeof result.chunk_index === 'number' ? result.chunk_index : -1,
+    // 0 rather than NaN: the canonical value must stay lossless JSON.
+    score: typeof result.score === 'number' && Number.isFinite(result.score) ? result.score : 0,
+    content: clipped.text,
+    truncated: clipped.truncated,
+  }
+}
+
+/**
+ * Keep the by-name matches worth showing: inside the scope the caller asked
+ * for, and not already represented by a passage hit. WeKnora's by-name search
+ * spans the whole tenant, so the scope filter is what stops a narrowed call
+ * from reporting documents outside it.
+ */
+function projectNamedDocuments(
+  named: DocumentRecord[],
+  passages: SearchHit[],
+  knowledgeBaseIds: string[],
+  knowledgeIds: string[],
+): DocumentMatch[] {
+  const already = new Set(passages.map(hit => hit.knowledge_id))
+  const scope = new Set(knowledgeBaseIds)
+  const wanted = new Set(knowledgeIds)
+  const out: DocumentMatch[] = []
+  for (const document of named) {
+    const id = typeof document.id === 'string' ? document.id : ''
+    const kbId = typeof document.knowledge_base_id === 'string' ? document.knowledge_base_id : ''
+    if (id === '' || already.has(id)) continue
+    if (wanted.size > 0 ? !wanted.has(id) : !scope.has(kbId)) continue
+    const title = typeof document.title === 'string' && document.title.trim() !== ''
+      ? document.title.trim()
+      : typeof document.file_name === 'string' ? document.file_name : id
+    out.push({
+      knowledge_id: id,
+      title,
+      knowledge_base_id: kbId,
+      knowledge_base: typeof document.knowledge_base_name === 'string' ? document.knowledge_base_name : kbId,
+    })
+    already.add(id)
+  }
+  return out
+}
+
+/** Storage order, so a reassembled document reads top to bottom. */
+function orderByChunkIndex(left: ChunkRecord, right: ChunkRecord): number {
+  const a = typeof left.chunk_index === 'number' ? left.chunk_index : 0
+  const b = typeof right.chunk_index === 'number' ? right.chunk_index : 0
+  return a - b
+}
+
+/** Assemble the four tool definitions for one configured deployment. */
+export function createTools(client: WeknoraClient, config: ResolvedConfig): Record<string, ReturnType<typeof tool>> {
+  const name = (suffix: string): string => `${config.toolPrefix}_${suffix}`
+  const scopeNote = config.knowledgeBaseIds.length > 0
+    ? ` Searches knowledge base(s) ${config.knowledgeBaseIds.join(', ')} unless you name others.`
+    : ' Searches every knowledge base this credential can see unless you narrow it with knowledge_base_ids.'
+
+  // An unscoped call reaches WeKnora as a refusal on the retrieval route and as
+  // an answer grounded in nothing on the RAG route, so an unconfigured
+  // deployment resolves the full visible set once and reuses it. Making the
+  // model pick a scope first is worse: knowledge bases are often named too
+  // poorly to choose between, and fanning out across them is cheap while they
+  // share a vector store.
+  let everyId: Promise<string[]> | undefined
+  const allKnowledgeBaseIds = async (signal: AbortSignal): Promise<string[]> => {
+    everyId ??= client.listKnowledgeBases(signal).then(
+      bases => bases.map(kb => typeof kb.id === 'string' ? kb.id : '').filter(id => id !== ''),
+      (error: unknown) => {
+        everyId = undefined
+        throw error
+      },
+    )
+    return await everyId
+  }
+  const resolveScope = async (requested: string[], knowledgeIds: string[], signal: AbortSignal): Promise<string[]> => {
+    if (requested.length > 0) return requested
+    if (config.knowledgeBaseIds.length > 0) return config.knowledgeBaseIds
+    if (knowledgeIds.length > 0) return []
+    return await allKnowledgeBaseIds(signal)
+  }
+
+  const tools: Record<string, ReturnType<typeof tool>> = {}
+
+  if (config.tools.listKnowledgeBases) {
+    tools[name('list_knowledge_bases')] = tool({
+      description: 'List the WeKnora knowledge bases this deployment can retrieve from, with their ids. '
+        + `${name('search')} already spans them all, so reach for this only to report what is available or to `
+        + 'narrow a later search to one of them.',
+      args: {},
+      async execute(_args, context) {
+        const bases = await client.listKnowledgeBases(context.abort)
+        const value: KnowledgeBasesValue = {
+          count: bases.length,
+          knowledge_bases: bases.map(kb => ({
+            id: typeof kb.id === 'string' ? kb.id : '',
+            name: typeof kb.name === 'string' ? kb.name : '',
+            description: typeof kb.description === 'string' ? kb.description : '',
+          })),
+        }
+        if (value.count === 0) {
+          return { title: 'WeKnora knowledge bases', output: 'No knowledge base is available to this WeKnora credential.', metadata: value }
+        }
+        const lines = value.knowledge_bases.map(kb => {
+          const description = kb.description === '' ? '' : ` — ${kb.description}`
+          return `- ${kb.name} (id: ${kb.id})${description}`
+        })
+        return {
+          title: 'WeKnora knowledge bases',
+          output: `${value.count} knowledge base(s):\n${lines.join('\n')}`,
+          metadata: value,
+        }
+      },
+    })
+  }
+
+  if (config.tools.search) {
+    tools[name('search')] = tool({
+      description: 'Search WeKnora knowledge bases and return the matching passages verbatim (hybrid vector + keyword '
+        + 'retrieval, no model summarization). Use this to ground an answer in the organization\'s own documents, and '
+        + 'also to locate a document by name — a query that reads like a title additionally returns the documents it '
+        + 'names.' + scopeNote
+        + ` Every hit carries a knowledge_id you can pass to ${name('read_document')} for the full document.`,
+      args: {
+        query: tool.schema.string().describe('Natural-language query; a full question retrieves better than keywords.'),
+        knowledge_base_ids: tool.schema.array(tool.schema.string()).optional()
+          .describe('Restrict the search to these knowledge base ids.'),
+        knowledge_ids: tool.schema.array(tool.schema.string()).optional()
+          .describe('Restrict the search to these document ids.'),
+        max_results: tool.schema.number().int().optional()
+          .describe(`Maximum passages to return (default ${config.maxResults}).`),
+      },
+      async execute(args, context) {
+        const toolName = name('search')
+        const query = args.query.trim()
+        const knowledgeIds = args.knowledge_ids ?? []
+        const knowledgeBaseIds = await resolveScope(args.knowledge_base_ids ?? [], knowledgeIds, context.abort)
+        // Fail here rather than let WeKnora answer 400: the model can act on a
+        // message naming the argument to supply, not on a transport error.
+        if (knowledgeBaseIds.length === 0 && knowledgeIds.length === 0) {
+          throw new Error(`${toolName}: this WeKnora credential can see no knowledge base, so there is `
+            + 'nothing to search. Check the deployment\'s API key scope.')
+        }
+        const requested = args.max_results
+        const limit = typeof requested === 'number' && Number.isFinite(requested) && requested > 0
+          ? Math.min(Math.floor(requested), config.maxResults)
+          : config.maxResults
+        const [hits, named] = await Promise.all([
+          client.search({ query, knowledgeBaseIds, knowledgeIds }, context.abort),
+          // By-name matching is an enrichment, and older WeKnora builds may not
+          // route it. Losing it must not cost the model its passages.
+          client.findDocuments({ keyword: query, limit }, context.abort).catch(() => []),
+        ])
+        const results = hits.slice(0, limit).map((hit, index) => projectHit(hit, index + 1, config.maxChunkChars))
+        const value: SearchValue = {
+          query,
+          knowledge_base_ids: knowledgeBaseIds,
+          count: results.length,
+          results,
+          documents: projectNamedDocuments(named, results, knowledgeBaseIds, knowledgeIds),
+        }
+        const namedText = value.documents.length === 0
+          ? ''
+          : `\n\nDocuments named "${value.query}" (read them with ${name('read_document')}):\n`
+            + value.documents.map(document =>
+              `- ${document.title} · knowledge_id: ${document.knowledge_id} · in ${document.knowledge_base}`).join('\n')
+        let output: string
+        if (value.count === 0) {
+          output = namedText === ''
+            ? `Nothing in WeKnora matched "${value.query}" (searched: ${describeScope(value.knowledge_base_ids)}). `
+              + 'Try a differently worded query, or widen the knowledge base scope.'
+            : `No passage matched "${value.query}", but its name matches document(s).${namedText}`
+        } else {
+          const blocks = value.results.map(hit =>
+            `[${hit.rank}] ${hit.document} · score ${formatScore(hit.score)} · chunk ${hit.chunk_index} `
+            + `· knowledge_id: ${hit.knowledge_id}\n${hit.content}${hit.truncated ? '\n(passage truncated)' : ''}`)
+          output = `${value.count} passage(s) for "${value.query}" `
+            + `(searched: ${describeScope(value.knowledge_base_ids)}):\n\n${blocks.join('\n\n')}${namedText}`
+        }
+        return { title: `WeKnora search: ${clip(query, 60).text}`, output, metadata: value }
+      },
+    })
+  }
+
+  if (config.tools.readDocument) {
+    tools[name('read_document')] = tool({
+      description: 'Read a WeKnora document\'s stored passages in order, reassembled into text. '
+        + `Use it after ${name('search')} when one passage is not enough context; page through long documents.`,
+      args: {
+        knowledge_id: tool.schema.string().describe('Document id, as returned in a search hit.'),
+        page: tool.schema.number().int().optional().describe('Page of passages, starting at 1.'),
+        page_size: tool.schema.number().int().optional().describe('Passages per page (max 100).'),
+      },
+      async execute(args, context) {
+        const knowledgeId = args.knowledge_id.trim()
+        const page = typeof args.page === 'number' && args.page > 0 ? Math.min(Math.floor(args.page), 10_000) : 1
+        const pageSize = typeof args.page_size === 'number' && args.page_size > 0
+          ? Math.min(Math.floor(args.page_size), 100)
+          : 20
+        const [result, metadata] = await Promise.all([
+          client.listChunks({ knowledgeId, page, pageSize }, context.abort),
+          // Only page 1 is worth the extra call and the summary's tokens: by
+          // page 2 the model has already seen what this document is. Metadata
+          // is context, not the payload, so a deployment that cannot serve it
+          // must still hand over the text.
+          page === 1
+            ? client.getDocument(knowledgeId, context.abort).catch(() => ({}) as DocumentRecord)
+            : Promise.resolve({} as DocumentRecord),
+        ])
+        const ordered = [...result.chunks].sort(orderByChunkIndex)
+        const joined = ordered.map(chunk => typeof chunk.content === 'string' ? chunk.content : '').join('\n\n')
+        const clipped = clip(joined, config.maxChunkChars * Math.max(1, Math.min(ordered.length, 10)))
+        const title = typeof metadata.title === 'string' && metadata.title.trim() !== ''
+          ? metadata.title.trim()
+          : typeof metadata.file_name === 'string' ? metadata.file_name.trim() : ''
+        const value: DocumentValue = {
+          knowledge_id: knowledgeId,
+          title,
+          summary: clip(typeof metadata.description === 'string' ? metadata.description.trim() : '', config.maxChunkChars).text,
+          page: result.page,
+          page_size: result.pageSize,
+          total_chunks: result.total,
+          returned_chunks: ordered.length,
+          has_more: result.page * result.pageSize < result.total,
+          truncated: clipped.truncated,
+          content: clipped.text,
+        }
+        const label = value.title === '' ? value.knowledge_id : `${value.title} (${value.knowledge_id})`
+        let output: string
+        if (value.returned_chunks === 0) {
+          output = `Document ${label} has no passage on page ${value.page} (${value.total_chunks} passage(s) in total).`
+        } else {
+          // The summary lets the model judge a long document from page 1
+          // instead of paging blindly to find out what it is holding.
+          const summary = value.summary === '' ? '' : `\n\nSummary: ${value.summary}`
+          const more = value.has_more ? `\n\n(more passages available: request page ${value.page + 1})` : ''
+          const cut = value.truncated ? '\n(content truncated)' : ''
+          output = `Document ${label}, passages ${value.returned_chunks} of ${value.total_chunks} `
+            + `(page ${value.page}):${summary}\n\n${value.content}${cut}${more}`
+        }
+        return { title: `WeKnora document: ${label}`, output, metadata: value }
+      },
+    })
+  }
+
+  if (config.tools.ask) {
+    const pipeline = config.agentId === undefined ? 'RAG' : 'agent'
+    tools[name('ask')] = tool({
+      description: `Ask WeKnora a question and get its own composed answer with citations (${pipeline} pipeline runs `
+        + 'server-side: query rewriting, retrieval, reranking and summarization). Reserve it for broad or '
+        + 'synthesis questions whose answer spans many documents, where retrieving passages yourself would take '
+        + `several rounds. For anything you can answer from specific passages, prefer ${name('search')}: it is far `
+        + 'faster and leaves you the evidence to reason over rather than another model\'s conclusion.',
+      args: {
+        query: tool.schema.string().describe('The question to answer.'),
+        knowledge_base_ids: tool.schema.array(tool.schema.string()).optional()
+          .describe('Restrict retrieval to these knowledge base ids.'),
+        agent_id: tool.schema.string().optional().describe('Custom agent id; selects the server-side ReAct pipeline.'),
+        session_id: tool.schema.string().optional().describe('Continue an earlier WeKnora session instead of starting one.'),
+        web_search: tool.schema.boolean().optional().describe('Let WeKnora also search the web, when its deployment allows it.'),
+      },
+      async execute(args, context) {
+        const toolName = name('ask')
+        const query = args.query.trim()
+        const requested = args.knowledge_base_ids ?? []
+        const agentId = (typeof args.agent_id === 'string' && args.agent_id.trim() !== '' ? args.agent_id.trim() : undefined)
+          ?? config.agentId
+        // A custom agent resolves its own scope server-side from its
+        // KBSelectionMode, and ids sent here would override that as an explicit
+        // mention. The RAG pipeline has no such default: it retrieves only what
+        // the request names, and answers from nothing when it names nothing.
+        const knowledgeBaseIds = agentId === undefined
+          ? await resolveScope(requested, [], context.abort)
+          : requested.length > 0 ? requested : config.knowledgeBaseIds
+        if (agentId === undefined && knowledgeBaseIds.length === 0) {
+          throw new Error(`${toolName}: this WeKnora credential can see no knowledge base, so there is `
+            + 'nothing to answer from. Check the deployment\'s API key scope.')
+        }
+        const sessionId = (typeof args.session_id === 'string' && args.session_id.trim() !== '' ? args.session_id.trim() : undefined)
+          ?? await client.createSession(`opencode: ${clip(query, 60).text}`, context.abort)
+        const streamed = await client.ask({ sessionId, query, knowledgeBaseIds, agentId, webSearch: args.web_search === true }, context.abort)
+        const value: AskValue = {
+          answer: streamed.answer.trim(),
+          session_id: streamed.sessionId,
+          pipeline: agentId === undefined ? 'rag' : 'agent',
+          tool_calls: streamed.toolCalls,
+          references: streamed.references.slice(0, config.maxResults).map(reference => ({
+            knowledge_id: typeof reference.knowledge_id === 'string' ? reference.knowledge_id : '',
+            document: documentLabel(reference),
+            chunk_index: typeof reference.chunk_index === 'number' ? reference.chunk_index : -1,
+            content: clip(typeof reference.content === 'string' ? reference.content : '', config.maxChunkChars).text,
+          })),
+        }
+        const parts: string[] = []
+        parts.push(value.answer === ''
+          ? 'WeKnora returned an empty answer. Retry with a more specific question, or retrieve passages instead.'
+          : value.answer)
+        if (value.references.length > 0) {
+          const cited = value.references.map((reference, index) =>
+            `[${index + 1}] ${reference.document} · chunk ${reference.chunk_index} · knowledge_id: ${reference.knowledge_id}`)
+          parts.push(`Citations:\n${cited.join('\n')}`)
+        }
+        if (value.tool_calls.length > 0) parts.push(`WeKnora tools used: ${value.tool_calls.join(', ')}`)
+        parts.push(`WeKnora session: ${value.session_id} (pass session_id to ask a follow-up in context)`)
+        return { title: `WeKnora answer: ${clip(query, 60).text}`, output: parts.join('\n\n'), metadata: value }
+      },
+    })
+  }
+
+  return tools
+}

--- a/packages/opencode-weknora/test/config.test.mjs
+++ b/packages/opencode-weknora/test/config.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { ConfigError, configFromEnv, normalizeBaseUrl, resolveConfig } from '../dist/config.js'
+
+test('resolveConfig applies the documented defaults', () => {
+  const config = resolveConfig(undefined)
+  assert.equal(config.baseUrl, 'http://localhost:8080/api/v1')
+  assert.deepEqual(config.knowledgeBaseIds, [])
+  assert.equal(config.maxResults, 8)
+  assert.equal(config.maxChunkChars, 1200)
+  assert.equal(config.resourceUrls, 'public')
+  assert.equal(config.toolPrefix, 'weknora')
+  assert.deepEqual(config.tools, { listKnowledgeBases: true, search: true, readDocument: true, ask: true })
+})
+
+test('normalizeBaseUrl appends the api root once', () => {
+  assert.equal(normalizeBaseUrl('https://weknora.example.com'), 'https://weknora.example.com/api/v1')
+  assert.equal(normalizeBaseUrl('https://weknora.example.com/'), 'https://weknora.example.com/api/v1')
+  assert.equal(normalizeBaseUrl('http://localhost:8080/api/v1'), 'http://localhost:8080/api/v1')
+})
+
+test('resolveConfig reports every violation instead of failing late', () => {
+  assert.throws(() => resolveConfig({ baseUrl: '  ', maxResults: -1, toolPrefix: '1bad', resourceUrls: 'both' }), (error) => {
+    assert.ok(error instanceof ConfigError)
+    const text = String(error.message)
+    for (const fragment of ['baseUrl', 'maxResults', 'toolPrefix', 'resourceUrls']) assert.ok(text.includes(fragment))
+    return true
+  })
+})
+
+test('configFromEnv reads the WEKNORA_* variables', () => {
+  const config = configFromEnv({
+    WEKNORA_BASE_URL: 'https://weknora.example.com',
+    WEKNORA_API_KEY: 'sk-test',
+    WEKNORA_TENANT_ID: '10000',
+    WEKNORA_KNOWLEDGE_BASE_IDS: 'kb-a, kb-b ,,',
+    WEKNORA_TOOL_PREFIX: 'team_kb',
+  })
+  assert.equal(config.baseUrl, 'https://weknora.example.com')
+  assert.equal(config.apiKey, 'sk-test')
+  assert.equal(config.tenantId, '10000')
+  assert.deepEqual(config.knowledgeBaseIds, ['kb-a', 'kb-b'])
+  assert.equal(config.toolPrefix, 'team_kb')
+  // An invalid enum value is ignored rather than failing the whole layer.
+  assert.equal(configFromEnv({ WEKNORA_RESOURCE_URLS: 'both' }).resourceUrls, undefined)
+})
+
+test('plugin options merge over the environment', () => {
+  const config = resolveConfig({ ...configFromEnv({ WEKNORA_API_KEY: 'sk-env' }), apiKey: 'sk-options' })
+  assert.equal(config.apiKey, 'sk-options')
+})

--- a/packages/opencode-weknora/test/contract.test.mjs
+++ b/packages/opencode-weknora/test/contract.test.mjs
@@ -1,0 +1,120 @@
+/**
+ * The plugin side of the API contract: the calls this package makes must stay
+ * exactly the ones recorded in test/fixtures/api-contract.json, which
+ * contract/contract_test.go checks against WeKnora's real Go request and
+ * response types. Change a request body and both sides tell you.
+ */
+
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { after, test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { WeknoraClient } from '../dist/client.js'
+import { resolveConfig } from '../dist/config.js'
+import { createTools } from '../dist/tools.js'
+import { startMockWeknora } from './helpers/mock-weknora.mjs'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const fixture = JSON.parse(await readFile(join(here, 'fixtures', 'api-contract.json'), 'utf8'))
+const exec = { abort: new AbortController().signal }
+
+/** Replay every documented call against the mock and record what went out. */
+async function replayCalls() {
+  const mock = await startMockWeknora()
+  after(() => mock.close())
+
+  const ragConfig = resolveConfig({ baseUrl: mock.url, knowledgeBaseIds: ['kb-product'] })
+  const ragTools = createTools(new WeknoraClient(ragConfig), ragConfig)
+  await ragTools.weknora_list_knowledge_bases.execute({}, exec)
+  await ragTools.weknora_search.execute({ query: '默认的检索阈值是多少' }, exec)
+  await ragTools.weknora_read_document.execute(
+    { knowledge_id: 'doc-retrieval-pipeline', page: 1, page_size: 5 },
+    exec,
+  )
+  await ragTools.weknora_ask.execute({ query: '默认的检索阈值是多少' }, exec)
+
+  const agentConfig = resolveConfig({ baseUrl: mock.url, agentId: 'agent-42' })
+  const agentTools = createTools(new WeknoraClient(agentConfig), agentConfig)
+  await agentTools.weknora_ask.execute({ query: '部署方式', session_id: 's1', web_search: true }, exec)
+
+  return mock.requests.map(request => ({
+    method: request.method,
+    path: request.path,
+    query: request.query,
+    body: Object.keys(request.body).length === 0 ? null : request.body,
+  }))
+}
+
+const observed = await replayCalls()
+
+/** Order-insensitive key: a tool that fires two calls at once may land either way round. */
+const callKey = call => `${call.method} ${call.path} ${JSON.stringify(call.query)} ${JSON.stringify(call.body)}`
+
+test('the plugin makes exactly the documented WeKnora calls', () => {
+  const expected = fixture.calls.map(call => ({
+    method: call.method,
+    path: call.path,
+    query: call.query,
+    body: call.body,
+  }))
+  assert.deepEqual(
+    observed.map(callKey).sort(),
+    expected.map(callKey).sort(),
+  )
+})
+
+test('the fixture covers every endpoint the plugin touches', () => {
+  const endpoints = new Set(observed.map(call => call.path.replace(/\/(session-mock-1|s1|doc-[\w-]+)$/, '/:id')))
+  assert.deepEqual([...endpoints].sort(), [
+    '/api/v1/agent-chat/:id',
+    '/api/v1/chunks/:id',
+    '/api/v1/knowledge-bases',
+    '/api/v1/knowledge-search',
+    '/api/v1/knowledge-chat/:id',
+    '/api/v1/knowledge/search',
+    '/api/v1/knowledge/:id',
+    '/api/v1/sessions',
+  ].sort())
+})
+
+test('every stream event the plugin handles is declared in the fixture', async () => {
+  const mock = await startMockWeknora()
+  after(() => mock.close())
+  const config = resolveConfig({ baseUrl: mock.url, agentId: 'agent-42' })
+  const client = new WeknoraClient(config)
+  const answer = await client.ask(
+    { sessionId: 's1', query: '默认的检索阈值是多少', knowledgeBaseIds: [], agentId: 'agent-42', webSearch: false },
+    exec.abort,
+  )
+  // The mock streams tool_call, references, answer and complete; error is
+  // covered by the client error paths. All five must be in the declared set.
+  for (const event of ['answer', 'references', 'tool_call', 'complete', 'error']) {
+    assert.ok(fixture.streamResponseTypes.includes(event), `${event} must be declared in the fixture`)
+  }
+  assert.notEqual(answer.answer, '')
+  assert.notEqual(answer.references.length, 0)
+  assert.deepEqual(answer.toolCalls, ['knowledge_search'])
+})
+
+test('the plugin only reads response fields the fixture declares', async () => {
+  const mock = await startMockWeknora()
+  after(() => mock.close())
+  const config = resolveConfig({ baseUrl: mock.url, knowledgeBaseIds: ['kb-product'] })
+  const client = new WeknoraClient(config)
+  // A backend that serves nothing but the declared fields must still produce a
+  // complete tool result, which is what "these are the fields we depend on" means.
+  const declared = new Set(fixture.responseFieldsRead['types.SearchResult'])
+  const trimmed = {
+    search: async (input, signal) =>
+      (await client.search(input, signal)).map(result => Object.fromEntries(
+        Object.entries(result).filter(([key]) => declared.has(key)),
+      )),
+    findDocuments: async (input, signal) => await client.findDocuments(input, signal),
+  }
+  const tools = createTools(trimmed, config)
+  const result = await tools.weknora_search.execute({ query: '混合检索' }, exec)
+  assert.match(result.output, /knowledge_id: doc-/)
+  assert.match(result.output, /score \d\.\d{3}/)
+})

--- a/packages/opencode-weknora/test/fixtures/api-contract.json
+++ b/packages/opencode-weknora/test/fixtures/api-contract.json
@@ -1,0 +1,119 @@
+{
+  "$comment": [
+    "The exact WeKnora API calls this plugin makes, and the response fields it reads.",
+    "test/contract.test.mjs asserts the plugin still emits these calls;",
+    "contract/contract_test.go asserts the WeKnora server still accepts them and still",
+    "serves those response fields, so a rename on either side fails CI instead of a user's agent."
+  ],
+  "calls": [
+    {
+      "tool": "weknora_list_knowledge_bases",
+      "method": "GET",
+      "path": "/api/v1/knowledge-bases",
+      "query": { "resource_urls": "public" },
+      "body": null,
+      "goRequestType": null
+    },
+    {
+      "tool": "weknora_search",
+      "method": "POST",
+      "path": "/api/v1/knowledge-search",
+      "query": { "resource_urls": "public" },
+      "body": {
+        "query": "默认的检索阈值是多少",
+        "knowledge_base_ids": ["kb-product"]
+      },
+      "goRequestType": "session.SearchKnowledgeRequest"
+    },
+    {
+      "tool": "weknora_search",
+      "method": "GET",
+      "path": "/api/v1/knowledge/search",
+      "query": { "keyword": "默认的检索阈值是多少", "limit": "8", "resource_urls": "public" },
+      "body": null,
+      "goRequestType": null
+    },
+    {
+      "tool": "weknora_read_document",
+      "method": "GET",
+      "path": "/api/v1/chunks/doc-retrieval-pipeline",
+      "query": { "page": "1", "page_size": "5", "resource_urls": "public" },
+      "body": null,
+      "goRequestType": "types.Pagination"
+    },
+    {
+      "tool": "weknora_read_document",
+      "method": "GET",
+      "path": "/api/v1/knowledge/doc-retrieval-pipeline",
+      "query": { "resource_urls": "public" },
+      "body": null,
+      "goRequestType": null
+    },
+    {
+      "tool": "weknora_ask",
+      "method": "POST",
+      "path": "/api/v1/sessions",
+      "query": { "resource_urls": "public" },
+      "body": {
+        "title": "opencode: 默认的检索阈值是多少"
+      },
+      "goRequestType": "session.CreateSessionRequest"
+    },
+    {
+      "tool": "weknora_ask",
+      "method": "POST",
+      "path": "/api/v1/knowledge-chat/session-mock-1",
+      "query": { "resource_urls": "public" },
+      "body": {
+        "query": "默认的检索阈值是多少",
+        "channel": "api",
+        "knowledge_base_ids": ["kb-product"]
+      },
+      "goRequestType": "session.CreateKnowledgeQARequest"
+    },
+    {
+      "tool": "weknora_ask",
+      "method": "POST",
+      "path": "/api/v1/agent-chat/s1",
+      "query": { "resource_urls": "public" },
+      "body": {
+        "query": "部署方式",
+        "channel": "api",
+        "agent_id": "agent-42",
+        "agent_enabled": true,
+        "web_search_enabled": true
+      },
+      "goRequestType": "session.CreateKnowledgeQARequest"
+    }
+  ],
+  "responseFieldsRead": {
+    "types.SearchResult": [
+      "id",
+      "content",
+      "knowledge_id",
+      "chunk_index",
+      "knowledge_title",
+      "knowledge_filename",
+      "score"
+    ],
+    "types.Chunk": ["id", "content", "chunk_index", "knowledge_id"],
+    "types.Knowledge": [
+      "id",
+      "title",
+      "file_name",
+      "description",
+      "knowledge_base_id",
+      "knowledge_base_name"
+    ],
+    "types.StreamResponse": [
+      "response_type",
+      "content",
+      "knowledge_references",
+      "session_id",
+      "tool_calls"
+    ],
+    "types.LLMToolCall": ["function"],
+    "types.FunctionCall": ["name"]
+  },
+  "streamResponseTypes": ["answer", "references", "tool_call", "error", "complete"]
+}

--- a/packages/opencode-weknora/test/helpers/mock-weknora.mjs
+++ b/packages/opencode-weknora/test/helpers/mock-weknora.mjs
@@ -1,0 +1,368 @@
+/**
+ * A stand-in WeKnora backend used by the unit tests and by the end-to-end run
+ * inside opencode. It speaks the same routes, envelopes and SSE event types as the
+ * real server (see internal/handler/session/qa.go and internal/types/chat.go),
+ * so a test failure here means the plugin, not the fixture, drifted.
+ */
+
+import { createServer } from 'node:http'
+
+const DOCUMENTS = [
+  {
+    knowledge_id: 'doc-retrieval-pipeline',
+    knowledge_title: 'WeKnora 检索流程.md',
+    knowledge_base_id: 'kb-product',
+    // WeKnora stores the generated summary in `description`, not `summary`.
+    description: '讲解 WeKnora 混合检索的召回、阈值与父子分块回溯。',
+    chunks: [
+      'WeKnora 的混合检索先做向量召回，再做关键词召回，最后交给 rerank 模型统一排序。',
+      '默认的 vector_threshold 是 0.5，keyword_threshold 是 0.3，可以在知识库配置里按库调整。',
+      '父子分块开启后，命中子块会回溯父块，把更完整的上下文交给生成模型。',
+    ],
+  },
+  {
+    knowledge_id: 'doc-architecture',
+    knowledge_title: '系统架构图.md',
+    knowledge_base_id: 'kb-product',
+    description: '检索与生成两层的系统架构示意图。',
+    chunks: [
+      '系统由检索与生成两层组成，整体结构见架构图。\n\n![系统架构](resource://AbCdEfGhIjKlMnOpQrStUv)',
+    ],
+  },
+  {
+    knowledge_id: 'doc-deployment',
+    knowledge_title: 'WeKnora 部署手册.md',
+    knowledge_base_id: 'kb-ops',
+    description: '单机与 Kubernetes 部署方式，以及可选的向量库后端。',
+    chunks: [
+      'WeKnora 支持 docker compose 单机部署，也提供 Helm chart 用于 Kubernetes。',
+      '向量库可以选择 pgvector、Milvus、Qdrant、Weaviate、OpenSearch 等后端。',
+    ],
+  },
+  {
+    // Title and body share no wording on purpose: retrieving this document by
+    // name is the only way to reach it, which is what the by-name search is for.
+    knowledge_id: 'doc-release-checklist',
+    knowledge_title: '灰度发布检查单.md',
+    knowledge_base_id: 'kb-ops',
+    description: '上线前的确认项与回滚准备。',
+    chunks: [
+      '上线前需确认监控告警、回滚预案与数据库变更脚本均已就绪，并由值班同学复核。',
+    ],
+  },
+]
+
+// Titled so a by-name query matches it while its text shares nothing with that
+// query — the case passage retrieval alone cannot serve.
+DOCUMENTS.push({
+  knowledge_id: 'doc-release-checklist',
+  knowledge_title: '灰度发布检查单.md',
+  knowledge_base_id: 'kb-ops',
+  description: '上线前的确认项与回滚方案。',
+  chunks: ['本文列出上线前需要确认的配置项与回滚方案。'],
+})
+
+const KNOWLEDGE_BASES = [
+  { id: 'kb-product', name: 'Product docs', description: 'WeKnora 产品与检索文档' },
+  { id: 'kb-ops', name: 'Ops runbooks', description: '部署与运维手册' },
+]
+
+const ARCH_HANDLE = 'resource://AbCdEfGhIjKlMnOpQrStUv'
+const ARCH_PUBLIC = 'https://cdn.example.com/architecture.png'
+
+/** Mirror WeKnora's `resource_urls=public` rewrite of `resource://` handles. */
+function rewriteResources(value, publicMode) {
+  if (!publicMode) return value
+  return JSON.parse(JSON.stringify(value).replaceAll(ARCH_HANDLE, ARCH_PUBLIC))
+}
+
+/**
+ * Score a passage by character-bigram overlap. The real backend scores with
+ * embeddings plus keyword match; bigrams are enough to make the fixture rank
+ * plausibly for both Chinese and English queries.
+ */
+function scoreOf(query, content) {
+  const normalized = query.replace(/[\s,，。？?、！!：:；;“”"']+/g, '')
+  const shingles = new Set()
+  for (let index = 0; index + 2 <= normalized.length; index += 1) {
+    shingles.add(normalized.slice(index, index + 2))
+  }
+  if (shingles.size === 0) return 0
+  const hits = [...shingles].filter(shingle => content.includes(shingle)).length
+  return Math.min(0.99, 0.4 + (hits / shingles.size) * 0.5)
+}
+
+function searchResults(query, knowledgeBaseIds, knowledgeIds) {
+  const documents = DOCUMENTS.filter(document =>
+    (knowledgeIds.length === 0 || knowledgeIds.includes(document.knowledge_id))
+    && (knowledgeBaseIds.length === 0 || knowledgeBaseIds.includes(document.knowledge_base_id)))
+  return documents
+    .flatMap(document => document.chunks.map((content, index) => ({
+      id: `${document.knowledge_id}-chunk-${index}`,
+      content,
+      knowledge_id: document.knowledge_id,
+      knowledge_title: document.knowledge_title,
+      chunk_index: index,
+      score: scoreOf(query, content),
+      match_type: 2,
+      start_at: 0,
+      end_at: content.length,
+      metadata: {},
+    })))
+    .filter(result => result.score > 0.4)
+    .sort((left, right) => right.score - left.score)
+}
+
+/** The document shape the by-name search and `GET /knowledge/:id` both return. */
+function documentRecord(document) {
+  return {
+    id: document.knowledge_id,
+    title: document.knowledge_title,
+    file_name: document.knowledge_title,
+    file_type: 'md',
+    description: document.description,
+    knowledge_base_id: document.knowledge_base_id,
+    knowledge_base_name: KNOWLEDGE_BASES.find(kb => kb.id === document.knowledge_base_id)?.name ?? '',
+    parse_status: 'completed',
+    summary_status: 'completed',
+  }
+}
+
+/** Assemble the answer the fake RAG/agent pipeline streams back. */
+function answerFor(query, results) {
+  if (results.length === 0) return `没有检索到与「${query}」相关的内容。`
+  const cited = results.slice(0, 2).map(result => result.content).join(' ')
+  return `根据知识库内容：${cited}（问题：${query}）`
+}
+
+/**
+ * Start the mock backend.
+ * @param options.apiKey - when set, requests must carry it as `X-API-Key`.
+ * @param options.streamError - make the chat routes stream an `error` event.
+ * @param options.streamTruncated - end the chat stream mid-answer, with no `complete`.
+ * @param options.forbidPublicResourceUrls - reject `resource_urls=public` with the
+ *   403 WeKnora returns for a knowledge-base-restricted API key.
+ * @returns the base URL, the recorded requests, and a close function.
+ */
+export async function startMockWeknora(options = {}) {
+  const requests = []
+  // Paths forced to fail, so a test can prove the plugin degrades rather than
+  // breaks when a deployment does not serve one of the optional routes.
+  const failures = new Map()
+  const server = createServer((request, response) => {
+    const url = new URL(request.url, 'http://mock.invalid')
+    const chunks = []
+    request.on('data', chunk => chunks.push(chunk))
+    request.on('end', () => {
+      const rawBody = Buffer.concat(chunks).toString('utf8')
+      let body = {}
+      if (rawBody !== '') {
+        try {
+          body = JSON.parse(rawBody)
+        } catch {
+          body = { _unparsed: rawBody }
+        }
+      }
+      requests.push({
+        method: request.method,
+        path: url.pathname,
+        query: Object.fromEntries(url.searchParams),
+        headers: request.headers,
+        body,
+      })
+
+      const json = (status, payload) => {
+        response.writeHead(status, { 'Content-Type': 'application/json' })
+        response.end(JSON.stringify(payload))
+      }
+
+      if (options.apiKey !== undefined && request.headers['x-api-key'] !== options.apiKey) {
+        json(401, { success: false, error: { message: 'invalid api key' } })
+        return
+      }
+
+      if (options.forbidPublicResourceUrls === true && url.searchParams.get('resource_urls') === 'public') {
+        json(403, {
+          success: false,
+          error: { message: 'resource_urls=public is not available for a knowledge-base-restricted API key' },
+        })
+        return
+      }
+
+      const publicMode = url.searchParams.get('resource_urls') === 'public'
+
+      const forced = failures.get(url.pathname)
+      if (forced !== undefined) {
+        json(forced, { success: false, error: { message: `forced failure for ${url.pathname}` } })
+        return
+      }
+
+      if (request.method === 'GET' && url.pathname === '/api/v1/knowledge-bases') {
+        json(200, { success: true, data: KNOWLEDGE_BASES })
+        return
+      }
+
+      // By-name document search. Spans every knowledge base and takes no
+      // scope, matching the real /knowledge/search route.
+      if (request.method === 'GET' && url.pathname === '/api/v1/knowledge/search') {
+        const keyword = (url.searchParams.get('keyword') ?? url.searchParams.get('query') ?? '').trim()
+        if (keyword === '') {
+          json(400, { success: false, error: { message: 'missing search keyword: pass ?keyword=... or ?query=...' } })
+          return
+        }
+        const limit = Number(url.searchParams.get('limit') ?? '20')
+        json(200, {
+          success: true,
+          data: DOCUMENTS
+            .filter(document => document.knowledge_title.toLowerCase().includes(keyword.toLowerCase()))
+            .slice(0, limit)
+            .map(document => documentRecord(document)),
+        })
+        return
+      }
+
+      if (request.method === 'GET' && url.pathname.startsWith('/api/v1/knowledge/')) {
+        const knowledgeId = decodeURIComponent(url.pathname.slice('/api/v1/knowledge/'.length))
+        const document = DOCUMENTS.find(entry => entry.knowledge_id === knowledgeId)
+        if (document === undefined) {
+          json(404, { success: false, error: { message: 'knowledge not found' } })
+          return
+        }
+        json(200, { success: true, data: documentRecord(document) })
+        return
+      }
+
+      if (request.method === 'POST' && url.pathname === '/api/v1/knowledge-search') {
+        if (typeof body.query !== 'string' || body.query === '') {
+          json(400, { success: false, error: { message: 'Query content cannot be empty' } })
+          return
+        }
+        // Mirror the real handler, which refuses an unscoped retrieval
+        // (internal/handler/session/qa.go). Answering one here would let the
+        // plugin ship a call every deployment rejects.
+        if ((body.knowledge_base_ids ?? []).length === 0
+          && (body.knowledge_ids ?? []).length === 0
+          && (body.tag_ids ?? []).length === 0) {
+          json(400, {
+            success: false,
+            error: {
+              message: 'At least one knowledge_base_id, knowledge_base_ids, knowledge_ids, or scoped tag must be provided',
+            },
+          })
+          return
+        }
+        json(200, {
+          success: true,
+          data: rewriteResources(
+            searchResults(body.query, body.knowledge_base_ids ?? [], body.knowledge_ids ?? []),
+            publicMode,
+          ),
+        })
+        return
+      }
+
+      if (request.method === 'GET' && url.pathname.startsWith('/api/v1/chunks/')) {
+        const knowledgeId = decodeURIComponent(url.pathname.slice('/api/v1/chunks/'.length))
+        const document = DOCUMENTS.find(entry => entry.knowledge_id === knowledgeId)
+        if (document === undefined) {
+          json(404, { success: false, error: { message: 'knowledge not found' } })
+          return
+        }
+        const page = Number(url.searchParams.get('page') ?? '1')
+        const pageSize = Number(url.searchParams.get('page_size') ?? '10')
+        const start = (page - 1) * pageSize
+        json(200, {
+          success: true,
+          data: document.chunks.slice(start, start + pageSize).map((content, index) => ({
+            id: `${knowledgeId}-chunk-${start + index}`,
+            knowledge_id: knowledgeId,
+            knowledge_base_id: 'kb-product',
+            content,
+            chunk_index: start + index,
+            is_enabled: true,
+          })),
+          total: document.chunks.length,
+          page,
+          page_size: pageSize,
+        })
+        return
+      }
+
+      if (request.method === 'POST' && url.pathname === '/api/v1/sessions') {
+        json(201, { success: true, data: { id: 'session-mock-1', title: body.title ?? '' } })
+        return
+      }
+
+      const chatMatch = /^\/api\/v1\/(knowledge-chat|agent-chat)\/(.+)$/.exec(url.pathname)
+      if (request.method === 'POST' && chatMatch !== null) {
+        const [, route, sessionId] = chatMatch
+        response.writeHead(200, {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          'Connection': 'keep-alive',
+        })
+        const send = payload => response.write(`event:message\ndata:${JSON.stringify(payload)}\n\n`)
+        if (options.streamError === true) {
+          send({ id: 'e1', response_type: 'error', content: 'model provider unavailable', done: true })
+          response.end()
+          return
+        }
+        // The RAG route retrieves only what the request scopes: a session holds
+        // no knowledge base of its own (CreateSessionRequest carries none), so
+        // WeKnora has no default to fall back on and answers from nothing.
+        // Retrieving here anyway would hide an unscoped ask from the tests. The
+        // agent route does have a server-side default, its KBSelectionMode.
+        const scoped = (body.knowledge_base_ids ?? []).length > 0 || (body.knowledge_ids ?? []).length > 0
+        const results = rewriteResources(
+          route === 'agent-chat' || scoped
+            ? searchResults(body.query ?? '', body.knowledge_base_ids ?? [], [])
+            : [],
+          publicMode,
+        )
+        if (route === 'agent-chat') {
+          send({
+            id: 't1',
+            response_type: 'tool_call',
+            content: '',
+            done: false,
+            session_id: sessionId,
+            tool_calls: [{ id: 'call-1', function: { name: 'knowledge_search', arguments: '{}' } }],
+          })
+        }
+        send({ id: 'r1', response_type: 'references', content: '', done: false, knowledge_references: results })
+        const pieces = answerFor(body.query ?? '', results).match(/.{1,24}/gs) ?? []
+        // A stream cut off mid-answer, which is what a dropped connection or a
+        // killed backend looks like: answer deltas but no `complete`.
+        if (options.streamTruncated === true) {
+          send({ id: 'a1', response_type: 'answer', content: pieces[0] ?? '', done: false, session_id: sessionId })
+          response.end()
+          return
+        }
+        for (const piece of pieces) {
+          send({ id: 'a1', response_type: 'answer', content: piece, done: false, session_id: sessionId })
+        }
+        send({ id: 'c1', response_type: 'complete', content: '', done: true, session_id: sessionId })
+        response.end()
+        return
+      }
+
+      json(404, { success: false, error: { message: `no route for ${request.method} ${url.pathname}` } })
+    })
+  })
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  const { port } = server.address()
+  return {
+    url: `http://127.0.0.1:${port}/api/v1`,
+    requests,
+    /** Force `path` to answer `status` from now on. */
+    fail(path, status) {
+      failures.set(path, status)
+    },
+    async close() {
+      await new Promise(resolve => server.close(resolve))
+    },
+  }
+}
+
+export { ARCH_HANDLE, ARCH_PUBLIC, DOCUMENTS, KNOWLEDGE_BASES }

--- a/packages/opencode-weknora/test/live.integration.test.mjs
+++ b/packages/opencode-weknora/test/live.integration.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+/**
+ * Live integration against a real WeKnora deployment. Gated by environment:
+ *   WEKNORA_LIVE_URL     e.g. http://localhost:8080
+ *   WEKNORA_LIVE_API_KEY an API key with retrieve (+ chat for ask) access
+ *   WEKNORA_LIVE_ASK=1   additionally run the (slow, model-backed) ask tool
+ */
+
+const url = process.env.WEKNORA_LIVE_URL
+const apiKey = process.env.WEKNORA_LIVE_API_KEY
+
+test('live: list, search and read against a deployment', { skip: url === undefined || apiKey === undefined }, async () => {
+  const { WeknoraClient } = await import('../dist/client.js')
+  const { resolveConfig } = await import('../dist/config.js')
+  const { createTools } = await import('../dist/tools.js')
+
+  const config = resolveConfig({ baseUrl: url, apiKey })
+  const client = new WeknoraClient(config)
+  const tools = createTools(client, config)
+  const context = { abort: new AbortController().signal }
+
+  const listed = await tools.weknora_list_knowledge_bases.execute({}, context)
+  assert.ok(listed.metadata.count >= 1, 'the deployment has at least one knowledge base')
+  const scope = listed.metadata.knowledge_bases.map((kb) => kb.id)
+
+  // Any real corpus answers a query about itself; the sample document used in
+  // this project's verification is titled "opencode-weknora integration probe".
+  const searched = await tools.weknora_search.execute(
+    { query: 'opencode weknora integration probe', knowledge_base_ids: scope }, context,
+  )
+  assert.ok(Array.isArray(searched.metadata.results))
+  assert.ok(searched.metadata.count >= 1, `search returned ${searched.metadata.count} hits`)
+  const hit = searched.metadata.results[0]
+  assert.ok(hit.knowledge_id !== '')
+  assert.ok(hit.content.length > 0)
+
+  const read = await tools.weknora_read_document.execute({ knowledge_id: hit.knowledge_id }, context)
+  assert.equal(read.metadata.knowledge_id, hit.knowledge_id)
+  assert.ok(read.metadata.content.length > 0)
+
+  if (process.env.WEKNORA_LIVE_ASK === '1') {
+    const asked = await tools.weknora_ask.execute(
+      { query: 'What does the integration probe document say about itself?', knowledge_base_ids: scope }, context,
+    )
+    assert.ok(asked.metadata.answer.length > 0)
+    assert.ok(asked.metadata.session_id !== '')
+  }
+})

--- a/packages/opencode-weknora/test/tools.test.mjs
+++ b/packages/opencode-weknora/test/tools.test.mjs
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { resolveConfig } from '../dist/config.js'
+import { createTools } from '../dist/tools.js'
+
+const signal = new AbortController().signal
+const context = { abort: signal }
+
+/** A WeknoraClient stand-in recording calls and answering from fixtures. */
+function mockClient(overrides = {}) {
+  const calls = []
+  return {
+    calls,
+    async listKnowledgeBases() {
+      calls.push(['listKnowledgeBases'])
+      return overrides.bases ?? [{ id: 'kb-1', name: 'Manual', description: 'the manual' }]
+    },
+    async search(request) {
+      calls.push(['search', request])
+      return overrides.hits ?? [{
+        id: 'c-1', knowledge_id: 'k-1', knowledge_title: 'Handbook', chunk_index: 0, score: 0.87,
+        content: 'x'.repeat(50),
+      }]
+    },
+    async findDocuments(request) {
+      calls.push(['findDocuments', request])
+      return overrides.named ?? [{ id: 'k-9', title: 'Handbook annex', knowledge_base_id: 'kb-1', knowledge_base_name: 'Manual' }]
+    },
+    async getDocument(knowledgeId) {
+      calls.push(['getDocument', knowledgeId])
+      return overrides.document ?? { title: 'Handbook', description: 'everything', file_name: 'hb.md' }
+    },
+    async listChunks(request) {
+      calls.push(['listChunks', request])
+      return overrides.chunks ?? {
+        page: 1, pageSize: 20, total: 2,
+        chunks: [
+          { id: 'c-1', chunk_index: 1, content: 'first passage' },
+          { id: 'c-2', chunk_index: 0, content: 'zeroth passage' },
+        ],
+      }
+    },
+    async createSession(title) {
+      calls.push(['createSession', title])
+      return 'sess-1'
+    },
+    async ask(request) {
+      calls.push(['ask', request])
+      return overrides.answer ?? {
+        answer: ' forty-two ', sessionId: request.sessionId, toolCalls: ['retrieval'],
+        references: [{ knowledge_id: 'k-1', knowledge_title: 'Handbook', chunk_index: 3, content: 'the answer' }],
+      }
+    },
+  }
+}
+
+test('registers the four prefixed tools and honors toggles', () => {
+  const tools = createTools(mockClient(), resolveConfig({ toolPrefix: 'team_kb' }))
+  assert.deepEqual(Object.keys(tools).sort(),
+    ['team_kb_ask', 'team_kb_list_knowledge_bases', 'team_kb_read_document', 'team_kb_search'])
+
+  const fewer = createTools(mockClient(), resolveConfig({ tools: { ask: false, listKnowledgeBases: false } }))
+  assert.deepEqual(Object.keys(fewer).sort(), ['weknora_read_document', 'weknora_search'])
+})
+
+test('search returns passages plus named documents, clipped, in the result envelope', async () => {
+  const client = mockClient()
+  const tools = createTools(client, resolveConfig({ maxChunkChars: 20 }))
+  const result = await tools.weknora_search.execute({ query: ' how do I X ' }, context)
+  assert.equal(result.metadata.count, 1)
+  assert.equal(result.metadata.results[0].document, 'Handbook')
+  assert.ok(result.metadata.results[0].content.length <= 21, 'clipped to the budget plus the ellipsis')
+  assert.ok(result.metadata.results[0].content.endsWith('…'))
+  assert.equal(result.metadata.results[0].truncated, true)
+  assert.ok(result.output.includes('score'))
+  assert.ok(result.output.includes('Handbook annex'), 'named documents are reported')
+  const searchCall = client.calls.find((call) => call[0] === 'search')
+  assert.equal(searchCall[1].query, 'how do I X')
+})
+
+test('search falls back to every visible knowledge base when unscoped', async () => {
+  const client = mockClient()
+  const tools = createTools(client, resolveConfig({}))
+  await tools.weknora_search.execute({ query: 'q' }, context)
+  assert.equal(client.calls[0][0], 'listKnowledgeBases')
+  assert.deepEqual(client.calls.find((call) => call[0] === 'search')[1].knowledgeBaseIds, ['kb-1'])
+  // The resolved set is cached per process: a second call does not re-list.
+  await tools.weknora_search.execute({ query: 'q2' }, context)
+  assert.equal(client.calls.filter((call) => call[0] === 'listKnowledgeBases').length, 1)
+})
+
+test('configured scope wins over the visible-set fallback', async () => {
+  const client = mockClient()
+  const tools = createTools(client, resolveConfig({ knowledgeBaseIds: ['kb-mine'] }))
+  await tools.weknora_search.execute({ query: 'q' }, context)
+  assert.deepEqual(client.calls.find((call) => call[0] === 'search')[1].knowledgeBaseIds, ['kb-mine'])
+  assert.equal(client.calls.filter((call) => call[0] === 'listKnowledgeBases').length, 0)
+})
+
+test('read_document orders passages and clips, with page-1 summary', async () => {
+  const client = mockClient()
+  const tools = createTools(client, resolveConfig({}))
+  const result = await tools.weknora_read_document.execute({ knowledge_id: 'k-1' }, context)
+  assert.equal(result.metadata.title, 'Handbook')
+  assert.ok(result.output.indexOf('zeroth passage') < result.output.indexOf('first passage'))
+  assert.ok(result.output.includes('Summary: everything'))
+  const chunkCall = client.calls.find((call) => call[0] === 'listChunks')
+  assert.deepEqual([chunkCall[1].page, chunkCall[1].pageSize], [1, 20])
+})
+
+test('ask uses the RAG pipeline, clips references and reports the session', async () => {
+  const client = mockClient()
+  const tools = createTools(client, resolveConfig({ knowledgeBaseIds: ['kb-1'] }))
+  const result = await tools.weknora_ask.execute({ query: 'meaning?' }, context)
+  assert.equal(result.metadata.answer, 'forty-two')
+  assert.equal(result.metadata.pipeline, 'rag')
+  assert.equal(result.metadata.session_id, 'sess-1')
+  assert.deepEqual(result.metadata.references[0].document, 'Handbook')
+  assert.ok(result.output.includes('Citations:'))
+  assert.ok(result.output.includes('session_id'))
+  const askCall = client.calls.find((call) => call[0] === 'ask')
+  assert.deepEqual(askCall[1].knowledgeBaseIds, ['kb-1'])
+})
+
+test('ask with agent_id leaves the scope decision server-side', async () => {
+  const client = mockClient()
+  const tools = createTools(client, resolveConfig({}))
+  await tools.weknora_ask.execute({ query: 'q', agent_id: 'agent-7' }, context)
+  const askCall = client.calls.find((call) => call[0] === 'ask')
+  assert.equal(askCall[1].agentId, 'agent-7')
+  assert.deepEqual(askCall[1].knowledgeBaseIds, [])
+  assert.equal(client.calls.filter((call) => call[0] === 'listKnowledgeBases').length, 0)
+})

--- a/packages/opencode-weknora/tsconfig.build.json
+++ b/packages/opencode-weknora/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  }
+}

--- a/packages/opencode-weknora/tsconfig.json
+++ b/packages/opencode-weknora/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "declaration": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## 背景

Implements #3061

[opencode](https://opencode.ai) 自身不带任何检索或知识库能力——它的工具只读工作区和互联网。与 `dsh-weknora`（#2759）面对的是同一个缺口：知识在 WeKnora 里，agent 在 opencode 里。本 PR 新增官方 opencode 插件，把 WeKnora 知识库接进 opencode 的 agent。

## 改动

新增 `packages/opencode-weknora/`，向 agent 注册四个**只读**工具（与 dsh 版一致）：

| 工具 | WeKnora 端点 | 模型拿到什么 |
|---|---|---|
| `weknora_list_knowledge_bases` | `GET /knowledge-bases` | 知识库名称与 id，便于模型圈定检索范围 |
| `weknora_search` | `POST /knowledge-search` + `GET /knowledge/search` | 原文段落，附 `knowledge_id`、得分与 chunk 序号；查询像标题时还会返回命名的文档 |
| `weknora_read_document` | `GET /chunks/:knowledge_id` + `GET /knowledge/:id` | 单篇文档按序重组的正文，支持翻页 |
| `weknora_ask` | `POST /sessions` + `knowledge-chat` / `agent-chat` | WeKnora 自己的成稿答案、引用、服务端工具调用与可续会话 id |

插件只读，不做写入：不摄取、不改 chunk、不删除。凭据以 `X-API-Key`（可选 `X-Tenant-ID`）传递，报错只带 HTTP 状态与 WeKnora 自身原因，不带 key。段落在进入模型前按 `maxChunkChars` 裁剪并显式告知模型 `truncated`。

安装即一行配置：

```json
{ "plugin": [["@wxg-prc-cpg/opencode-weknora", { "baseUrl": "https://weknora.example.com", "apiKey": "sk-..." }]] }
```

## 设计取舍

**客户端与 dsh 版逐字相同**（`src/client.ts`），因此双侧 API 契约 fixture 与 dsh 共用同一形状；差异只在宿主侧注册形态——opencode 的官方 `@opencode-ai/plugin` 提供带 Zod 参数 schema 的 `tool()` 帮助器、来自 agent 的 `AbortSignal` 和 `output`+`metadata` 结果信封，插件按此渲染，并把入口模块收敛为只导出插件本身（opencode 的加载器会把入口模块的每个函数导出都当插件调用）。

**配置在插件加载期校验**，写错字段会在加载时列出每一条违规，而不是等到第一次工具调用才炸。配置优先级：opencode 插件选项 > `WEKNORA_*` 环境变量 > 默认值，一份环境可服务多个 agent 而单个项目只覆盖差异项。

**未配置范围的调用**会先解析凭据可见的全部知识库（进程内缓存）：让模型先选库往往更差——知识库命名通常不足以在它们之间做选择，而共享向量库的扇出检索是廉价的。

## 测试

- **单元测试**（mock 后端驱动工具，断言模型实际看到的内容，含前缀改名、工具裁剪、双部署并挂）
- **契约层**与 dsh 相同的双侧固化：`test/contract.test.mjs` 校验插件仍只发 fixture 记录的调用，`contract/contract_test.go` 校验 WeKnora 真实的 Go 请求/响应类型仍接受并提供这些字段，任一侧改名都在 CI 挂掉而不是在用户的 agent 里挂掉
- **对真实部署的集成测试**（`test/live.integration.test.mjs`，提供 `WEKNORA_LIVE_*` 环境变量才运行）：四工具全链路 + RAG ask 流式回答已在真实部署上验证通过；社区先行版 [`opencode-weknora@0.1.0`](https://www.npmjs.com/package/opencode-weknora) 已发布并经 opencode TUI 手动多工具链路测试（list → search → read 自主编排）

本机验证记录：`npm ci && npm run typecheck && npm run build && node --test "test/*.test.mjs"`（17 项：16 过 + live 套件按设计跳过）+ `go test ./packages/opencode-weknora/contract/...` + `npm pack` 文件清单校验，全部通过；worktree 构建产物在真实 opencode 中加载并注册四工具冒烟通过。

## CI

新增 `.github/workflows/opencode-plugin.yml`（镜像 `dsh-plugin.yml` 的模式）：触碰该目录时运行 typecheck、单元与双侧契约测试、打包文件清单校验；发布仅在 `opencode-weknora-v*` tag 触发，带版本一致性检查与 npm 不可变性兜底，发布带 provenance。

在 CI 内驱动 opencode agent loop 的端到端检查（对应 dsh 的 e2e job）列为后续跟进项——在它落地之前，对真实部署的手动验证路径已写入包 README 的 Development 一节。

## 说明

包以 `@wxg-prc-cpg/opencode-weknora` 发布，与 `@wxg-prc-cpg/dsh-weknora` 的组织与命名约定一致。无前缀社区先行版 `opencode-weknora`（同一作者、同一代码）已在 npm 上；如官方希望直接接管该包名，作者配合走 npm 转移流程（见 #3061）。

本 PR 不改动 WeKnora 主体的任何代码——除 `contract/contract_test.go` 只读地断言现有类型外，全部为新增目录、四个根 README 的一段介绍，以及一个新 workflow。
