### PR TITLE
fix(web): let register-by-invite reachable under invite_only via share link

### DIFF
--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -798,11 +798,14 @@ onMounted(async () => {
       return
     }
 
-    // 3. 未登录：按注册模式决定界面。invite_only 停在登录页、登录后再兑换；self_serve 保持注册流程。
+    // 3. 未登录：按注册模式决定界面。持有有效共享链接 token 时仍进入
+    //    邀请注册模式（token 即授权，对应后端 /auth/register-by-invite，
+    //    它豁免 invite_only）；无 token 时 invite_only 停在登录页、登录后
+    //    再兑换，self_serve 则保持公开注册流程。
     const cfg = await getAuthConfig()
     const inviteOnly = cfg.registration_mode === 'invite_only'
     registrationEnabled.value = !inviteOnly
-    isRegisterMode.value = !inviteOnly
+    isRegisterMode.value = !inviteOnly || !!inviteLookup.value
     loadOIDCConfig()
     return
   }


### PR DESCRIPTION
## Summary

With `registration_mode=invite_only` (e.g. `DISABLE_REGISTRATION=true`), a brand-new user who follows an Owner-issued share link (`/register?token=xxx`) only sees the **login** card — the registration form never renders, even though the link carries a valid token.

Root cause: in `Login.vue` `onMounted`, the not-logged-in branch forced `isRegisterMode = !inviteOnly`. Under `invite_only` this is `false`, so the register card (`v-if="isRegisterMode && (registrationEnabled || inviteLookup)"`) never shows — even though the template already supports `inviteLookup` bypassing the `invite_only` gate.

But the backend `POST /auth/register-by-invite` is intentionally **not** gated by `invite_only` (the token *is* the authorisation, see `auth_register_by_invite.go`), and `register-by-invite` is exactly the documented path to onboard brand-new users under `invite_only` (docs: "打通 invite-only 模式下的开户闭环"). So this is a frontend gap: the register mode is locked out before the existing bypass can apply.

Fix: when a valid share-link token resolved (`inviteLookup` set), still enter register mode even under `invite_only`: `isRegisterMode = !inviteOnly || !!inviteLookup`. Behavior:
- `invite_only` + valid token → register card shows; submit hits `register-by-invite` (creates account + joins workspace).
- `invite_only` + no/invalid token → stays on login (invalid tokens already `return` earlier).
- `self_serve` / no-token flows unchanged.

Changed files: frontend/src/views/auth/Login.vue (1 file, +5/-2).

Fixes #2985