### PR TITLE
fix(organization): 修正成员权限说明中编辑角色的共享知识库权限

### DIFF
--- a/frontend/src/views/organization/OrganizationEditorModal.vue
+++ b/frontend/src/views/organization/OrganizationEditorModal.vue
@@ -108,7 +108,7 @@
                             <li><t-icon name="check" class="check-icon" />{{ $t('organization.editor.editorPerm1') }}</li>
                             <li><t-icon name="check" class="check-icon" />{{ $t('organization.editor.editorPerm2') }}</li>
                             <li><t-icon name="check" class="check-icon" />{{ $t('organization.editor.useSharedAgentsPerm') }}</li>
-                            <li><t-icon name="close" class="close-icon" />{{ $t('organization.editor.shareKBPerm') }}</li>
+                            <li><t-icon name="check" class="check-icon" />{{ $t('organization.editor.shareKBPerm') }}</li>
                             <li><t-icon name="close" class="close-icon" />{{ $t('organization.editor.editorPerm3') }}</li>
                           </ul>
                         </div>

--- a/frontend/src/views/organization/OrganizationSettingsModal.vue
+++ b/frontend/src/views/organization/OrganizationSettingsModal.vue
@@ -265,7 +265,7 @@
                         <li><t-icon name="check" class="check-icon" />{{ $t('organization.editor.editorPerm1') }}</li>
                         <li><t-icon name="check" class="check-icon" />{{ $t('organization.editor.editorPerm2') }}</li>
                         <li><t-icon name="check" class="check-icon" />{{ $t('organization.editor.useSharedAgentsPerm') }}</li>
-                        <li><t-icon name="close" class="close-icon" />{{ $t('organization.editor.shareKBPerm') }}</li>
+                        <li><t-icon name="check" class="check-icon" />{{ $t('organization.editor.shareKBPerm') }}</li>
                         <li><t-icon name="close" class="close-icon" />{{ $t('organization.editor.editorPerm3') }}</li>
                       </ul>
                     </div>
@@ -1098,7 +1098,7 @@ const orgRoleMatrix: Record<OrgRole, OrgRolePerm[]> = {
     { key: 'viewerPerm1', has: true },
     { key: 'editorPerm1', has: true },
     { key: 'useSharedAgentsPerm', has: true },
-    { key: 'shareKBPerm', has: false },
+    { key: 'shareKBPerm', has: true },
     { key: 'adminPerm1', has: false },
   ],
   viewer: [


### PR DESCRIPTION
## Description

成员权限说明弹窗(`OrganizationSettingsModal` / `OrganizationEditorModal`)将编辑(editor)角色的「共享知识库到共享空间」标记为不可用(❌),与后端实际行为不符:

- 后端 `kbShareService.ShareKnowledgeBase` 对共享人的组织角色要求是 **editor+**:`internal/application/service/kbshare.go` 中 `tm.Role.HasPermission(types.OrgRoleEditor)`(权重 admin=3 / editor=2 / viewer=1),其错误文案本身就是 "only editors and admins can share knowledge bases to this organization";
- 智能体共享同理:`internal/application/service/agent_share.go` 同样只要求 editor+;
- 前端没有按角色拦截共享入口的逻辑,编辑角色在实际使用中可以把知识库共享到共享空间(已实测验证)。

本 PR 将两个弹窗(竖版权限卡 + 设置弹窗的紧凑权限矩阵)中编辑角色的这一条从 ❌ 改为 ✅,共 3 行,使权限说明与代码行为一致。只读(viewer)列及其余条目不变;i18n 文案无需改动。

## Type of Change

- [x] 🐛 Bug fix

## Related Issue

已在 issue / PR 中搜索("共享空间 权限"、"shareKBPerm" 等),无重复报告。

## Testing

- 核对后端权限判定:`kbshare.go`(`HasPermission(types.OrgRoleEditor)`)、`agent_share.go`(同阈值),确认 editor 可共享、viewer 被拒绝,与修改后的说明一致
- 实际环境中以编辑角色账号执行共享操作成功(后端放行),与修改前弹窗说明矛盾
- `git diff --check` 通过
- 改动为纯模板说明(图标 close→check、矩阵布尔值翻转),无逻辑变化,不影响构建与运行时行为

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [ ] Targeted tests for the changed components pass(改动为模板静态说明,现有测试不覆盖该文案矩阵)
- [x] Self-reviewed the code
- [ ] Updated related documentation(无需,本次即是修正 UI 说明)

## Screenshots / Recordings

改动为权限说明中编辑角色一行 ❌→✅(两个弹窗共 3 行,纯模板改动),暂未附运行时截图;如需要我再补充。
