### PR TITLE
fix: 修复含 NUL 字节的回答落库失败（22P05）导致消息永久丢失

### DIFF
--- a/internal/application/repository/message.go
+++ b/internal/application/repository/message.go
@@ -1,8 +1,11 @@
 package repository
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"slices"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -126,9 +129,53 @@ func (r *messageRepository) ListMessagesBySessionAfterTime(
 
 // UpdateMessage updates an existing message
 func (r *messageRepository) UpdateMessage(ctx context.Context, message *types.Message) error {
-	return r.db.WithContext(ctx).Model(&types.Message{}).Where(
+	err := r.db.WithContext(ctx).Model(&types.Message{}).Where(
 		"id = ? AND session_id = ?", message.ID, message.SessionID,
 	).Updates(message).Error
+	if err != nil && isUnsupportedUnicodeEscape(err) {
+		// jsonb columns reject the six-char NUL escape sequence that Go's json.Marshal emits
+		// for NUL bytes carried in from binary content (e.g. raw PDF bytes
+		// fetched by web search). Strip them and retry once so a completed
+		// answer is never lost to a dirty reference payload.
+		stripNulFromMessage(message)
+		return r.db.WithContext(ctx).Model(&types.Message{}).Where(
+			"id = ? AND session_id = ?", message.ID, message.SessionID,
+		).Updates(message).Error
+	}
+	return err
+}
+
+// isUnsupportedUnicodeEscape reports whether err is PostgreSQL's SQLSTATE
+// 22P05 (unsupported Unicode escape sequence), raised when a jsonb value
+// contains the escaped NUL code point.
+func isUnsupportedUnicodeEscape(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "22P05") || strings.Contains(msg, "unsupported Unicode escape sequence")
+}
+
+var nulEscape = []byte{'\\', 'u', '0', '0', '0', '0'}
+
+// stripNulFromMessage removes NUL bytes (serialized as escapes) from
+// every jsonb-bound field plus the text columns, so a retried update can pass
+// PostgreSQL's jsonb validation.
+func stripNulFromMessage(message *types.Message) {
+	for _, field := range []any{
+		&message.KnowledgeReferences,
+		&message.AgentSteps,
+		&message.MentionedItems,
+		&message.Images,
+		&message.Attachments,
+		&message.Artifacts,
+		&message.Usage,
+	} {
+		data, err := json.Marshal(field)
+		if err != nil || !bytes.Contains(data, nulEscape) {
+			continue
+		}
+		_ = json.Unmarshal(bytes.ReplaceAll(data, nulEscape, nil), field)
+	}
+	message.Content = strings.ReplaceAll(message.Content, "\x00", "")
+	message.RenderedContent = strings.ReplaceAll(message.RenderedContent, "\x00", "")
 }
 
 // DeleteMessage deletes a message

--- a/internal/infrastructure/web_fetch/fetcher.go
+++ b/internal/infrastructure/web_fetch/fetcher.go
@@ -441,6 +441,10 @@ func newFetchError(code ErrorCode, retryable bool, format string, args ...interf
 }
 
 func htmlToText(html string) (string, error) {
+	// Binary responses served as text/html (e.g. PDFs) leak raw bytes,
+	// including NUL, into the extracted text. NUL later breaks jsonb
+	// persistence (SQLSTATE 22P05), so drop it before parsing.
+	html = strings.ReplaceAll(html, "\x00", "")
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
 	if err != nil {
 		fallback := stripTags(html)


### PR DESCRIPTION
## 问题现象

开启 web 搜索的问答中，若搜索命中 PDF 等二进制资源，回答在页面上正常流式生成完毕，但刷新页面后该条回答变为空白并报错 `Stream connection failed: Error: HTTP 404`。实测某生产会话中 8 轮 web 搜索问答有 4 轮因此丢失。

## 根因

1. web 抓取将二进制响应体（如 PDF，Content-Type 为 text/html 或解析宽容）当 HTML 提取文本，原始字节（含 NUL）混入正文，随检索引用进入 `knowledge_references` 等 jsonb 字段；
2. Go `json.Marshal` 将 NUL 字节序列化为六字符转义序列，PostgreSQL jsonb 拒绝该转义（SQLSTATE 22P05），`UpdateMessage` 整条 UPDATE 失败且无重试；
3. 消息停留在占位状态（`is_completed=false`、`content=''`）。前端进入会话时对未完成的最后一条消息自动发起 continue-stream，流事件在 Redis 过期后返回 404，回答内容永久不可见。

## 修复

- **源头清洗**（`internal/infrastructure/web_fetch/fetcher.go`）：`htmlToText` 入口移除 NUL 字节。chat pipeline 与 agent web_fetch 共用该出口，一并覆盖；
- **写入兜底**（`internal/application/repository/message.go`）：`UpdateMessage` 失败且匹配 22P05 错误签名时，对全部 jsonb 绑定字段及 text 列清除 NUL 后重试一次，保证回答不因脏引用丢失。正常路径零开销（仅在失败后触发）。

## 说明

- 用户故意输入的形似转义序列的字面文本经 Go 序列化后反斜杠会被转义，不会被误删；
- 清洗仅移除 NUL，幂等，已验证干净数据二次清洗不变；
- 兜底同时覆盖 KB 文档解析、第三方搜索 provider 等其他可能引入 NUL 的路径。
