### PR TITLE
fix(wiki): make the category_path directory filter match on SQLite

### DIFF
--- a/internal/application/repository/wiki_page.go
+++ b/internal/application/repository/wiki_page.go
@@ -30,6 +30,13 @@ func NewWikiPageRepository(db *gorm.DB) interfaces.WikiPageRepository {
 	return &wikiPageRepository{db: db}
 }
 
+func (r *wikiPageRepository) wikiDialect() string {
+	if r.db == nil || r.db.Dialector == nil {
+		return ""
+	}
+	return r.db.Name()
+}
+
 func (r *wikiPageRepository) wikiCategoryRankOrder() string {
 	if r.db != nil && r.db.Dialector != nil && r.db.Dialector.Name() == "sqlite" {
 		return "CASE WHEN COALESCE(json_array_length(category_path), 0) > 0 THEN 0 ELSE 1 END ASC"
@@ -376,9 +383,15 @@ func (r *wikiPageRepository) List(ctx context.Context, req *types.WikiPageListRe
 	}
 	if wantPath := types.CleanWikiCategoryPath(req.CategoryPath); len(wantPath) > 0 {
 		if encoded, err := json.Marshal([]string(wantPath)); err == nil {
-			if r.db.Dialector != nil && r.db.Dialector.Name() == "postgres" {
+			switch r.wikiDialect() {
+			case "postgres":
 				query = query.Where("category_path::jsonb = ?::jsonb", string(encoded))
-			} else {
+			case "sqlite":
+				// StringArray.Value yields []byte, which SQLite stores as a BLOB;
+				// a BLOB never compares equal to a TEXT bind, so compare the
+				// text form instead.
+				query = query.Where("CAST(category_path AS TEXT) = ?", string(encoded))
+			default:
 				query = query.Where("category_path = ?", string(encoded))
 			}
 		}

--- a/internal/application/repository/wiki_page_test.go
+++ b/internal/application/repository/wiki_page_test.go
@@ -177,6 +177,53 @@ func TestList_WikiPathSortReturnsCategorizedPagesFirst(t *testing.T) {
 	assert.Equal(t, "entity/001-root", got[2].Slug)
 }
 
+// TestList_CategoryPathFilterMatchesOnSQLite protects the directory view on the
+// SQLite build: the sidebar loads a folder's pages with category_path +
+// category_depth, and StringArray is stored as a BLOB there, so a plain
+// equality against a TEXT bind never matched and every folder listed empty.
+func TestList_CategoryPathFilterMatchesOnSQLite(t *testing.T) {
+	db := setupWikiPagesTestDB(t)
+	repo := NewWikiPageRepository(db)
+	ctx := context.Background()
+
+	entity, published := types.WikiPageTypeEntity, types.WikiPageStatusPublished
+	pages := []*types.WikiPage{
+		makeCategorizedWikiPage("kb-c", "entity/in-ai", entity, published, "AI"),
+		makeCategorizedWikiPage("kb-c", "entity/in-ai-llm", entity, published, "AI", "LLM"),
+		makeCategorizedWikiPage("kb-c", "entity/in-people", entity, published, "人物"),
+		makeWikiPage("kb-c", "entity/root", entity, published),
+	}
+	for _, p := range pages {
+		require.NoError(t, repo.Create(ctx, p))
+	}
+
+	depth := 1
+	got, total, err := repo.List(ctx, &types.WikiPageListRequest{
+		KnowledgeBaseID: "kb-c",
+		PageType:        types.WikiPageTypeEntity,
+		CategoryPath:    types.StringArray{"AI"},
+		CategoryDepth:   &depth,
+		Page:            1,
+		PageSize:        10,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	require.Len(t, got, 1)
+	assert.Equal(t, "entity/in-ai", got[0].Slug)
+
+	got, total, err = repo.List(ctx, &types.WikiPageListRequest{
+		KnowledgeBaseID: "kb-c",
+		PageType:        types.WikiPageTypeEntity,
+		CategoryPath:    types.StringArray{"人物"},
+		Page:            1,
+		PageSize:        10,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	require.Len(t, got, 1)
+	assert.Equal(t, "entity/in-people", got[0].Slug)
+}
+
 // TestFolderTree_CRUDAndChildListing exercises the wiki_folders repository:
 // child listing ordered by sort_order/name, find-by-name, page counting under
 // a folder, and that ListDistinctCategoryPaths reflects the folder paths.


### PR DESCRIPTION
## Description

On the SQLite build, opening a wiki folder in the sidebar lists no pages. The directory view loads a folder's pages with `category_path=<folder path>&category_depth=<n>`, and the repository pushes that filter to SQL as `category_path = '<json>'`. `types.StringArray.Value()` returns `[]byte`, which SQLite stores with the BLOB storage class; a BLOB never compares equal to a TEXT bind, so the predicate matched nothing even when the stored JSON was identical (`typeof(category_path)` is `blob`, `category_path = '["AI"]'` counts 0, `CAST(category_path AS TEXT) = '["AI"]'` counts 1).

**Fix.** `wikiPageRepository.List` compares `CAST(category_path AS TEXT)` on SQLite, keeps the `::jsonb` comparison on Postgres, and leaves other dialects on the plain equality. A small `wikiDialect()` helper replaces the inline dialect probe.

## Type of Change
- [x] 🐛 Bug fix

## Related Issue
Fixes #

## Testing

- `TestList_CategoryPathFilterMatchesOnSQLite` (repository, in-memory SQLite): pages filed under `AI`, `AI/LLM`, `人物`, and root; filtering by `category_path=AI&category_depth=1` returns exactly `entity/in-ai`, and `category_path=人物` returns exactly `entity/in-people`. On `upstream/main` both queries return 0 rows (`expected: 1, actual: 0`).
- `go test ./internal/application/repository/ -run 'TestList_|Folder'` passes; `golangci-lint run --new-from-rev=upstream/main ./internal/application/repository/...` reports 0 issues; `git diff --check` is clean.

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above (full `go test ./...` not run on a 4 GB host; the touched package was run for the wiki tests)
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.) — no API surface change

## Screenshots / Recordings
Backend-only change; no UI modifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFSMrLZZ3oq1dKmJFAofz6
