### PR TITLE
feat(knowledge): finalize folder uploads and store attachments

### DIFF
--- a/frontend/src/api/knowledge-base/index.ts
+++ b/frontend/src/api/knowledge-base/index.ts
@@ -230,6 +230,12 @@ export function uploadKnowledgeFile(
   return postUpload(`/api/v1/knowledge-bases/${kbId}/knowledge/file`, formData, onProgress);
 }
 
+export function finalizeFolderUpload(kbId: string, knowledgeIds: string[]) {
+  return post(`/api/v1/knowledge-bases/${kbId}/knowledge/folder/finalize`, {
+    knowledge_ids: knowledgeIds,
+  });
+}
+
 // 从URL创建知识
 // data.tag_ids: 可选，指定知识所属的多个标签 ID
 export function createKnowledgeFromURL(

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -28,6 +28,7 @@ import {
   listKnowledgeTags,
   updateKnowledgeTagBatch,
   uploadKnowledgeFile,
+  finalizeFolderUpload,
   createKnowledgeFromURL,
   reparseKnowledge,
   cancelKnowledgeParse,
@@ -62,6 +63,7 @@ import {
 } from './wikiStatusRefresh';
 import { listMoveTargets, moveKnowledge, getKnowledgeMoveProgress } from '@/api/knowledge-base';
 import { resolveKnowledgeDownloadFileName } from './knowledgeDownloadFileName';
+import { chunkFolderFinalizeKnowledgeIDs, resolveFolderFileMode } from './utils/folderFileMode';
 import {
   buildUploadFileName,
   canMoveFolderTo,
@@ -1664,6 +1666,7 @@ const executeUploadBatch = async (
   let failCount = 0;
   const totalCount = files.length;
   const hasFolderPaths = files.some(isFolderUpload);
+  const deferredKnowledgeIds: string[] = [];
 
   for (const file of files) {
     try {
@@ -1672,7 +1675,20 @@ const executeUploadBatch = async (
         tag_ids?: string[]
         fileName?: string
         process_config?: KnowledgeProcessOverrides
+        folder_upload?: boolean
+        defer_processing?: boolean
+        store_only?: boolean
       } = { file, tag_ids: tagIdsToUpload };
+      if (isFolderUpload(file)) {
+        const mode = resolveFolderFileMode(file.name, supportedFileTypes.value);
+        if (!mode) {
+          failCount++;
+          continue;
+        }
+        uploadData.folder_upload = true;
+        uploadData.defer_processing = true;
+        uploadData.store_only = mode === 'store-only';
+      }
 
       const fileName = getFolderUploadFileName(file, options.targetFolder || ROOT_FOLDER_PATH);
       if (fileName) uploadData.fileName = fileName;
@@ -1684,6 +1700,10 @@ const executeUploadBatch = async (
       const isSuccess = responseData?.success || responseData?.code === 200 || responseData?.status === 'success' || (!responseData?.error && responseData);
       if (isSuccess) {
         successCount++;
+        const knowledgeId = responseData?.data?.id || responseData?.id;
+        if (uploadData.defer_processing && !uploadData.store_only && knowledgeId) {
+          deferredKnowledgeIds.push(knowledgeId);
+        }
       } else {
         failCount++;
         if (totalCount === 1) {
@@ -1708,6 +1728,20 @@ const executeUploadBatch = async (
         }
         MessagePlugin.error(errorMessage);
       }
+    }
+  }
+
+  if (hasFolderPaths && deferredKnowledgeIds.length > 0) {
+    try {
+      // Every source is registered before this loop starts, so batching only
+      // respects the API limit and cannot race relative-reference resolution.
+      for (const knowledgeIDs of chunkFolderFinalizeKnowledgeIDs(deferredKnowledgeIds)) {
+        await finalizeFolderUpload(targetKbId, knowledgeIDs);
+      }
+    } catch (error) {
+      // Files are safely registered as pending. A later retry can finalize
+      // them without losing their directory-relative references.
+      failCount += deferredKnowledgeIds.length;
     }
   }
 

--- a/frontend/src/views/knowledge/utils/folderFileMode.ts
+++ b/frontend/src/views/knowledge/utils/folderFileMode.ts
@@ -1,0 +1,31 @@
+import { shouldRejectKnowledgeFileType } from '../../../utils/fileTypeVerification'
+
+export const STORE_ONLY_FILE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'yaml', 'yml', 'json', 'xml', 'pdf', 'txt', 'csv']
+
+export type FolderFileMode = 'defer-processing' | 'store-only' | null
+
+export const FOLDER_FINALIZE_BATCH_SIZE = 1000
+
+// Parser engines arrive asynchronously. While their list is empty, known
+// default document types (notably Markdown) must remain parseable rather than
+// being permanently classified as store-only attachments.
+export function resolveFolderFileMode(filename: string, supportedFileTypes?: Set<string> | string[]): FolderFileMode {
+  const types = supportedFileTypes
+    ? supportedFileTypes instanceof Set ? supportedFileTypes : new Set(supportedFileTypes)
+    : undefined
+  const extension = filename.includes('.') ? filename.substring(filename.lastIndexOf('.') + 1).toLowerCase() : ''
+  if (types && types.size > 0) {
+    if (types.has(extension)) return 'defer-processing'
+  } else if (!shouldRejectKnowledgeFileType(filename)) {
+    return 'defer-processing'
+  }
+  return STORE_ONLY_FILE_EXTENSIONS.includes(extension) ? 'store-only' : null
+}
+
+export function chunkFolderFinalizeKnowledgeIDs(knowledgeIDs: string[]): string[][] {
+  const batches: string[][] = []
+  for (let offset = 0; offset < knowledgeIDs.length; offset += FOLDER_FINALIZE_BATCH_SIZE) {
+    batches.push(knowledgeIDs.slice(offset, offset + FOLDER_FINALIZE_BATCH_SIZE))
+  }
+  return batches
+}

--- a/frontend/src/views/knowledge/utils/uploadSources.test.ts
+++ b/frontend/src/views/knowledge/utils/uploadSources.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { chunkFolderFinalizeKnowledgeIDs, resolveFolderFileMode } from './folderFileMode.ts'
+
+test('resolveFolderFileMode keeps default Markdown parseable while engines load', () => {
+  assert.equal(resolveFolderFileMode('README.md', new Set()), 'defer-processing')
+})
+
+test('resolveFolderFileMode distinguishes configured parser files and attachments', () => {
+  assert.equal(resolveFolderFileMode('README.md', new Set(['md'])), 'defer-processing')
+  assert.equal(resolveFolderFileMode('diagram.svg', new Set(['md'])), 'store-only')
+  assert.equal(resolveFolderFileMode('payload.exe', new Set(['md'])), null)
+})
+
+test('chunkFolderFinalizeKnowledgeIDs keeps every request within the API limit', () => {
+  const ids = Array.from({ length: 1201 }, (_, index) => String(index))
+  const batches = chunkFolderFinalizeKnowledgeIDs(ids)
+  assert.deepEqual(batches.map(batch => batch.length), [1000, 201])
+  assert.equal(batches.flat().length, ids.length)
+})

--- a/frontend/src/views/knowledge/utils/uploadSources.ts
+++ b/frontend/src/views/knowledge/utils/uploadSources.ts
@@ -1,4 +1,5 @@
 import { kbFileTypeVerification } from '@/utils'
+import { STORE_ONLY_FILE_EXTENSIONS } from './folderFileMode'
 
 export const UPLOAD_VIDEO_EXTENSIONS = ['mp4', 'mov', 'avi', 'mkv', 'webm', 'wmv', 'flv']
 
@@ -62,7 +63,11 @@ export function filterUploadFiles(
       continue
     }
 
-    if (kbFileTypeVerification(file, multiFile, dynamicTypes)) {
+    // A directory may additionally contain a small set of safe attachment
+    // types referenced by a Markdown sibling. Other unsupported types remain
+    // rejected, just like individual-file uploads.
+    const isStoreOnlyAttachment = options.fromFolder && STORE_ONLY_FILE_EXTENSIONS.includes(fileExt)
+    if (!isStoreOnlyAttachment && kbFileTypeVerification(file, multiFile, dynamicTypes)) {
       skippedCount++
       continue
     }

--- a/internal/application/repository/knowledge.go
+++ b/internal/application/repository/knowledge.go
@@ -373,10 +373,13 @@ func (r *knowledgeRepository) CheckKnowledgeExists(
 		if params.FileHash != "" {
 			var knowledge types.Knowledge
 			duplicateQuery := query.Where("type = ? AND file_hash = ?", "file", params.FileHash)
+			if params.MatchLogicalPath {
+				duplicateQuery = duplicateQuery.Where("folder_path = ? AND file_name = ?", params.FolderPath, params.FileName)
+			}
 			if params.FileType != "" {
 				duplicateQuery = duplicateQuery.Where("LOWER(file_type) = ?", strings.ToLower(params.FileType))
 			}
-			err := duplicateQuery.First(&knowledge).Error
+			err := duplicateQuery.Order("created_at DESC, id DESC").First(&knowledge).Error
 			if err != nil {
 				if errors.Is(err, gorm.ErrRecordNotFound) {
 					return false, nil, nil
@@ -389,14 +392,14 @@ func (r *knowledgeRepository) CheckKnowledgeExists(
 		// If no hash or hash doesn't match, use filename, size, and file type.
 		if params.FileName != "" && params.FileSize > 0 {
 			var knowledge types.Knowledge
-			duplicateQuery := query.Where(
-				"type = ? AND file_name = ? AND file_size = ?",
-				"file", params.FileName, params.FileSize,
-			)
+			duplicateQuery := query.Where("type = ? AND file_name = ? AND file_size = ?", "file", params.FileName, params.FileSize)
+			if params.MatchLogicalPath {
+				duplicateQuery = duplicateQuery.Where("folder_path = ?", params.FolderPath)
+			}
 			if params.FileType != "" {
 				duplicateQuery = duplicateQuery.Where("LOWER(file_type) = ?", strings.ToLower(params.FileType))
 			}
-			err := duplicateQuery.First(&knowledge).Error
+			err := duplicateQuery.Order("created_at DESC, id DESC").First(&knowledge).Error
 			if err != nil {
 				if errors.Is(err, gorm.ErrRecordNotFound) {
 					return false, nil, nil

--- a/internal/application/repository/knowledge_duplicate_test.go
+++ b/internal/application/repository/knowledge_duplicate_test.go
@@ -61,3 +61,54 @@ func TestCheckKnowledgeExists_FileHashIsScopedByFileType(t *testing.T) {
 		assert.Equal(t, "md", knowledge.FileType)
 	})
 }
+
+func TestCheckKnowledgeExists_FileHashIsScopedByLogicalPath(t *testing.T) {
+	db := setupKnowledgeTestDB(t)
+	repo := NewKnowledgeRepository(db)
+	ctx := context.Background()
+	tenantID := uint64(1)
+	kbID := uuid.NewString()
+	const fileHash = "same-logo-content"
+
+	require.NoError(t, db.Exec(`
+		INSERT INTO knowledges (id, tenant_id, knowledge_base_id, type, title, file_name, folder_path, file_type, file_hash, parse_status)
+		VALUES (?, ?, ?, 'file', 'logo.png', 'logo.png', 'module-a', 'png', ?, 'completed')
+	`, uuid.NewString(), tenantID, kbID, fileHash).Error)
+
+	t.Run("same content in a sibling folder is not a duplicate", func(t *testing.T) {
+		exists, knowledge, err := repo.CheckKnowledgeExists(ctx, tenantID, kbID, &types.KnowledgeCheckParams{
+			Type: "file", FileHash: fileHash, FileType: "png", FolderPath: "module-b", MatchLogicalPath: true,
+		})
+		require.NoError(t, err)
+		assert.False(t, exists)
+		assert.Nil(t, knowledge)
+	})
+
+	t.Run("same content with another name in the same folder is not a duplicate", func(t *testing.T) {
+		exists, knowledge, err := repo.CheckKnowledgeExists(ctx, tenantID, kbID, &types.KnowledgeCheckParams{
+			Type: "file", FileName: "logo-copy.png", FileHash: fileHash, FileType: "png", FolderPath: "module-a", MatchLogicalPath: true,
+		})
+		require.NoError(t, err)
+		assert.False(t, exists)
+		assert.Nil(t, knowledge)
+	})
+
+	t.Run("same content at the same logical path remains a duplicate", func(t *testing.T) {
+		exists, knowledge, err := repo.CheckKnowledgeExists(ctx, tenantID, kbID, &types.KnowledgeCheckParams{
+			Type: "file", FileName: "logo.png", FileHash: fileHash, FileType: "png", FolderPath: "module-a", MatchLogicalPath: true,
+		})
+		require.NoError(t, err)
+		assert.True(t, exists)
+		require.NotNil(t, knowledge)
+		assert.Equal(t, "module-a", knowledge.FolderPath)
+	})
+
+	t.Run("ordinary uploads retain content-based duplicate semantics", func(t *testing.T) {
+		exists, knowledge, err := repo.CheckKnowledgeExists(ctx, tenantID, kbID, &types.KnowledgeCheckParams{
+			Type: "file", FileName: "renamed.png", FileHash: fileHash, FileType: "png",
+		})
+		require.NoError(t, err)
+		assert.True(t, exists)
+		require.NotNil(t, knowledge)
+	})
+}

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -21,10 +21,27 @@ import (
 	"github.com/hibiken/asynq"
 )
 
-// CreateKnowledgeFromFile creates a knowledge entry from an uploaded file
+// CreateKnowledgeFromFile creates a knowledge entry from an uploaded file.
+// The regular single-file path always starts processing immediately.
 func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 	kbID string, file *multipart.FileHeader, metadata map[string]string, enableMultimodel *bool, customFileName string, tagIDs []string, channel string,
 	processOverrides *types.KnowledgeProcessOverrides,
+) (*types.Knowledge, error) {
+	return s.createKnowledgeFromFile(ctx, kbID, file, metadata, enableMultimodel, customFileName, tagIDs, channel, processOverrides, types.KnowledgeFileImportOptions{})
+}
+
+// CreateKnowledgeFromFileWithOptions is used by finalized folder uploads.
+// It keeps the existing interface method stable for every non-folder caller.
+func (s *knowledgeService) CreateKnowledgeFromFileWithOptions(ctx context.Context,
+	kbID string, file *multipart.FileHeader, metadata map[string]string, enableMultimodel *bool, customFileName string, tagIDs []string, channel string,
+	processOverrides *types.KnowledgeProcessOverrides, options types.KnowledgeFileImportOptions,
+) (*types.Knowledge, error) {
+	return s.createKnowledgeFromFile(ctx, kbID, file, metadata, enableMultimodel, customFileName, tagIDs, channel, processOverrides, options)
+}
+
+func (s *knowledgeService) createKnowledgeFromFile(ctx context.Context,
+	kbID string, file *multipart.FileHeader, metadata map[string]string, enableMultimodel *bool, customFileName string, tagIDs []string, channel string,
+	processOverrides *types.KnowledgeProcessOverrides, importOptions types.KnowledgeFileImportOptions,
 ) (*types.Knowledge, error) {
 	logger.Info(ctx, "Start creating knowledge from file")
 
@@ -71,8 +88,12 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 	// gates the same extension set, but this path must keep returning
 	// ErrInvalidFileType rather than the shared gate's localized message.
 	logger.Infof(ctx, "Checking file type: %s", fileName)
-	if !isValidFileType(fileName) {
+	if !isValidFileType(fileName) && !importOptions.StoreOnly {
 		logger.Error(ctx, "Invalid file type")
+		return nil, ErrInvalidFileType
+	}
+	if importOptions.StoreOnly && !isAllowedStoreOnlyFileType(fileName) {
+		logger.Error(ctx, "Invalid store-only file type")
 		return nil, ErrInvalidFileType
 	}
 
@@ -88,11 +109,13 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
 	logger.Infof(ctx, "Checking if file exists, tenant ID: %d", tenantID)
 	exists, existingKnowledge, err := s.repo.CheckKnowledgeExists(ctx, tenantID, kbID, &types.KnowledgeCheckParams{
-		Type:     "file",
-		FileName: fileName,
-		FileType: getFileType(fileName),
-		FileSize: file.Size,
-		FileHash: hash,
+		Type:             "file",
+		FileName:         fileName,
+		FolderPath:       folderPath,
+		MatchLogicalPath: importOptions.FolderUpload,
+		FileType:         getFileType(fileName),
+		FileSize:         file.Size,
+		FileHash:         hash,
 	})
 	if err != nil {
 		logger.Errorf(ctx, "Failed to check knowledge existence: %v", err)
@@ -144,9 +167,12 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 		folderPath = types.NormalizeKnowledgeFolderPath(safeFolderPath)
 	}
 
-	eff, err := resolveFileImportProcessConfig(ctx, kb, getFileType(safeFilename), processOverrides, enableMultimodel)
-	if err != nil {
-		return nil, err
+	var eff types.EffectiveProcessConfig
+	if !importOptions.StoreOnly {
+		eff, err = resolveFileImportProcessConfig(ctx, kb, getFileType(safeFilename), processOverrides, enableMultimodel)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Prepare knowledge record
@@ -163,7 +189,7 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 		FileType:         getFileType(safeFilename),
 		FileSize:         file.Size,
 		FileHash:         hash,
-		ParseStatus:      "pending",
+		ParseStatus:      types.ParseStatusPending,
 		EnableStatus:     "disabled",
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
@@ -201,6 +227,16 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 	if err := s.setAndAttachKnowledgeTags(ctx, tenantID, kbID, knowledge, tagIDs); err != nil {
 		logger.Errorf(ctx, "Failed to set knowledge tags, knowledge ID: %s, error: %v", knowledge.ID, err)
 		return nil, err
+	}
+	if importOptions.StoreOnly {
+		knowledge.ParseStatus = types.ParseStatusSkipped
+		if err := s.repo.UpdateKnowledgeColumn(ctx, knowledge.ID, "parse_status", knowledge.ParseStatus); err != nil {
+			return nil, err
+		}
+		return knowledge, nil
+	}
+	if importOptions.DeferProcessing {
+		return knowledge, nil
 	}
 
 	// Enqueue document processing task to Asynq
@@ -275,6 +311,29 @@ func (s *knowledgeService) CreateKnowledgeFromFile(ctx context.Context,
 
 	logger.Infof(ctx, "Knowledge from file created successfully, ID: %s", knowledge.ID)
 	return knowledge, nil
+}
+
+// FinalizeFolderUpload starts processing files that were registered with
+// DeferProcessing. Every supplied ID is re-scoped to the tenant and knowledge
+// base here; callers may only start entries that are still pending.
+func (s *knowledgeService) FinalizeFolderUpload(ctx context.Context, kbID string, knowledgeIDs []string) (started, skipped int, err error) {
+	tenantID := ctx.Value(types.TenantIDContextKey).(uint64)
+	for _, id := range knowledgeIDs {
+		knowledge, getErr := s.repo.GetKnowledgeByID(ctx, tenantID, id)
+		if getErr != nil || knowledge == nil {
+			skipped++
+			continue
+		}
+		if knowledge.KnowledgeBaseID != kbID || knowledge.ParseStatus != types.ParseStatusPending {
+			skipped++
+			continue
+		}
+		if _, reparseErr := s.ReparseKnowledge(ctx, knowledge.ID, nil); reparseErr != nil {
+			return started, skipped, reparseErr
+		}
+		started++
+	}
+	return started, skipped, nil
 }
 
 // CreateKnowledgeFromURL creates a knowledge entry from a URL source

--- a/internal/application/service/knowledge_finalize_folder_test.go
+++ b/internal/application/service/knowledge_finalize_folder_test.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+	"github.com/stretchr/testify/require"
+)
+
+type finalizeFolderRepoStub struct {
+	interfaces.KnowledgeRepository
+	knowledge *types.Knowledge
+}
+
+func (r *finalizeFolderRepoStub) GetKnowledgeByID(_ context.Context, _ uint64, _ string) (*types.Knowledge, error) {
+	return r.knowledge, nil
+}
+
+func TestFinalizeFolderUploadLeavesStoreOnlyAttachmentsSkipped(t *testing.T) {
+	svc := &knowledgeService{repo: &finalizeFolderRepoStub{knowledge: &types.Knowledge{
+		ID: "attachment", KnowledgeBaseID: "kb-1", ParseStatus: types.ParseStatusSkipped,
+	}}}
+	ctx := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+
+	started, skipped, err := svc.FinalizeFolderUpload(ctx, "kb-1", []string{"attachment"})
+	require.NoError(t, err)
+	require.Zero(t, started)
+	require.Equal(t, 1, skipped)
+}

--- a/internal/application/service/knowledge_process.go
+++ b/internal/application/service/knowledge_process.go
@@ -2420,6 +2420,9 @@ func (s *knowledgeService) ReparseKnowledge(
 		logger.Errorf(ctx, "Failed to load knowledge: %v", err)
 		return nil, err
 	}
+	if existing.ParseStatus == types.ParseStatusSkipped {
+		return nil, werrors.NewBadRequestError("仅存储附件不能重新解析")
+	}
 
 	// Allocate a fresh span tree attempt up front. Doing this BEFORE
 	// the cleanup + enqueue means: (a) the UI immediately sees a new
@@ -3225,6 +3228,13 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 		logger.Infof(ctx, "Knowledge cancelled by user, aborting processing: %s", payload.KnowledgeID)
 		return nil
 	}
+	if knowledge.ParseStatus == types.ParseStatusSkipped {
+		// Store-only directory attachments own a resource but deliberately have
+		// no chunks or embeddings. A stale or incorrectly-enqueued task must
+		// never turn them into normal knowledge documents.
+		logger.Infof(ctx, "Knowledge is a store-only attachment, skipping processing: %s", payload.KnowledgeID)
+		return nil
+	}
 
 	// 检查任务状态 - 幂等性处理
 	if knowledge.ParseStatus == types.ParseStatusCompleted {
@@ -3504,7 +3514,6 @@ func (s *knowledgeService) ProcessDocument(ctx context.Context, t *asynq.Task) e
 
 	// Step 2: Store images and update markdown references
 	var storedImages []docparser.StoredImage
-
 	if s.imageResolver != nil && convertResult != nil {
 		fileSvc := s.resolveFileService(ctx, kb)
 		tenantID, _ := ctx.Value(types.TenantIDContextKey).(uint64)

--- a/internal/application/service/knowledge_util.go
+++ b/internal/application/service/knowledge_util.go
@@ -35,6 +35,16 @@ var supportedImportFileExtensions = map[string]struct{}{
 	"mp3": {}, "wav": {}, "m4a": {}, "flac": {}, "ogg": {},
 }
 
+// storeOnlyFileExtensions are non-parser attachments that may be retained by a
+// directory upload for Markdown relative references. This intentionally stays
+// narrow: a folder upload must not silently ingest arbitrary build artifacts,
+// executables, or archives simply because they are adjacent to a document.
+var storeOnlyFileExtensions = map[string]struct{}{
+	"png": {}, "jpg": {}, "jpeg": {}, "gif": {}, "webp": {}, "svg": {},
+	"yaml": {}, "yml": {}, "json": {}, "xml": {},
+	"pdf": {}, "txt": {}, "csv": {},
+}
+
 // dataTableFileExtensions are the spreadsheet formats that get an extra
 // table-summary task after their document-process task.
 var dataTableFileExtensions = map[string]struct{}{
@@ -60,6 +70,11 @@ func isSupportedImportExtension(ext string) bool {
 // isValidFileType checks if a filename's extension is supported for import.
 func isValidFileType(filename string) bool {
 	return isSupportedImportExtension(getFileType(filename))
+}
+
+func isAllowedStoreOnlyFileType(filename string) bool {
+	_, ok := storeOnlyFileExtensions[normalizeFileExtension(getFileType(filename))]
+	return ok
 }
 
 // isDataTableFileType reports whether an extension is a spreadsheet format.

--- a/internal/application/service/knowledge_util_filetype_test.go
+++ b/internal/application/service/knowledge_util_filetype_test.go
@@ -76,3 +76,21 @@ func TestIsDataTableFileType(t *testing.T) {
 		}
 	}
 }
+
+func TestIsAllowedStoreOnlyFileType(t *testing.T) {
+	for _, tt := range []struct {
+		filename string
+		want     bool
+	}{
+		{"image.webp", true},
+		{"diagram.SVG", true},
+		{"schema.yaml", true},
+		{"archive.zip", false},
+		{"program.exe", false},
+		{"no-extension", false},
+	} {
+		if got := isAllowedStoreOnlyFileType(tt.filename); got != tt.want {
+			t.Errorf("isAllowedStoreOnlyFileType(%q) = %v, want %v", tt.filename, got, tt.want)
+		}
+	}
+}

--- a/internal/handler/knowledge.go
+++ b/internal/handler/knowledge.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"mime/multipart"
 	"net/http"
 	"strconv"
 	"strings"
@@ -420,8 +421,48 @@ func (h *KnowledgeHandler) CreateKnowledgeFromFile(c *gin.Context) {
 
 	channel := c.PostForm("channel")
 
-	// Create knowledge entry from the file
-	knowledge, err := h.kgService.CreateKnowledgeFromFile(ctx, kbID, file, metadata, enableMultimodel, customFileName, tagIDs, channel, processOverrides)
+	importOptions := types.KnowledgeFileImportOptions{}
+	for _, field := range []struct {
+		name string
+		set  *bool
+	}{
+		{"folder_upload", &importOptions.FolderUpload},
+		{"defer_processing", &importOptions.DeferProcessing},
+		{"store_only", &importOptions.StoreOnly},
+	} {
+		if raw := c.PostForm(field.name); raw != "" {
+			value, parseErr := strconv.ParseBool(raw)
+			if parseErr != nil {
+				c.Error(errors.NewBadRequestError("Invalid " + field.name + " format"))
+				return
+			}
+			*field.set = value
+		}
+	}
+	if (importOptions.DeferProcessing || importOptions.StoreOnly) && !importOptions.FolderUpload {
+		c.Error(errors.NewBadRequestError("defer_processing and store_only require folder_upload"))
+		return
+	}
+	if importOptions.StoreOnly {
+		importOptions.DeferProcessing = true
+	}
+
+	// Create knowledge entry from the file. The extended method is optional on
+	// the service interface so existing non-folder callers and narrow test
+	// doubles remain source-compatible.
+	var knowledge *types.Knowledge
+	if importOptions.DeferProcessing || importOptions.StoreOnly {
+		creator, ok := h.kgService.(interface {
+			CreateKnowledgeFromFileWithOptions(context.Context, string, *multipart.FileHeader, map[string]string, *bool, string, []string, string, *types.KnowledgeProcessOverrides, types.KnowledgeFileImportOptions) (*types.Knowledge, error)
+		})
+		if !ok {
+			c.Error(errors.NewInternalServerError("Folder upload is not supported by this knowledge service"))
+			return
+		}
+		knowledge, err = creator.CreateKnowledgeFromFileWithOptions(ctx, kbID, file, metadata, enableMultimodel, customFileName, tagIDs, channel, processOverrides, importOptions)
+	} else {
+		knowledge, err = h.kgService.CreateKnowledgeFromFile(ctx, kbID, file, metadata, enableMultimodel, customFileName, tagIDs, channel, processOverrides)
+	}
 	// Check for duplicate knowledge error
 	if err != nil {
 		if h.handleDuplicateKnowledgeError(c, err, knowledge, "file") {
@@ -446,6 +487,43 @@ func (h *KnowledgeHandler) CreateKnowledgeFromFile(c *gin.Context) {
 		"success": true,
 		"data":    knowledge,
 	})
+}
+
+// FinalizeFolderUpload starts parsing the successfully registered documents of
+// one directory upload. Attachments stored with store_only stay skipped.
+func (h *KnowledgeHandler) FinalizeFolderUpload(c *gin.Context) {
+	ctx := c.Request.Context()
+	_, kbID, effectiveTenantID, permission, err := h.validateKnowledgeBaseAccess(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	if permission != types.OrgRoleAdmin && permission != types.OrgRoleEditor {
+		c.Error(errors.NewForbiddenError("No permission to finalize folder upload"))
+		return
+	}
+	ctx = context.WithValue(ctx, types.TenantIDContextKey, effectiveTenantID)
+
+	var request struct {
+		KnowledgeIDs []string `json:"knowledge_ids" binding:"required,max=1000"`
+	}
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(errors.NewBadRequestError("Invalid folder upload finalize request").WithDetails(err.Error()))
+		return
+	}
+	finalizer, ok := h.kgService.(interface {
+		FinalizeFolderUpload(context.Context, string, []string) (int, int, error)
+	})
+	if !ok {
+		c.Error(errors.NewInternalServerError("Folder upload is not supported by this knowledge service"))
+		return
+	}
+	started, skipped, err := finalizer.FinalizeFolderUpload(ctx, kbID, request.KnowledgeIDs)
+	if err != nil {
+		c.Error(errors.NewInternalServerError("Failed to finalize folder upload").WithDetails(err.Error()))
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": gin.H{"started": started, "skipped": skipped}})
 }
 
 // CreateKnowledgeFromURL godoc

--- a/internal/router/routes_knowledge.go
+++ b/internal/router/routes_knowledge.go
@@ -71,6 +71,7 @@ func RegisterKnowledgeRoutes(r *gin.RouterGroup, handler *handler.KnowledgeHandl
 	kbRead := kb.With(apiKeyRetrieve(apiKeyFullAccess()))
 	{
 		kb.POST("/file", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.CreateKnowledgeFromFile)
+		kb.POST("/folder/finalize", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.FinalizeFolderUpload)
 		kb.POST("/url", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.CreateKnowledgeFromURL)
 		kb.POST("/manual", g.OwnedKBOrAdmin(), g.KBAccessWrite("id"), handler.CreateManualKnowledge)
 		kbRead.GET("", g.Viewer(), g.KBAccessRead("id"), handler.ListKnowledge)

--- a/internal/types/knowledge.go
+++ b/internal/types/knowledge.go
@@ -67,6 +67,10 @@ const (
 	// queued downstream tasks, but the knowledge row and any already-written
 	// chunks/index are kept so the user can re-trigger parsing via reparse.
 	ParseStatusCancelled = "cancelled"
+	// ParseStatusSkipped indicates a file that is deliberately stored for
+	// reference only. It has a source resource but must never enter the
+	// document parsing, chunking, or embedding pipeline.
+	ParseStatusSkipped = "skipped"
 )
 
 // Summary status constants for async summary generation
@@ -464,6 +468,12 @@ func (k *Knowledge) SetProcessOverrides(o *KnowledgeProcessOverrides) error {
 type KnowledgeCheckParams struct {
 	// File parameters
 	FileName string
+	// FolderPath scopes file deduplication for directory uploads. An empty
+	// value is the knowledge-base root folder.
+	FolderPath string
+	// MatchLogicalPath opts into folder-upload duplicate semantics. Ordinary
+	// uploads continue to deduplicate by content as they did before folders.
+	MatchLogicalPath bool
 	// FileType scopes file-hash deduplication; callers checking file uploads should set it.
 	FileType string
 	FileSize int64

--- a/internal/types/knowledge_file_import.go
+++ b/internal/types/knowledge_file_import.go
@@ -1,0 +1,19 @@
+package types
+
+// KnowledgeFileImportOptions controls ingestion behaviour for a file upload.
+// It is intentionally separate from KnowledgeProcessOverrides: these options
+// decide whether a file enters the pipeline at all, rather than how it is
+// parsed once queued.
+type KnowledgeFileImportOptions struct {
+	// FolderUpload marks the directory-upload flow. It scopes duplicate checks
+	// by the full logical path, while ordinary file uploads keep their historic
+	// content-based duplicate semantics.
+	FolderUpload bool
+	// DeferProcessing persists a parseable file as pending without enqueueing
+	// it. Folder upload finalization uses this to register every sibling before
+	// any Markdown reference is resolved.
+	DeferProcessing bool
+	// StoreOnly persists an attachment and its resource handle, but never
+	// parses, chunks, or embeds it.
+	StoreOnly bool
+}


### PR DESCRIPTION
## Summary
- Register directory-upload files before processing, then finalize parseable entries in bounded batches.
- Keep non-parser attachments as store-only resources with a narrow allowlist.
- Scope duplicate matching by logical path only for directory uploads.

## Validation
- Go tests cover folder duplicate scope, store-only filtering, and finalize behavior.
- Frontend tests cover parser-engine loading fallback and 1,000-ID finalize batching.
- Frontend type check passes.
