### PR TITLE
fix(preview): lazy-load markdown images without dropping data URIs

### DIFF
--- a/frontend/src/components/document-preview.vue
+++ b/frontend/src/components/document-preview.vue
@@ -6,10 +6,10 @@ import { previewTemporaryAttachment } from '@/api/chat/temporary-attachments';
 import { downloadArtifact } from '@/api/chat';
 import hljs from 'highlight.js';
 import 'highlight.js/styles/github.css';
-import markedKatex from 'marked-katex-extension';
 import 'katex/dist/katex.min.css';
 import { useI18n } from 'vue-i18n';
-import { sanitizeHTML, sanitizeMarkdownHTML, safeMarkdownToHTML } from '@/utils/security';
+import { sanitizeHTML, sanitizeMarkdownHTML } from '@/utils/security';
+import { renderDocumentPreviewMarkdown } from '@/utils/documentPreviewMarkdown';
 import { openMermaidFullscreen } from '@/utils/mermaidViewer';
 import { renderMermaidToSvg } from '@/utils/mermaidShared';
 import {
@@ -80,15 +80,6 @@ function ensureBlobType(blob: Blob, ft: string): Blob {
 function getHighlightLang(ft: string): string {
   return resolveHighlightLang(ft);
 }
-
-const preprocessMathDelimiters = (rawText: string): string => {
-  if (!rawText || typeof rawText !== 'string') {
-    return '';
-  }
-  return rawText
-    .replace(/\\\[([\s\S]*?)\\\]/g, '$$$$$1$$$$')
-    .replace(/\\\(([\s\S]*?)\\\)/g, '$$$1$$');
-};
 
 async function renderDocx(blob: Blob) {
   const { renderAsync } = await import('docx-preview');
@@ -169,7 +160,6 @@ async function renderText(blob: Blob, fileType: string) {
 }
 
 async function renderMarkdown(blob: Blob) {
-  const { marked } = await import('marked');
   const text = await blob.text();
 
   // 校验文本内容是否有效
@@ -178,33 +168,7 @@ async function renderMarkdown(blob: Blob) {
     return;
   }
 
-  marked.use({
-    breaks: true,
-    gfm: true,
-  });
-  marked.use(markedKatex({ throwOnError: false, nonStandard: true }));
-  const renderer = new marked.Renderer();
-  renderer.code = function ({text, lang}) {
-    // 空值校验：防止 text 为 undefined 或 null
-    if (!text || typeof text !== 'string') {
-      text = '';
-    }
-
-    let highlighted = '';
-    if (lang && hljs.getLanguage(lang)) {
-      try { highlighted = hljs.highlight(text, { language: lang }).value; }
-      catch { highlighted = hljs.highlightAuto(text).value; }
-    } else {
-      highlighted = hljs.highlightAuto(text).value;
-    }
-    return `<pre><code class="hljs">${highlighted}</code></pre>`;
-  };
-  const mathSafeText = preprocessMathDelimiters(text);
-  const safeText = safeMarkdownToHTML(mathSafeText);
-  // Keep this renderer local. `marked.use` mutates a shared singleton and
-  // would otherwise inherit renderers installed by the chunk-content view.
-  const rawHtml = marked.parse(safeText, { renderer }) as string;
-  markdownHtml.value = sanitizeHTML(rawHtml);
+  markdownHtml.value = renderDocumentPreviewMarkdown(text);
 }
 
 function onImageLoad(e: Event) {

--- a/frontend/src/utils/documentPreviewMarkdown.test.ts
+++ b/frontend/src/utils/documentPreviewMarkdown.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  isSafePreviewImageHref,
+  renderDocumentPreviewMarkdown,
+} from './documentPreviewMarkdown.ts'
+import { applyDocumentPreviewImageAttributes } from './security.ts'
+
+test('preview Markdown keeps native lazy image attributes', () => {
+  const html = renderDocumentPreviewMarkdown('![test](https://example.com/test.png)', value => value)
+
+  assert.match(html, /src="https:\/\/example.com\/test.png"/)
+  assert.match(html, /loading="lazy"/)
+  assert.match(html, /decoding="async"/)
+  assert.match(html, /fetchpriority="low"/)
+})
+
+test('preview Markdown keeps data URI images used by document parsers', () => {
+  const html = renderDocumentPreviewMarkdown(
+    '![chart](data:image/png;base64,AAAA)',
+    value => value,
+  )
+
+  assert.match(html, /src="data:image\/png;base64,AAAA"/)
+  assert.match(html, /loading="lazy"/)
+})
+
+test('preview Markdown keeps relative and protocol-relative images', () => {
+  const relative = renderDocumentPreviewMarkdown('![rel](images/a.png)', value => value)
+  const protocolRelative = renderDocumentPreviewMarkdown(
+    '![cdn](//cdn.example.com/a.png)',
+    value => value,
+  )
+
+  assert.match(relative, /src="images\/a.png"/)
+  assert.match(protocolRelative, /src="\/\/cdn.example.com\/a.png"/)
+})
+
+test('preview Markdown drops javascript image URLs', () => {
+  const html = renderDocumentPreviewMarkdown('![x](javascript:alert(1))', value => value)
+
+  assert.doesNotMatch(html, /javascript:/i)
+  assert.doesNotMatch(html, /<img/i)
+})
+
+test('isSafePreviewImageHref matches the shared DOMPurify image URI policy', () => {
+  assert.equal(isSafePreviewImageHref('https://example.com/a.png'), true)
+  assert.equal(isSafePreviewImageHref('data:image/png;base64,AAAA'), true)
+  assert.equal(isSafePreviewImageHref('resource://AbCdEfGhIjKlMnOpQrStUv'), true)
+  assert.equal(isSafePreviewImageHref('/files/a.png'), true)
+  assert.equal(isSafePreviewImageHref('images/a.png'), true)
+  assert.equal(isSafePreviewImageHref('//cdn.example.com/a.png'), true)
+  assert.equal(isSafePreviewImageHref('javascript:alert(1)'), false)
+  assert.equal(isSafePreviewImageHref('data:text/html,<script>alert(1)</script>'), false)
+  assert.equal(isSafePreviewImageHref('#fragment'), false)
+})
+
+test('preview Markdown keeps the marked-katex extension when using an image renderer', () => {
+  const html = renderDocumentPreviewMarkdown('公式 $E = mc^2$', value => value)
+
+  assert.match(html, /katex/)
+})
+
+test('preview Markdown skips highlightAuto on huge unlabeled fences', () => {
+  const source = 'a'.repeat(40_000)
+  const html = renderDocumentPreviewMarkdown('```\n' + source + '\n```', value => value)
+
+  assert.match(html, /<pre><code class="hljs">/)
+  assert.equal(html.includes(`>${source}<`), true)
+  assert.doesNotMatch(html, /hljs-/)
+})
+
+test('raw HTML images cannot override preview loading attributes', () => {
+  const attributes = new Map([
+    ['alt', 'score > 90'],
+    ['title', 'A > B'],
+    ['loading', 'eager'],
+    ['fetchpriority', 'high'],
+  ])
+  const image = {
+    tagName: 'IMG',
+    setAttribute: (name: string, value: string) => attributes.set(name, value),
+  }
+  applyDocumentPreviewImageAttributes(image as unknown as Node)
+  assert.equal(attributes.get('alt'), 'score > 90')
+  assert.equal(attributes.get('title'), 'A > B')
+  assert.equal(attributes.get('loading'), 'lazy')
+  assert.equal(attributes.get('decoding'), 'async')
+  assert.equal(attributes.get('fetchpriority'), 'low')
+})

--- a/frontend/src/utils/documentPreviewMarkdown.ts
+++ b/frontend/src/utils/documentPreviewMarkdown.ts
@@ -1,0 +1,67 @@
+import hljs from 'highlight.js'
+import { Marked, Renderer } from 'marked'
+import markedKatex from 'marked-katex-extension'
+
+import { domPurifyAllowedUriRegexp } from './markdownDomPurify.ts'
+import { escapeHTML, safeMarkdownToHTML, sanitizeDocumentPreviewHTML } from './security.ts'
+
+const PREVIEW_IMAGE_ATTRIBUTES = 'loading="lazy" decoding="async" fetchpriority="low"'
+const HIGHLIGHT_AUTO_MAX_CHARS = 32_768
+
+export function isSafePreviewImageHref(href: unknown): href is string {
+  if (typeof href !== 'string') return false
+  const trimmed = href.trim()
+  if (!trimmed || trimmed.startsWith('#')) return false
+  return domPurifyAllowedUriRegexp.test(trimmed)
+}
+
+function highlightPreviewCode(source: string, lang?: string): string {
+  if (lang && hljs.getLanguage(lang)) {
+    try {
+      return hljs.highlight(source, { language: lang }).value
+    } catch {
+      // Fall through to auto-detect or plain text.
+    }
+  }
+  if (source.length > HIGHLIGHT_AUTO_MAX_CHARS) {
+    return escapeHTML(source)
+  }
+  return hljs.highlightAuto(source).value
+}
+
+function createPreviewMarkdownRenderer(): Renderer {
+  const renderer = new Renderer()
+  renderer.image = ({ href, title, text }) => {
+    if (!isSafePreviewImageHref(href)) return ''
+    const safeHref = href.trim().replace(/"/g, '&quot;')
+    const safeTitle = title ? ` title="${escapeHTML(title)}"` : ''
+    return `<img src="${safeHref}" alt="${escapeHTML(text || '')}"${safeTitle} class="markdown-image" ${PREVIEW_IMAGE_ATTRIBUTES}>`
+  }
+  renderer.code = ({ text, lang }) => {
+    const source = typeof text === 'string' ? text : ''
+    return `<pre><code class="hljs">${highlightPreviewCode(source, lang)}</code></pre>`
+  }
+  return renderer
+}
+
+const previewMarked = new Marked({
+  breaks: true,
+  gfm: true,
+  renderer: createPreviewMarkdownRenderer(),
+})
+previewMarked.use(markedKatex({ throwOnError: false, nonStandard: true }))
+
+function preprocessMathDelimiters(rawText: string): string {
+  if (!rawText || typeof rawText !== 'string') return ''
+  return rawText
+    .replace(/\\\[([\s\S]*?)\\\]/g, '$$$$$1$$$$')
+    .replace(/\\\(([\s\S]*?)\\\)/g, '$$$1$$')
+}
+
+export function renderDocumentPreviewMarkdown(
+  markdown: string,
+  sanitize: (html: string) => string = sanitizeDocumentPreviewHTML,
+): string {
+  const mathSafe = preprocessMathDelimiters(markdown)
+  return sanitize(previewMarked.parse(safeMarkdownToHTML(mathSafe)) as string)
+}

--- a/frontend/src/utils/security.ts
+++ b/frontend/src/utils/security.ts
@@ -35,6 +35,8 @@ type SecurityHooks = {
   afterSanitizeElements: NodeHook;
 };
 
+const DOCUMENT_PREVIEW_IMAGE_ATTRS = ['loading', 'decoding', 'fetchpriority'] as const;
+
 function sanitizeWithSecurityHooks(
   html: string,
   config: Config,
@@ -114,6 +116,47 @@ export function sanitizeHTML(html: string): string {
   } catch (error) {
     console.error('HTML sanitization failed:', error);
     // 如果清理失败，返回转义的纯文本
+    return escapeHTML(html);
+  }
+}
+
+export function applyDocumentPreviewImageAttributes(currentNode: Node): void {
+  if (!('tagName' in currentNode) || !('setAttribute' in currentNode)) return;
+  const element = currentNode as Element;
+  if (element.tagName !== 'IMG') return;
+  element.setAttribute('loading', 'lazy');
+  element.setAttribute('decoding', 'async');
+  element.setAttribute('fetchpriority', 'low');
+}
+
+const documentPreviewDomPurifyConfig = {
+  ...DOMPurifyConfig,
+  ADD_ATTR: [...DOCUMENT_PREVIEW_IMAGE_ATTRS],
+};
+
+const documentPreviewSecurityHooks: SecurityHooks = {
+  beforeSanitizeElements: domPurifySecurityHooks.beforeSanitizeElements,
+  afterSanitizeElements: (currentNode) => {
+    domPurifySecurityHooks.afterSanitizeElements(currentNode);
+    applyDocumentPreviewImageAttributes(currentNode);
+  },
+};
+
+/** Sanitize DocumentPreview Markdown and enforce a single image loading policy. */
+export function sanitizeDocumentPreviewHTML(html: string): string {
+  if (!html || typeof html !== 'string') {
+    return '';
+  }
+
+  try {
+    const preparedHTML = protectProviderImageSrcInHTML(html);
+    return sanitizeWithSecurityHooks(
+      preparedHTML,
+      documentPreviewDomPurifyConfig as unknown as Config,
+      documentPreviewSecurityHooks,
+    );
+  } catch (error) {
+    console.error('Document preview HTML sanitization failed:', error);
     return escapeHTML(html);
   }
 }


### PR DESCRIPTION
## Summary
- Keep large Markdown previews as a single document, but load images with native `loading="lazy"`, `decoding="async"`, and `fetchpriority="low"`.
- Use a dedicated `Marked` instance plus a preview-only sanitizer, so chat renderers are not mutated and shared `sanitizeHTML` allowlists are not widened.
- Allow `data:image/*`, relative, protocol-relative, and provider URLs that already pass DOMPurify; still drop `javascript:` and other unsafe schemes.
- Skip `highlightAuto` on unlabeled fences larger than 32KB so huge code dumps do not freeze the preview thread.

This is an alternative to #2999: that approach rejected every explicit scheme that failed `isValidImageURL()`, which would hide `![alt](data:image/...;base64,...)` images emitted by document parsers.

## Test plan
- [ ] Open a Markdown file with remote images and confirm below-the-fold images do not all fetch immediately.
- [ ] Preview a `.md` that uses `![alt](data:image/png;base64,...)` and confirm the image still renders.
- [ ] Preview Markdown with `$E = mc^2$` and confirm KaTeX still renders.
- [ ] `cd frontend && npx tsx --test src/utils/documentPreviewMarkdown.test.ts`
- [ ] `cd frontend && npm test && npm run type-check`