### PR TITLE
refactor(system): signal create-user idempotency via HTTP status

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -23489,10 +23489,6 @@ const docTemplate = `{
                     "description": "GeneratedPassword is the plaintext password when the server\nauto-generated one. Absent when the caller supplied the password.",
                     "type": "string"
                 },
-                "idempotent": {
-                    "description": "Idempotent is true when the identity already existed (HTTP 200).\nThe SPA axios interceptor discards status codes, so this flag is\nthe body-level signal that nothing was created or changed.",
-                    "type": "boolean"
-                },
                 "user": {
                     "$ref": "#/definitions/github_com_Tencent_WeKnora_internal_types.UserInfo"
                 }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -23482,10 +23482,6 @@
                     "description": "GeneratedPassword is the plaintext password when the server\nauto-generated one. Absent when the caller supplied the password.",
                     "type": "string"
                 },
-                "idempotent": {
-                    "description": "Idempotent is true when the identity already existed (HTTP 200).\nThe SPA axios interceptor discards status codes, so this flag is\nthe body-level signal that nothing was created or changed.",
-                    "type": "boolean"
-                },
                 "user": {
                     "$ref": "#/definitions/github_com_Tencent_WeKnora_internal_types.UserInfo"
                 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5064,12 +5064,6 @@ definitions:
           GeneratedPassword is the plaintext password when the server
           auto-generated one. Absent when the caller supplied the password.
         type: string
-      idempotent:
-        description: |-
-          Idempotent is true when the identity already existed (HTTP 200).
-          The SPA axios interceptor discards status codes, so this flag is
-          the body-level signal that nothing was created or changed.
-        type: boolean
       user:
         $ref: '#/definitions/github_com_Tencent_WeKnora_internal_types.UserInfo'
     type: object

--- a/frontend/src/api/system/index.ts
+++ b/frontend/src/api/system/index.ts
@@ -398,22 +398,25 @@ export interface CreateSystemUserResponse {
    * be fetched again.
    */
   generated_password?: string
+}
+
+export interface CreateSystemUserResult extends CreateSystemUserResponse {
   /**
-   * True on the 200 retry when the identity already existed. The shared
-   * axios interceptor drops HTTP status, so callers must read this flag
-   * instead of the status code.
+   * True only when this call created the account (HTTP 201), false on the
+   * idempotent 200 retry (identity already existed).
    */
-  idempotent?: boolean
+  created: boolean
 }
 
 /**
  * Provision a new local user account (SystemAdmin only).
- * Backend returns the unwrapped CreateSystemUserResponse body.
- * 201 on create, 200 with `idempotent: true` when the identity existed.
+ * The backend answers 201 on create and 200 on the idempotent retry with
+ * the same CreateSystemUserResponse body. The status is projected onto
+ * `created`.
  */
-export async function createSystemUser(req: CreateSystemUserRequest): Promise<CreateSystemUserResponse> {
-  const response = await post('/api/v1/system/admin/users/create', req)
-  return response as unknown as CreateSystemUserResponse
+export async function createSystemUser(req: CreateSystemUserRequest): Promise<CreateSystemUserResult> {
+  const response = await post<CreateSystemUserResponse>('/api/v1/system/admin/users/create', req)
+  return { ...response, created: response.$httpStatus === 201 }
 }
 
 // ---- System Settings (P1) ----

--- a/frontend/src/views/system/createUserDialogState.test.ts
+++ b/frontend/src/views/system/createUserDialogState.test.ts
@@ -14,7 +14,7 @@ const identity = { username: 'alice', email: 'alice@example.com' }
 
 test('reveal wins whenever the server minted a one-time password', () => {
   const view = resolveCreateUserView(
-    { generated_password: 'OnceOnly9', idempotent: false },
+    { generated_password: 'OnceOnly9', created: true },
     identity,
     true,
   )
@@ -26,27 +26,27 @@ test('reveal wins whenever the server minted a one-time password', () => {
   })
 })
 
-test('idempotent flag is the 200 retry signal when no password was minted', () => {
+test('created:false is the 200 retry signal when no password was minted', () => {
   assert.deepEqual(
-    resolveCreateUserView({ idempotent: true }, identity, true),
+    resolveCreateUserView({ created: false }, identity, true),
     { kind: 'idempotent' },
   )
   assert.deepEqual(
-    resolveCreateUserView({ idempotent: true }, identity, false),
+    resolveCreateUserView({ created: false }, identity, false),
     { kind: 'idempotent' },
   )
 })
 
-test('supplied-password create without the idempotent flag is a real create', () => {
+test('created:true with a supplied password is a real create', () => {
   assert.deepEqual(
-    resolveCreateUserView({}, identity, false),
+    resolveCreateUserView({ created: true }, identity, false),
     { kind: 'created' },
   )
 })
 
-test('auto-generate create missing generated_password is not treated as idempotent', () => {
+test('auto-generate create that failed to return generated_password surfaces missingPassword', () => {
   assert.deepEqual(
-    resolveCreateUserView({}, identity, true),
+    resolveCreateUserView({ created: true }, identity, true),
     { kind: 'missingPassword' },
   )
 })

--- a/frontend/src/views/system/createUserDialogState.ts
+++ b/frontend/src/views/system/createUserDialogState.ts
@@ -1,20 +1,12 @@
 /**
  * Pure helpers for the SystemAdmin create-user dialog.
- *
- * The axios interceptor discards HTTP status, so 201 (created) and 200
- * (idempotent retry) used to look identical. The backend now sets
- * `idempotent` on the body; generated_password is still the signal for
- * the one-time reveal view.
  */
+
+import type { CreateSystemUserResult } from "@/api/system"
 
 export type CreateUserIdentity = {
   username: string
   email: string
-}
-
-export type CreateUserApiResponse = {
-  generated_password?: string
-  idempotent?: boolean
 }
 
 export type CreateUserReveal = CreateUserIdentity & {
@@ -30,7 +22,7 @@ export type CreateUserView =
 export type CreateUserNotice = 'reveal' | 'created' | 'idempotent' | 'missingPassword'
 
 export function resolveCreateUserView(
-  response: CreateUserApiResponse,
+  response: Omit<CreateSystemUserResult, 'user'>,
   identity: CreateUserIdentity,
   autoGenerate: boolean,
 ): CreateUserView {
@@ -43,7 +35,7 @@ export function resolveCreateUserView(
       generatedPassword: generated,
     }
   }
-  if (response.idempotent) {
+  if (!response.created) {
     return { kind: 'idempotent' }
   }
   if (autoGenerate) {

--- a/internal/handler/system.go
+++ b/internal/handler/system.go
@@ -1596,10 +1596,6 @@ type CreateSystemUserResponse struct {
 	// GeneratedPassword is the plaintext password when the server
 	// auto-generated one. Absent when the caller supplied the password.
 	GeneratedPassword string `json:"generated_password,omitempty"`
-	// Idempotent is true when the identity already existed (HTTP 200).
-	// The SPA axios interceptor discards status codes, so this flag is
-	// the body-level signal that nothing was created or changed.
-	Idempotent bool `json:"idempotent,omitempty"`
 }
 
 // CreateSystemUser godoc
@@ -1658,7 +1654,7 @@ func (h *SystemHandler) CreateSystemUser(c *gin.Context) {
 				"password_generated": false,
 				"idempotent":         true,
 			})
-			c.JSON(http.StatusOK, CreateSystemUserResponse{User: user.ToUserInfo(), Idempotent: true})
+			c.JSON(http.StatusOK, CreateSystemUserResponse{User: user.ToUserInfo()})
 		case errors.Is(err, service.ErrPasswordPolicy):
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		case errors.Is(err, service.ErrUserIdentityConflict):

--- a/internal/handler/system_user_create_test.go
+++ b/internal/handler/system_user_create_test.go
@@ -91,9 +91,6 @@ func TestCreateSystemUserCreatesUserWithExplicitPassword(t *testing.T) {
 			resp.GeneratedPassword,
 		)
 	}
-	if resp.Idempotent {
-		t.Fatal("fresh create must not set idempotent")
-	}
 	if users.gotReq == nil || users.gotReq.Password == nil || *users.gotReq.Password != "PlainPass9" {
 		t.Fatalf("service received unexpected request: %+v", users.gotReq)
 	}
@@ -135,9 +132,6 @@ func TestCreateSystemUserAutoGeneratesPasswordWhenEmpty(t *testing.T) {
 	}
 	if resp.GeneratedPassword != "G3n3r4t3dP4ssw0rd" {
 		t.Fatalf("generated_password=%q, want the once-only generated password", resp.GeneratedPassword)
-	}
-	if resp.Idempotent {
-		t.Fatal("fresh auto-generate create must not set idempotent")
 	}
 	if users.gotReq == nil || users.gotReq.Password != nil {
 		t.Fatalf("absent password must reach the service as nil, got %+v", users.gotReq)
@@ -265,9 +259,6 @@ func TestCreateSystemUserDuplicateIdentityReturnsExistingUser(t *testing.T) {
 	}
 	if resp.GeneratedPassword != "" {
 		t.Fatalf("generated_password=%q, want empty for an existing user", resp.GeneratedPassword)
-	}
-	if !resp.Idempotent {
-		t.Fatal("duplicate identity 200 must set idempotent=true so the SPA can tell it from a 201")
 	}
 	if len(audits.entries) != 1 || audits.entries[0].Action != types.AuditActionSystemUserCreated {
 		t.Fatalf("expected one %s audit entry, got %+v", types.AuditActionSystemUserCreated, audits.entries)


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

前端 createSystemUser 改为从 $httpStatus 投影出 created（201 新建 / 200 幂等重试），不再依赖 body 标志；后端删除响应体中冗余的 `idempotent` 字段（纯还原到加字段前的形态，审计轨迹保留该标记）。

Follow up #3034

## Type of Change
<!-- Check applicable items -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [x] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
