### PR TITLE
fix(wiki): keep folder names that look like page-type labels when placing pages

### DIFF
--- a/internal/application/repository/wiki_page.go
+++ b/internal/application/repository/wiki_page.go
@@ -365,16 +365,18 @@ func (r *wikiPageRepository) List(ctx context.Context, req *types.WikiPageListRe
 	// Directory filters are pushed to SQL so the DB does the counting and
 	// pagination instead of loading every page of the type into memory. `depth`
 	// is a cached column (= len(category_path)); `category_path` is a JSON column
-	// whose stored text is json.Marshal of the cleaned path, so we compare
-	// against the same encoding. Postgres needs an explicit jsonb cast for array
-	// equality; SQLite stores JSON as TEXT and compares directly.
+	// whose stored text is json.Marshal of the folder path segments, so we
+	// compare against the same encoding (literal segments, since the filter is a
+	// folder path and folder names are authoritative). Postgres needs an explicit
+	// jsonb cast for array equality; SQLite stores JSON as TEXT and compares
+	// directly.
 	if req.FolderID != nil {
 		query = query.Where("folder_id = ?", *req.FolderID)
 	}
 	if req.CategoryDepth != nil {
 		query = query.Where("depth = ?", *req.CategoryDepth)
 	}
-	if wantPath := types.CleanWikiCategoryPath(req.CategoryPath); len(wantPath) > 0 {
+	if wantPath := types.TrimWikiFolderSegments(req.CategoryPath); len(wantPath) > 0 {
 		if encoded, err := json.Marshal([]string(wantPath)); err == nil {
 			if r.db.Dialector != nil && r.db.Dialector.Name() == "postgres" {
 				query = query.Where("category_path::jsonb = ?::jsonb", string(encoded))

--- a/internal/application/service/wiki_page.go
+++ b/internal/application/service/wiki_page.go
@@ -1281,7 +1281,16 @@ func normalizeWikiHierarchy(page *types.WikiPage) {
 	}
 	page.ParentSlug = strings.TrimSpace(page.ParentSlug)
 
-	cleanPath := types.StringArray(types.CleanWikiCategoryPath(page.CategoryPath))
+	// A page filed in a folder mirrors the folder tree exactly: its
+	// category_path was derived from the validated folder path, so the
+	// model-noise cleaning (which drops type-like labels such as "概念") must
+	// not rewrite it. Only pages without a folder carry model-authored labels.
+	var cleanPath types.StringArray
+	if strings.TrimSpace(page.FolderID) != "" {
+		cleanPath = types.StringArray(types.TrimWikiFolderSegments(page.CategoryPath))
+	} else {
+		cleanPath = types.StringArray(types.CleanWikiCategoryPath(page.CategoryPath))
+	}
 	page.CategoryPath = cleanPath
 	page.Depth = len(cleanPath)
 
@@ -1366,13 +1375,12 @@ func (s *wikiPageService) UpdateIssueStatus(ctx context.Context, issueID string,
 
 // --- Folder tree (wiki_folders) ---
 
-// wikiFolderSegments splits a materialized folder path ("AI/RAG") into cleaned
-// segments. Empty/blank path yields nil (the wiki root).
+// wikiFolderSegments splits a materialized folder path ("AI/RAG") into its
+// literal segments. Empty/blank path yields nil (the wiki root). Folder names
+// are authoritative, so a folder named like a page type ("概念", "Concepts")
+// is kept rather than dropped as model noise.
 func wikiFolderSegments(path string) []string {
-	if strings.TrimSpace(path) == "" {
-		return nil
-	}
-	return types.CleanWikiCategoryPath(strings.Split(path, "/"))
+	return types.WikiFolderPathSegments(path)
 }
 
 // applyFolderToPage refreshes a page's derived category_path cache from its

--- a/internal/application/service/wiki_page_test.go
+++ b/internal/application/service/wiki_page_test.go
@@ -646,3 +646,63 @@ func TestFindPagesByNormalizedTitleMatchesWhitespace(t *testing.T) {
 	slugs := []string{batched[0].Slug, batched[1].Slug}
 	require.ElementsMatch(t, []string{"entity/confucius", "entity/mencius"}, slugs)
 }
+
+func TestNormalizeWikiHierarchyKeepsFolderBackedPathVerbatim(t *testing.T) {
+	page := &types.WikiPage{
+		Slug:         "concept/plan",
+		Title:        "将计就计",
+		PageType:     types.WikiPageTypeConcept,
+		FolderID:     "folder-concepts",
+		CategoryPath: types.StringArray{"概念", " 概念 ", "Concepts", ""},
+	}
+
+	normalizeWikiHierarchy(page)
+
+	want := types.StringArray{"概念", "概念", "Concepts"}
+	require.Equal(t, want, page.CategoryPath)
+	require.Equal(t, 3, page.Depth)
+	require.Equal(t, "concept/概念/概念/Concepts/将计就计", page.WikiPath)
+}
+
+func TestMovePageIntoTypeLabelNamedFolderKeepsHierarchy(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&types.WikiFolder{}, &types.WikiPage{}, &types.WikiPageRevision{}))
+
+	ctx := context.Background()
+	repo := repository.NewWikiPageRepository(db)
+	svc := NewWikiPageService(repo, nil, nil, nil, nil)
+	now := time.Now()
+
+	folder, err := svc.CreateFolder(ctx, "kb-move", 1, types.WikiFolderRootID, "概念")
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, &types.WikiPage{
+		ID: "page-plan", TenantID: 1, KnowledgeBaseID: "kb-move", Slug: "concept/plan",
+		Title: "将计就计", PageType: types.WikiPageTypeConcept, Status: types.WikiPageStatusPublished,
+		Version: 1, CreatedAt: now, UpdatedAt: now,
+	}))
+
+	moved, err := svc.MovePage(ctx, "kb-move", "concept/plan", folder.ID)
+	require.NoError(t, err)
+	require.Equal(t, folder.ID, moved.FolderID)
+
+	stored, err := repo.GetBySlug(ctx, "kb-move", "concept/plan")
+	require.NoError(t, err)
+	require.Equal(t, folder.ID, stored.FolderID)
+	require.Equal(t, types.StringArray{"概念"}, stored.CategoryPath)
+	require.Equal(t, 1, stored.Depth)
+	require.Equal(t, "concept/概念/将计就计", stored.WikiPath)
+
+	// Reading the page back through ListPages must not strip the folder name
+	// either: the directory tree places pages by these fields.
+	folderID := folder.ID
+	listed, err := svc.ListPages(ctx, &types.WikiPageListRequest{
+		KnowledgeBaseID: "kb-move",
+		FolderID:        &folderID,
+	})
+	require.NoError(t, err)
+	require.Len(t, listed.Pages, 1)
+	require.Equal(t, types.StringArray{"概念"}, listed.Pages[0].CategoryPath)
+	require.Equal(t, 1, listed.Pages[0].Depth)
+	require.Equal(t, "concept/概念/将计就计", listed.Pages[0].WikiPath)
+}

--- a/internal/types/wiki_page.go
+++ b/internal/types/wiki_page.go
@@ -63,6 +63,30 @@ func CleanWikiCategoryPath(parts []string) []string {
 	return cleaned
 }
 
+// TrimWikiFolderSegments keeps folder path segments verbatim, dropping only
+// blank entries. Folder names are validated on creation (no separators), and
+// the folder tree is the source of truth for a page's placement, so unlike
+// CleanWikiCategoryPath no page-type filtering, deduplication, or depth cap
+// applies: a user may legitimately name a folder "概念" or "Concepts".
+func TrimWikiFolderSegments(parts []string) []string {
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+// WikiFolderPathSegments splits a materialized folder path ("AI/RAG") into its
+// literal segments. An empty/blank path yields nil (the wiki root).
+func WikiFolderPathSegments(path string) []string {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	return TrimWikiFolderSegments(strings.Split(path, "/"))
+}
+
 // SplitWikiPageTypes parses a page_type value that may carry several
 // comma-separated types (e.g. "entity,concept") into a deduplicated slice,
 // dropping blanks. An empty/whitespace-only input yields nil ("no filter").

--- a/internal/types/wiki_page_test.go
+++ b/internal/types/wiki_page_test.go
@@ -309,3 +309,24 @@ func TestWikiConfig_JSONRoundTrip_WithGranularity(t *testing.T) {
 		t.Errorf("legacy row should normalize to standard")
 	}
 }
+
+func TestWikiFolderPathSegmentsKeepTypeLikeFolderNames(t *testing.T) {
+	got := WikiFolderPathSegments("概念/ 概念 /Concepts//实体")
+	want := []string{"概念", "概念", "Concepts", "实体"}
+	if len(got) != len(want) {
+		t.Fatalf("segments = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("segments[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if WikiFolderPathSegments("  ") != nil {
+		t.Fatalf("blank path must yield nil")
+	}
+	// The model-label cleaner still drops the same names, which is why folder
+	// paths must not go through it.
+	if cleaned := CleanWikiCategoryPath([]string{"概念"}); len(cleaned) != 0 {
+		t.Fatalf("CleanWikiCategoryPath(概念) = %v, want empty", cleaned)
+	}
+}


### PR DESCRIPTION
## Description

Moving a wiki page into a user-created folder named like a page type (`概念`, `实体`, `Concepts`, `摘要`, ...) only persisted `folder_id`; `category_path` came back empty, `depth` stayed `0`, and `wiki_path` lost the folder segment, so the directory tree kept rendering the page at the root (#3053).

**Root cause.** `applyFolderToPage()` derived `category_path` from the folder's materialized path through `types.CleanWikiCategoryPath()`, which is the cleaner for *model-authored* category labels and deliberately drops type-like labels (`isWikiTypeCategoryLabel`). `normalizeWikiHierarchy()` ran the same cleaner again on every write and on every `ListPages` read. A folder named `概念` therefore produced `category_path = []`, `depth = 0`, `wiki_path = concept/<title>`, exactly the rows quoted in the issue. `RenameOrMoveFolder` computed descendant folder depth through the same helper, and the directory listing's `category_path` filter was cleaned the same way, so such a folder could not be filtered on either.

**Fix.** Folder names are validated on creation (no separators) and the folder tree is the source of truth, so folder-derived paths are now kept verbatim:

- `types.TrimWikiFolderSegments` / `types.WikiFolderPathSegments`: split a folder path into its literal segments, dropping only blanks (no type-label filtering, deduplication, or depth cap).
- `wikiFolderSegments()` uses it, so `applyFolderToPage()` and descendant depth in `RenameOrMoveFolder()` mirror the folder path.
- `normalizeWikiHierarchy()` keeps a folder-backed page's `category_path` verbatim (trimming blanks) and only applies the model-noise cleaner to pages without a `folder_id`, so `ListPages` no longer strips the folder name on read. `normalizeWikiIndexEntryHierarchy` (model output) is unchanged.
- The repository `List` `category_path` filter uses the same literal normalization, matching what the directory view sends (the folder path).

`ListDistinctCategoryPaths` and the taxonomy planner still go through `CleanWikiCategoryPath`, since that path feeds model prompts and `FindOrCreateFolderPath` cleans model output before creating folders; this change only affects paths derived from existing folders.

## Type of Change
- [x] 🐛 Bug fix

## Related Issue
Fixes #3053

## Testing

- `TestWikiFolderPathSegmentsKeepTypeLikeFolderNames` (types): literal segments for `概念/ 概念 /Concepts//实体`, and a guard showing `CleanWikiCategoryPath` still drops `概念`, which is why folder paths must not go through it.
- `TestNormalizeWikiHierarchyKeepsFolderBackedPathVerbatim` (service): a page with `folder_id` keeps `["概念","概念","Concepts"]`, `depth = 3`, `wiki_path = concept/概念/概念/Concepts/将计就计`.
- `TestMovePageIntoTypeLabelNamedFolderKeepsHierarchy` (service, in-memory SQLite): `CreateFolder("概念")` + `MovePage` persists `category_path = ["概念"]`, `depth = 1`, `wiki_path = concept/概念/将计就计`, and `ListPages` by folder returns the same fields. Both service tests fail on `upstream/main` (`CategoryPath = []`, `Depth = 0`).
- The existing `TestNormalizeWikiHierarchyCleansModelCategoryNoise` / `...IndexEntry...` tests still pass, so model-authored labels are cleaned as before.

```
go test ./internal/types/ ./internal/application/service/ ./internal/application/repository/ -run 'Wiki|Folder|MovePage|NormalizeWikiHierarchy'
golangci-lint run --new-from-rev=upstream/main ./internal/types/... ./internal/application/service/... ./internal/application/repository/...   # 0 issues
git diff --check
```

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above (full `go test ./...` not run on a 4 GB host; the three touched packages were run in full for wiki tests)
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.) — no API surface change

## Screenshots / Recordings
Backend-only change; no UI modifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFSMrLZZ3oq1dKmJFAofz6
