### PR TITLE
fix(initialization): pass stored ExtraConfig to model connection test

### DIFF
--- a/internal/handler/initialization.go
+++ b/internal/handler/initialization.go
@@ -1648,16 +1648,20 @@ type ModelTestRequest struct {
 
 // fillSecretsFromStoredModel mutates req in place: if req.ModelID is set
 // and a secret field on the request is empty, the corresponding value from
-// the stored (and decrypted) model is copied in. Non-empty request values
-// are always preferred — they represent the user actively typing a new key
-// they want to verify. Missing or inaccessible model is treated as a no-op
-// (the connection test will fail downstream with a clearer "missing apiKey"
-// error than we could produce here).
+// the stored (and decrypted) model is copied in. The stored ExtraConfig is
+// filled in as well when the request does not carry one — provider-specific
+// settings (thinking_control, api_version, remote_model_name, ...) must
+// apply to the connection test exactly as they apply to real traffic, and
+// the frontend only sends extraConfig when the user actively edits it.
+// Non-empty request values are always preferred — they represent the user
+// actively typing a new key they want to verify. Missing or inaccessible
+// model is treated as a no-op (the connection test will fail downstream
+// with a clearer "missing apiKey" error than we could produce here).
 func (h *InitializationHandler) fillSecretsFromStoredModel(ctx context.Context, req *ModelTestRequest) {
 	if req == nil || req.ModelID == "" {
 		return
 	}
-	if req.APIKey != "" && req.AppSecret != "" {
+	if req.APIKey != "" && req.AppSecret != "" && req.ExtraConfig != nil {
 		return
 	}
 	stored, err := h.modelService.GetModelByID(ctx, req.ModelID)
@@ -1671,6 +1675,9 @@ func (h *InitializationHandler) fillSecretsFromStoredModel(ctx context.Context, 
 	}
 	if req.AppSecret == "" {
 		req.AppSecret = stored.Parameters.AppSecret
+	}
+	if req.ExtraConfig == nil {
+		req.ExtraConfig = stored.Parameters.ExtraConfig
 	}
 }
 

--- a/internal/handler/initialization_fill_secrets_test.go
+++ b/internal/handler/initialization_fill_secrets_test.go
@@ -1,0 +1,146 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+// stubFillSecretsModelService only implements GetModelByID; every other
+// ModelService call panics via the nil interface embedding. Keeps the test
+// focused on fillSecretsFromStoredModel's branching logic.
+type stubFillSecretsModelService struct {
+	interfaces.ModelService
+	getModelByID func(ctx context.Context, id string) (*types.Model, error)
+}
+
+func (s *stubFillSecretsModelService) GetModelByID(ctx context.Context, id string) (*types.Model, error) {
+	return s.getModelByID(ctx, id)
+}
+
+func TestFillSecretsFromStoredModel_FillsExtraConfig(t *testing.T) {
+	stored := &types.Model{
+		Parameters: types.ModelParameters{
+			APIKey:    "sk-stored",
+			AppSecret: "app-secret-stored",
+			ExtraConfig: map[string]string{
+				"thinking_control": "none",
+				"api_version":      "2024-10-21",
+			},
+		},
+	}
+	h := &InitializationHandler{
+		modelService: &stubFillSecretsModelService{
+			getModelByID: func(context.Context, string) (*types.Model, error) { return stored, nil },
+		},
+	}
+	req := &ModelTestRequest{ModelID: "m-1"}
+
+	h.fillSecretsFromStoredModel(context.Background(), req)
+
+	if req.APIKey != "sk-stored" || req.AppSecret != "app-secret-stored" {
+		t.Fatalf("secrets not filled from stored model: apiKey=%q appSecret=%q", req.APIKey, req.AppSecret)
+	}
+	if req.ExtraConfig == nil {
+		t.Fatalf("ExtraConfig not filled from stored model: got nil, want thinking_control/api_version")
+	}
+	if req.ExtraConfig["thinking_control"] != "none" || req.ExtraConfig["api_version"] != "2024-10-21" {
+		t.Fatalf("ExtraConfig contents wrong: %v", req.ExtraConfig)
+	}
+}
+
+// TestFillSecretsFromStoredModel_RequestExtraConfigWins: when the caller
+// actively sends an extraConfig payload (user editing the form), the stored
+// one must not overwrite it — same precedence as the secret fields.
+func TestFillSecretsFromStoredModel_RequestExtraConfigWins(t *testing.T) {
+	stored := &types.Model{
+		Parameters: types.ModelParameters{
+			ExtraConfig: map[string]string{"thinking_control": "none"},
+		},
+	}
+	h := &InitializationHandler{
+		modelService: &stubFillSecretsModelService{
+			getModelByID: func(context.Context, string) (*types.Model, error) { return stored, nil },
+		},
+	}
+	req := &ModelTestRequest{
+		ModelID:     "m-1",
+		APIKey:      "sk-typed",
+		AppSecret:   "app-typed",
+		ExtraConfig: map[string]string{"thinking_control": "enabled"},
+	}
+
+	h.fillSecretsFromStoredModel(context.Background(), req)
+
+	if req.ExtraConfig["thinking_control"] != "enabled" {
+		t.Fatalf("request ExtraConfig overwritten: %v", req.ExtraConfig)
+	}
+	if req.APIKey != "sk-typed" || req.AppSecret != "app-typed" {
+		t.Fatalf("request secrets overwritten: %q %q", req.APIKey, req.AppSecret)
+	}
+}
+
+// TestFillSecretsFromStoredModel_SecretsStillFilledWithoutExtraConfig:
+// regression guard for the early-return — a request that already carries
+// both secrets but no extraConfig must still pick up the stored
+// extraConfig (this is the exact #3057 scenario: the frontend "test"
+// button only sends modelId).
+func TestFillSecretsFromStoredModel_SecretsStillFilledWithoutExtraConfig(t *testing.T) {
+	stored := &types.Model{
+		Parameters: types.ModelParameters{
+			APIKey:      "sk-stored",
+			AppSecret:   "app-secret-stored",
+			ExtraConfig: map[string]string{"remote_model_name": "gpt-x"},
+		},
+	}
+	h := &InitializationHandler{
+		modelService: &stubFillSecretsModelService{
+			getModelByID: func(context.Context, string) (*types.Model, error) { return stored, nil },
+		},
+	}
+	req := &ModelTestRequest{ModelID: "m-1", APIKey: "sk-typed", AppSecret: "app-typed"}
+
+	h.fillSecretsFromStoredModel(context.Background(), req)
+
+	if req.ExtraConfig == nil || req.ExtraConfig["remote_model_name"] != "gpt-x" {
+		t.Fatalf("ExtraConfig not filled when secrets were provided: %v", req.ExtraConfig)
+	}
+}
+
+func TestFillSecretsFromStoredModel_NoModelIDNoop(t *testing.T) {
+	h := &InitializationHandler{
+		modelService: &stubFillSecretsModelService{
+			getModelByID: func(context.Context, string) (*types.Model, error) {
+				t.Fatal("GetModelByID must not be called without a model id")
+				return nil, nil
+			},
+		},
+	}
+	req := &ModelTestRequest{}
+
+	h.fillSecretsFromStoredModel(context.Background(), req)
+
+	if req.ExtraConfig != nil {
+		t.Fatalf("ExtraConfig changed without model id: %v", req.ExtraConfig)
+	}
+}
+
+func TestFillSecretsFromStoredModel_ModelNotFoundNoop(t *testing.T) {
+	h := &InitializationHandler{
+		modelService: &stubFillSecretsModelService{
+			getModelByID: func(context.Context, string) (*types.Model, error) {
+				return nil, errors.New("not found")
+			},
+		},
+	}
+	req := &ModelTestRequest{ModelID: "missing"}
+
+	h.fillSecretsFromStoredModel(context.Background(), req)
+
+	if req.ExtraConfig != nil {
+		t.Fatalf("ExtraConfig changed on model lookup failure: %v", req.ExtraConfig)
+	}
+}


### PR DESCRIPTION
## Description

`fillSecretsFromStoredModel` (internal/handler/initialization.go) only copied `APIKey`/`AppSecret` from the stored model into the connection-test request. The temporary test model assembled by `buildTestModel` therefore always had a **nil `ExtraConfig`**, so any provider-specific setting stored on the model — `thinking_control`, `api_version`, `remote_model_name`, `temperature_overrides`, ... — was silently dropped from `POST /api/v1/initialization/remote/check`.

Consequences: the **Test Connection** button validated a *bare* model instead of the stored configuration. Real chat traffic was unaffected (`GetModelByID` returns the full model), which made stored-config problems look like "works in chat, fails the test" — and masked any fix that depends on `extra_config` (e.g. the `thinking_control` handling around #2058).

## Changes

- `fillSecretsFromStoredModel` now fills `req.ExtraConfig` from `stored.Parameters.ExtraConfig` when the request does not carry one.
- Request-provided values keep precedence (the extraConfig early-return check was extended accordingly), matching the function's documented secret semantics: "non-empty request values are always preferred".
- Doc comment updated to describe the extraConfig behavior.

## Testing

- New `internal/handler/initialization_fill_secrets_test.go` covers:
  - extraConfig + secrets filled from stored model (the frontend "Test" button path: only `modelId` is sent);
  - request-provided `extraConfig` wins over stored values;
  - regression guard: extraConfig is still filled when the request already carries both secrets;
  - no-op paths (missing model id, model lookup failure).
- `go build`, `go vet`, `gofmt`, `git diff --check` clean; full `internal/handler` package tests pass.

Fixes #3057
