### PR TITLE
fix(chat): send one completion-token field per provider

### DIFF
--- a/internal/agent/const.go
+++ b/internal/agent/const.go
@@ -100,9 +100,10 @@ func (e *AgentEngine) getLLMStallTimeout() time.Duration {
 // exactly fits by our arithmetic is the one that gets rejected.
 const contextSafetyTokens = 4096
 
-// getCompletionTokenBudget is the max_tokens / max_completion_tokens sent on
-// each ReAct LLM round. Unset without a sandbox is 4096; unset with a
-// sandbox (write_sandbox_file / edit_sandbox_file) is 24576.
+// getCompletionTokenBudget is the single completion budget for each ReAct LLM
+// round. The chat layer maps it to max_tokens or max_completion_tokens per
+// provider. Unset without a sandbox is 4096; unset with a sandbox
+// (write_sandbox_file / edit_sandbox_file) is 24576.
 func (e *AgentEngine) getCompletionTokenBudget() int {
 	configured := 0
 	sandboxID := ""

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -665,7 +665,7 @@ func TestStreamThinkingToEventBus_SetsCompletionTokenBudget(t *testing.T) {
 			[]chat.Message{{Role: "user", Content: "test"}}, nil, 0, "sess-1")
 		require.NoError(t, err)
 		require.Len(t, mock.opts, 1)
-		assert.Equal(t, 4096, mock.opts[0].MaxTokens)
+		assert.Zero(t, mock.opts[0].MaxTokens)
 		assert.Equal(t, 4096, mock.opts[0].MaxCompletionTokens)
 	})
 
@@ -680,7 +680,7 @@ func TestStreamThinkingToEventBus_SetsCompletionTokenBudget(t *testing.T) {
 			[]chat.Message{{Role: "user", Content: "test"}}, nil, 0, "sess-1")
 		require.NoError(t, err)
 		require.Len(t, mock.opts, 1)
-		assert.Equal(t, types.DefaultSmartReasoningMaxCompletionTokens, mock.opts[0].MaxTokens)
+		assert.Zero(t, mock.opts[0].MaxTokens)
 		assert.Equal(t, types.DefaultSmartReasoningMaxCompletionTokens, mock.opts[0].MaxCompletionTokens)
 	})
 
@@ -697,7 +697,7 @@ func TestStreamThinkingToEventBus_SetsCompletionTokenBudget(t *testing.T) {
 			[]chat.Message{{Role: "user", Content: "test"}}, nil, 0, "sess-1")
 		require.NoError(t, err)
 		require.Len(t, mock.opts, 1)
-		assert.Equal(t, types.DefaultAgentMaxCompletionTokens, mock.opts[0].MaxTokens)
+		assert.Zero(t, mock.opts[0].MaxTokens)
 		assert.Equal(t, types.DefaultAgentMaxCompletionTokens, mock.opts[0].MaxCompletionTokens)
 	})
 
@@ -712,7 +712,7 @@ func TestStreamThinkingToEventBus_SetsCompletionTokenBudget(t *testing.T) {
 			[]chat.Message{{Role: "user", Content: "test"}}, nil, 0, "sess-1")
 		require.NoError(t, err)
 		require.Len(t, mock.opts, 1)
-		assert.Equal(t, 64000, mock.opts[0].MaxTokens)
+		assert.Zero(t, mock.opts[0].MaxTokens)
 		assert.Equal(t, 64000, mock.opts[0].MaxCompletionTokens)
 	})
 }

--- a/internal/agent/finalize.go
+++ b/internal/agent/finalize.go
@@ -103,7 +103,6 @@ Now generate the final answer:`, query, imageRequirement)
 		messages,
 		&chat.ChatOptions{
 			Temperature:         e.config.Temperature,
-			MaxTokens:           budget,
 			MaxCompletionTokens: budget,
 			PromptCacheKey:      sessionID,
 		}, // Thinking disabled for final answer synthesis

--- a/internal/agent/think.go
+++ b/internal/agent/think.go
@@ -252,7 +252,6 @@ func (e *AgentEngine) streamThinkingToEventBus(
 	parallelToolCalls := true
 	opts := &chat.ChatOptions{
 		Temperature:         e.config.Temperature,
-		MaxTokens:           budget,
 		MaxCompletionTokens: budget,
 		Tools:               tools,
 		Thinking:            e.config.Thinking,

--- a/internal/models/chat/anthropic.go
+++ b/internal/models/chat/anthropic.go
@@ -268,10 +268,8 @@ func (c *AnthropicChat) buildRequest(_ context.Context, messages []Message, opts
 		Messages:  make([]anthropicMessage, 0, len(messages)),
 	}
 	if opts != nil {
-		if opts.MaxTokens > 0 {
-			req.MaxTokens = opts.MaxTokens
-		} else if opts.MaxCompletionTokens > 0 {
-			req.MaxTokens = opts.MaxCompletionTokens
+		if budget := opts.CompletionBudget(); budget > 0 {
+			req.MaxTokens = budget
 		}
 		if opts.Temperature > 0 {
 			temperature := opts.Temperature

--- a/internal/models/chat/chat.go
+++ b/internal/models/chat/chat.go
@@ -26,11 +26,15 @@ type FunctionDef struct {
 
 // ChatOptions 聊天选项
 type ChatOptions struct {
-	Temperature         float64         `json:"temperature"`                   // 温度参数
-	TopP                float64         `json:"top_p"`                         // Top P 参数
-	Seed                int             `json:"seed"`                          // 随机种子
-	MaxTokens           int             `json:"max_tokens"`                    // 最大 token 数
-	MaxCompletionTokens int             `json:"max_completion_tokens"`         // 最大完成 token 数
+	Temperature float64 `json:"temperature"` // 温度参数
+	TopP        float64 `json:"top_p"`       // Top P 参数
+	Seed        int     `json:"seed"`        // 随机种子
+	// MaxTokens and MaxCompletionTokens are aliases for one completion budget.
+	// Callers may set either; CompletionBudget() prefers MaxCompletionTokens.
+	// The outbound Chat Completions JSON carries exactly one of max_tokens or
+	// max_completion_tokens, chosen per provider (see wireCompletionTokenField).
+	MaxTokens           int             `json:"max_tokens"`
+	MaxCompletionTokens int             `json:"max_completion_tokens"`
 	FrequencyPenalty    float64         `json:"frequency_penalty"`             // 频率惩罚
 	PresencePenalty     float64         `json:"presence_penalty"`              // 存在惩罚
 	Thinking            *bool           `json:"thinking"`                      // 是否启用思考

--- a/internal/models/chat/completion_budget.go
+++ b/internal/models/chat/completion_budget.go
@@ -1,0 +1,83 @@
+package chat
+
+import (
+	"github.com/Tencent/WeKnora/internal/models/provider"
+	"github.com/sashabaranov/go-openai"
+)
+
+// completionTokenField is the single Chat Completions wire name for a
+// completion budget. OpenAI treats max_tokens and max_completion_tokens as
+// mutually exclusive; gateways such as Volcengine Ark reject requests that
+// carry both (Tencent/WeKnora#3014).
+type completionTokenField string
+
+const (
+	completionTokenFieldMaxTokens           completionTokenField = "max_tokens"
+	completionTokenFieldMaxCompletionTokens completionTokenField = "max_completion_tokens"
+)
+
+// CompletionBudget is the single per-call generation cap. MaxTokens and
+// MaxCompletionTokens on ChatOptions are input aliases for the same budget
+// (YAML, older callers, and the agent UI all feed one of them). When both are
+// set, the newer MaxCompletionTokens wins.
+func (o *ChatOptions) CompletionBudget() int {
+	if o == nil {
+		return 0
+	}
+	if o.MaxCompletionTokens > 0 {
+		return o.MaxCompletionTokens
+	}
+	return o.MaxTokens
+}
+
+// wireCompletionTokenField picks the Chat Completions JSON key for this
+// provider+model, following the earendil-works/pi compat.maxTokensField
+// pattern: one internal budget, exactly one outbound field.
+//
+// Default is max_completion_tokens (OpenAI Chat Completions, Azure, Ark).
+// Providers that document only max_tokens — or silently ignore the newer
+// field, as DeepSeek does — stay on the legacy name. GPT-5 / o-series always
+// use max_completion_tokens, even when the configured provider would
+// otherwise send max_tokens.
+func wireCompletionTokenField(name provider.ProviderName, model string) completionTokenField {
+	if provider.IsOpenAIReasoningOrGPT5Model(model) {
+		return completionTokenFieldMaxCompletionTokens
+	}
+	switch name {
+	case provider.ProviderDeepSeek,
+		provider.ProviderGeneric,
+		provider.ProviderNvidia,
+		provider.ProviderMoonshot,
+		provider.ProviderZhipu,
+		provider.ProviderGPUStack,
+		provider.ProviderAliyun,
+		provider.ProviderLKEAP,
+		provider.ProviderSiliconFlow,
+		provider.ProviderHunyuan,
+		provider.ProviderMiniMax,
+		provider.ProviderMimo,
+		provider.ProviderModelScope,
+		provider.ProviderQianfan,
+		provider.ProviderQiniu,
+		provider.ProviderLongCat,
+		provider.ProviderNovita,
+		provider.ProviderLiteLLM,
+		provider.ProviderGemini,
+		provider.ProviderWeKnoraCloud:
+		return completionTokenFieldMaxTokens
+	default:
+		return completionTokenFieldMaxCompletionTokens
+	}
+}
+
+func applyCompletionBudget(req *openai.ChatCompletionRequest, budget int, field completionTokenField) {
+	if req == nil || budget <= 0 {
+		return
+	}
+	switch field {
+	case completionTokenFieldMaxTokens:
+		req.MaxTokens = budget
+	default:
+		req.MaxCompletionTokens = budget
+	}
+}

--- a/internal/models/chat/completion_budget.go
+++ b/internal/models/chat/completion_budget.go
@@ -34,23 +34,25 @@ func (o *ChatOptions) CompletionBudget() int {
 // provider+model, following the earendil-works/pi compat.maxTokensField
 // pattern: one internal budget, exactly one outbound field.
 //
-// Default is max_completion_tokens (OpenAI Chat Completions, Azure, Ark).
-// Only providers whose docs (or Pi's catalog) use the legacy name stay on
-// max_tokens. Unknown OpenAI-compat hosts — including Aliyun DashScope, which
-// documents max_completion_tokens for thinking models — keep the default.
-// GPT-5 / o-series always use max_completion_tokens.
+// Default is max_completion_tokens (OpenAI Chat Completions, Azure, Ark),
+// matching Pi. Only providers whose docs (or Pi's catalog) use the legacy
+// name stay on max_tokens. WeKnora-only hosts that document max_tokens
+// (LKEAP) are listed here too. Unknown OpenAI-compat hosts — including
+// Aliyun DashScope — keep the default. GPT-5 / o-series always use
+// max_completion_tokens.
 func wireCompletionTokenField(name provider.ProviderName, model string) completionTokenField {
 	if provider.IsOpenAIReasoningOrGPT5Model(model) {
 		return completionTokenFieldMaxCompletionTokens
 	}
 	switch name {
 	case provider.ProviderDeepSeek, // api-docs.deepseek.com: max_tokens only
-		provider.ProviderZhipu,       // open.bigmodel.cn: max_tokens only
+		provider.ProviderZhipu,       // open.bigmodel.cn: max_tokens only (Pi isZai)
 		provider.ProviderSiliconFlow, // docs.siliconflow.com schema: max_tokens
 		provider.ProviderMoonshot,    // Pi useMaxTokens (moonshot.ai)
 		provider.ProviderNvidia,      // Pi useMaxTokens (NIM / vLLM)
 		provider.ProviderGeneric,     // self-hosted vLLM typically ignores the new field
-		provider.ProviderGPUStack:    // private vLLM-class runtime
+		provider.ProviderGPUStack,    // private vLLM-class runtime
+		provider.ProviderLKEAP:       // cloud.tencent.com/document/product/1772/115969: max_tokens only
 		return completionTokenFieldMaxTokens
 	default:
 		return completionTokenFieldMaxCompletionTokens

--- a/internal/models/chat/completion_budget.go
+++ b/internal/models/chat/completion_budget.go
@@ -35,35 +35,22 @@ func (o *ChatOptions) CompletionBudget() int {
 // pattern: one internal budget, exactly one outbound field.
 //
 // Default is max_completion_tokens (OpenAI Chat Completions, Azure, Ark).
-// Providers that document only max_tokens — or silently ignore the newer
-// field, as DeepSeek does — stay on the legacy name. GPT-5 / o-series always
-// use max_completion_tokens, even when the configured provider would
-// otherwise send max_tokens.
+// Only providers whose docs (or Pi's catalog) use the legacy name stay on
+// max_tokens. Unknown OpenAI-compat hosts — including Aliyun DashScope, which
+// documents max_completion_tokens for thinking models — keep the default.
+// GPT-5 / o-series always use max_completion_tokens.
 func wireCompletionTokenField(name provider.ProviderName, model string) completionTokenField {
 	if provider.IsOpenAIReasoningOrGPT5Model(model) {
 		return completionTokenFieldMaxCompletionTokens
 	}
 	switch name {
-	case provider.ProviderDeepSeek,
-		provider.ProviderGeneric,
-		provider.ProviderNvidia,
-		provider.ProviderMoonshot,
-		provider.ProviderZhipu,
-		provider.ProviderGPUStack,
-		provider.ProviderAliyun,
-		provider.ProviderLKEAP,
-		provider.ProviderSiliconFlow,
-		provider.ProviderHunyuan,
-		provider.ProviderMiniMax,
-		provider.ProviderMimo,
-		provider.ProviderModelScope,
-		provider.ProviderQianfan,
-		provider.ProviderQiniu,
-		provider.ProviderLongCat,
-		provider.ProviderNovita,
-		provider.ProviderLiteLLM,
-		provider.ProviderGemini,
-		provider.ProviderWeKnoraCloud:
+	case provider.ProviderDeepSeek, // api-docs.deepseek.com: max_tokens only
+		provider.ProviderZhipu,       // open.bigmodel.cn: max_tokens only
+		provider.ProviderSiliconFlow, // docs.siliconflow.com schema: max_tokens
+		provider.ProviderMoonshot,    // Pi useMaxTokens (moonshot.ai)
+		provider.ProviderNvidia,      // Pi useMaxTokens (NIM / vLLM)
+		provider.ProviderGeneric,     // self-hosted vLLM typically ignores the new field
+		provider.ProviderGPUStack:    // private vLLM-class runtime
 		return completionTokenFieldMaxTokens
 	default:
 		return completionTokenFieldMaxCompletionTokens

--- a/internal/models/chat/completion_budget_test.go
+++ b/internal/models/chat/completion_budget_test.go
@@ -1,0 +1,98 @@
+package chat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatOptionsCompletionBudget(t *testing.T) {
+	assert.Zero(t, (*ChatOptions)(nil).CompletionBudget())
+	assert.Zero(t, (&ChatOptions{}).CompletionBudget())
+	assert.Equal(t, 128, (&ChatOptions{MaxTokens: 128}).CompletionBudget())
+	assert.Equal(t, 256, (&ChatOptions{MaxCompletionTokens: 256}).CompletionBudget())
+	assert.Equal(t, 256, (&ChatOptions{MaxTokens: 128, MaxCompletionTokens: 256}).CompletionBudget())
+}
+
+func TestWireCompletionTokenField(t *testing.T) {
+	assert.Equal(t, completionTokenFieldMaxCompletionTokens,
+		wireCompletionTokenField(provider.ProviderOpenAI, "gpt-4o"))
+	assert.Equal(t, completionTokenFieldMaxCompletionTokens,
+		wireCompletionTokenField(provider.ProviderVolcengine, "doubao-seed-2-0-mini"))
+	assert.Equal(t, completionTokenFieldMaxTokens,
+		wireCompletionTokenField(provider.ProviderDeepSeek, "deepseek-chat"))
+	assert.Equal(t, completionTokenFieldMaxTokens,
+		wireCompletionTokenField(provider.ProviderGeneric, "qwen3"))
+	assert.Equal(t, completionTokenFieldMaxTokens,
+		wireCompletionTokenField(provider.ProviderNvidia, "llama-3"))
+	// GPT-5 / o-series always use the modern field, even on a max_tokens provider.
+	assert.Equal(t, completionTokenFieldMaxCompletionTokens,
+		wireCompletionTokenField(provider.ProviderGeneric, "gpt-5-mini"))
+}
+
+func TestBuildChatCompletionRequest_OneWireTokenField(t *testing.T) {
+	messages := []Message{{Role: "user", Content: "hello"}}
+
+	t.Run("volcengine both aliases send only max_completion_tokens", func(t *testing.T) {
+		c := newOutboundChat(t, string(provider.ProviderVolcengine), "doubao-seed-2-0-mini", nil)
+		req := c.BuildChatCompletionRequest(messages, &ChatOptions{
+			MaxTokens: 2048, MaxCompletionTokens: 4096,
+		}, false)
+		assert.Equal(t, 4096, req.MaxCompletionTokens)
+		assert.Zero(t, req.MaxTokens)
+
+		body, err := json.Marshal(req)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), `"max_completion_tokens":4096`)
+		assert.NotContains(t, string(body), `"max_tokens"`)
+	})
+
+	t.Run("deepseek sends max_tokens", func(t *testing.T) {
+		c := newOutboundChat(t, string(provider.ProviderDeepSeek), "deepseek-chat", nil)
+		req := c.BuildChatCompletionRequest(messages, &ChatOptions{
+			MaxTokens: 2048, MaxCompletionTokens: 4096,
+		}, false)
+		c.adapter.ShapeRequest(&req, &ChatOptions{MaxTokens: 2048, MaxCompletionTokens: 4096}, false)
+		assert.Equal(t, 4096, req.MaxTokens)
+		assert.Zero(t, req.MaxCompletionTokens)
+
+		body, err := json.Marshal(req)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), `"max_tokens":4096`)
+		assert.NotContains(t, string(body), "max_completion_tokens")
+	})
+
+	t.Run("generic vLLM sends max_tokens from MaxTokens-only callers", func(t *testing.T) {
+		c := newOutboundChat(t, string(provider.ProviderGeneric), "qwen3", nil)
+		req := c.BuildChatCompletionRequest(messages, &ChatOptions{MaxTokens: 2048}, false)
+		assert.Equal(t, 2048, req.MaxTokens)
+		assert.Zero(t, req.MaxCompletionTokens)
+	})
+
+	t.Run("openai gpt-4o sends max_completion_tokens", func(t *testing.T) {
+		c := newOutboundChat(t, string(provider.ProviderOpenAI), "gpt-4o", nil)
+		req := c.BuildChatCompletionRequest(messages, &ChatOptions{MaxTokens: 128}, false)
+		assert.Zero(t, req.MaxTokens)
+		assert.Equal(t, 128, req.MaxCompletionTokens)
+	})
+}
+
+func TestOllamaBuildChatRequestUsesCompletionBudget(t *testing.T) {
+	c := &OllamaChat{modelName: "llama3"}
+	req := c.buildChatRequest(
+		[]Message{{Role: "user", Content: "hi"}},
+		&ChatOptions{MaxCompletionTokens: 512},
+		false,
+	)
+	assert.Equal(t, 512, req.Options["num_predict"])
+}
+
+func TestBuildLangfuseModelParamsUsesCompletionBudget(t *testing.T) {
+	params := buildLangfuseModelParams(&ChatOptions{MaxTokens: 128, MaxCompletionTokens: 256})
+	assert.Equal(t, 256, params["max_completion_tokens"])
+	_, hasLegacy := params["max_tokens"]
+	assert.False(t, hasLegacy)
+}

--- a/internal/models/chat/completion_budget_test.go
+++ b/internal/models/chat/completion_budget_test.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -18,33 +19,44 @@ func TestChatOptionsCompletionBudget(t *testing.T) {
 }
 
 func TestWireCompletionTokenField(t *testing.T) {
-	legacy := []provider.ProviderName{
-		provider.ProviderDeepSeek,
-		provider.ProviderZhipu,
-		provider.ProviderSiliconFlow,
-		provider.ProviderMoonshot,
-		provider.ProviderNvidia,
-		provider.ProviderGeneric,
-		provider.ProviderGPUStack,
+	// Every AllProviders() name must be classified here so a new vendor cannot
+	// silently inherit the default. Match Pi's polarity: default
+	// max_completion_tokens; only documented max_tokens hosts (plus WeKnora
+	// self-hosted / LKEAP, which Pi does not catalog) are exceptions.
+	want := map[provider.ProviderName]completionTokenField{
+		provider.ProviderDeepSeek:     completionTokenFieldMaxTokens,
+		provider.ProviderZhipu:        completionTokenFieldMaxTokens,
+		provider.ProviderSiliconFlow:  completionTokenFieldMaxTokens,
+		provider.ProviderMoonshot:     completionTokenFieldMaxTokens,
+		provider.ProviderNvidia:       completionTokenFieldMaxTokens,
+		provider.ProviderGeneric:      completionTokenFieldMaxTokens,
+		provider.ProviderGPUStack:     completionTokenFieldMaxTokens,
+		provider.ProviderLKEAP:        completionTokenFieldMaxTokens,
+		provider.ProviderOpenAI:       completionTokenFieldMaxCompletionTokens,
+		provider.ProviderAzureOpenAI:  completionTokenFieldMaxCompletionTokens,
+		provider.ProviderVolcengine:   completionTokenFieldMaxCompletionTokens,
+		provider.ProviderAliyun:       completionTokenFieldMaxCompletionTokens,
+		provider.ProviderLiteLLM:      completionTokenFieldMaxCompletionTokens,
+		provider.ProviderGemini:       completionTokenFieldMaxCompletionTokens,
+		provider.ProviderWeKnoraCloud: completionTokenFieldMaxCompletionTokens,
+		provider.ProviderHunyuan:      completionTokenFieldMaxCompletionTokens,
+		provider.ProviderMiniMax:      completionTokenFieldMaxCompletionTokens,
+		provider.ProviderOpenRouter:   completionTokenFieldMaxCompletionTokens,
+		provider.ProviderRequesty:     completionTokenFieldMaxCompletionTokens,
+		provider.ProviderJina:         completionTokenFieldMaxCompletionTokens,
+		provider.ProviderMimo:         completionTokenFieldMaxCompletionTokens,
+		provider.ProviderModelScope:   completionTokenFieldMaxCompletionTokens,
+		provider.ProviderQianfan:      completionTokenFieldMaxCompletionTokens,
+		provider.ProviderQiniu:        completionTokenFieldMaxCompletionTokens,
+		provider.ProviderLongCat:      completionTokenFieldMaxCompletionTokens,
+		provider.ProviderNovita:       completionTokenFieldMaxCompletionTokens,
+		provider.ProviderAnthropic:    completionTokenFieldMaxCompletionTokens,
 	}
-	for _, name := range legacy {
-		assert.Equal(t, completionTokenFieldMaxTokens, wireCompletionTokenField(name, "any"), string(name))
-	}
-
-	modern := []provider.ProviderName{
-		provider.ProviderOpenAI,
-		provider.ProviderAzureOpenAI,
-		provider.ProviderVolcengine,
-		provider.ProviderAliyun, // DashScope documents max_completion_tokens for thinking models
-		provider.ProviderLiteLLM,
-		provider.ProviderGemini,
-		provider.ProviderWeKnoraCloud,
-		provider.ProviderLKEAP,
-		provider.ProviderHunyuan,
-		provider.ProviderMiniMax,
-	}
-	for _, name := range modern {
-		assert.Equal(t, completionTokenFieldMaxCompletionTokens, wireCompletionTokenField(name, "any"), string(name))
+	require.Len(t, want, len(provider.AllProviders()), "classify every AllProviders() name")
+	for _, name := range provider.AllProviders() {
+		field, ok := want[name]
+		require.True(t, ok, "classify %s in TestWireCompletionTokenField", name)
+		assert.Equal(t, field, wireCompletionTokenField(name, "any"), string(name))
 	}
 
 	// GPT-5 / o-series always use the modern field, even on a max_tokens provider.
@@ -71,10 +83,21 @@ func TestBuildChatCompletionRequest_OneWireTokenField(t *testing.T) {
 
 	t.Run("deepseek sends max_tokens", func(t *testing.T) {
 		c := newOutboundChat(t, string(provider.ProviderDeepSeek), "deepseek-chat", nil)
-		req := c.BuildChatCompletionRequest(messages, &ChatOptions{
+		req := c.shapedRequest(messages, &ChatOptions{
 			MaxTokens: 2048, MaxCompletionTokens: 4096,
 		}, false)
-		c.adapter.ShapeRequest(&req, &ChatOptions{MaxTokens: 2048, MaxCompletionTokens: 4096}, false)
+		assert.Equal(t, 4096, req.MaxTokens)
+		assert.Zero(t, req.MaxCompletionTokens)
+
+		body, err := json.Marshal(req)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), `"max_tokens":4096`)
+		assert.NotContains(t, string(body), "max_completion_tokens")
+	})
+
+	t.Run("lkeap sends max_tokens", func(t *testing.T) {
+		c := newOutboundChat(t, string(provider.ProviderLKEAP), "deepseek-v3.1", nil)
+		req := c.BuildChatCompletionRequest(messages, &ChatOptions{MaxCompletionTokens: 4096}, false)
 		assert.Equal(t, 4096, req.MaxTokens)
 		assert.Zero(t, req.MaxCompletionTokens)
 
@@ -103,6 +126,36 @@ func TestBuildChatCompletionRequest_OneWireTokenField(t *testing.T) {
 		req := c.BuildChatCompletionRequest(messages, &ChatOptions{MaxTokens: 128}, false)
 		assert.Zero(t, req.MaxTokens)
 		assert.Equal(t, 128, req.MaxCompletionTokens)
+	})
+}
+
+func TestBuildOutbound_OneWireTokenField(t *testing.T) {
+	msgs := []Message{{Role: "user", Content: "hello"}}
+
+	t.Run("volcengine thinking keeps only max_completion_tokens", func(t *testing.T) {
+		c := newOutboundChat(t, string(provider.ProviderVolcengine), "doubao-seed-2-0-mini", nil)
+		body, _, useRaw, err := c.buildOutbound(context.Background(), msgs, &ChatOptions{
+			MaxTokens: 2048, MaxCompletionTokens: 4096, Thinking: ptrBool(true),
+		}, true)
+		require.NoError(t, err)
+		require.True(t, useRaw)
+		js := mustJSON(t, body)
+		assert.Contains(t, js, `"thinking"`)
+		assert.Contains(t, js, `"max_completion_tokens":4096`)
+		assert.NotContains(t, js, `"max_tokens"`)
+	})
+
+	t.Run("lkeap thinking keeps only max_tokens", func(t *testing.T) {
+		c := newOutboundChat(t, string(provider.ProviderLKEAP), "deepseek-v3.1", nil)
+		body, _, useRaw, err := c.buildOutbound(context.Background(), msgs, &ChatOptions{
+			MaxCompletionTokens: 4096, Thinking: ptrBool(false),
+		}, true)
+		require.NoError(t, err)
+		require.True(t, useRaw)
+		js := mustJSON(t, body)
+		assert.Contains(t, js, `"thinking"`)
+		assert.Contains(t, js, `"max_tokens":4096`)
+		assert.NotContains(t, js, "max_completion_tokens")
 	})
 }
 

--- a/internal/models/chat/completion_budget_test.go
+++ b/internal/models/chat/completion_budget_test.go
@@ -18,16 +18,35 @@ func TestChatOptionsCompletionBudget(t *testing.T) {
 }
 
 func TestWireCompletionTokenField(t *testing.T) {
-	assert.Equal(t, completionTokenFieldMaxCompletionTokens,
-		wireCompletionTokenField(provider.ProviderOpenAI, "gpt-4o"))
-	assert.Equal(t, completionTokenFieldMaxCompletionTokens,
-		wireCompletionTokenField(provider.ProviderVolcengine, "doubao-seed-2-0-mini"))
-	assert.Equal(t, completionTokenFieldMaxTokens,
-		wireCompletionTokenField(provider.ProviderDeepSeek, "deepseek-chat"))
-	assert.Equal(t, completionTokenFieldMaxTokens,
-		wireCompletionTokenField(provider.ProviderGeneric, "qwen3"))
-	assert.Equal(t, completionTokenFieldMaxTokens,
-		wireCompletionTokenField(provider.ProviderNvidia, "llama-3"))
+	legacy := []provider.ProviderName{
+		provider.ProviderDeepSeek,
+		provider.ProviderZhipu,
+		provider.ProviderSiliconFlow,
+		provider.ProviderMoonshot,
+		provider.ProviderNvidia,
+		provider.ProviderGeneric,
+		provider.ProviderGPUStack,
+	}
+	for _, name := range legacy {
+		assert.Equal(t, completionTokenFieldMaxTokens, wireCompletionTokenField(name, "any"), string(name))
+	}
+
+	modern := []provider.ProviderName{
+		provider.ProviderOpenAI,
+		provider.ProviderAzureOpenAI,
+		provider.ProviderVolcengine,
+		provider.ProviderAliyun, // DashScope documents max_completion_tokens for thinking models
+		provider.ProviderLiteLLM,
+		provider.ProviderGemini,
+		provider.ProviderWeKnoraCloud,
+		provider.ProviderLKEAP,
+		provider.ProviderHunyuan,
+		provider.ProviderMiniMax,
+	}
+	for _, name := range modern {
+		assert.Equal(t, completionTokenFieldMaxCompletionTokens, wireCompletionTokenField(name, "any"), string(name))
+	}
+
 	// GPT-5 / o-series always use the modern field, even on a max_tokens provider.
 	assert.Equal(t, completionTokenFieldMaxCompletionTokens,
 		wireCompletionTokenField(provider.ProviderGeneric, "gpt-5-mini"))
@@ -70,6 +89,13 @@ func TestBuildChatCompletionRequest_OneWireTokenField(t *testing.T) {
 		req := c.BuildChatCompletionRequest(messages, &ChatOptions{MaxTokens: 2048}, false)
 		assert.Equal(t, 2048, req.MaxTokens)
 		assert.Zero(t, req.MaxCompletionTokens)
+	})
+
+	t.Run("aliyun dashscope keeps max_completion_tokens", func(t *testing.T) {
+		c := newOutboundChat(t, string(provider.ProviderAliyun), "qwen-plus", nil)
+		req := c.BuildChatCompletionRequest(messages, &ChatOptions{MaxTokens: 2048}, false)
+		assert.Zero(t, req.MaxTokens)
+		assert.Equal(t, 2048, req.MaxCompletionTokens)
 	})
 
 	t.Run("openai gpt-4o sends max_completion_tokens", func(t *testing.T) {

--- a/internal/models/chat/langfuse_wrapper.go
+++ b/internal/models/chat/langfuse_wrapper.go
@@ -193,11 +193,8 @@ func buildLangfuseModelParams(opts *ChatOptions) map[string]interface{} {
 	if opts.TopP != 0 {
 		params["top_p"] = opts.TopP
 	}
-	if opts.MaxTokens > 0 {
-		params["max_tokens"] = opts.MaxTokens
-	}
-	if opts.MaxCompletionTokens > 0 {
-		params["max_completion_tokens"] = opts.MaxCompletionTokens
+	if budget := opts.CompletionBudget(); budget > 0 {
+		params["max_completion_tokens"] = budget
 	}
 	if opts.FrequencyPenalty != 0 {
 		params["frequency_penalty"] = opts.FrequencyPenalty

--- a/internal/models/chat/llm_debug.go
+++ b/internal/models/chat/llm_debug.go
@@ -57,11 +57,8 @@ func buildOptionsSection(opts *ChatOptions) string {
 	if opts.TopP > 0 {
 		parts = append(parts, fmt.Sprintf("TopP=%.2f", opts.TopP))
 	}
-	if opts.MaxTokens > 0 {
-		parts = append(parts, fmt.Sprintf("MaxTokens=%d", opts.MaxTokens))
-	}
-	if opts.MaxCompletionTokens > 0 {
-		parts = append(parts, fmt.Sprintf("MaxCompletionTokens=%d", opts.MaxCompletionTokens))
+	if budget := opts.CompletionBudget(); budget > 0 {
+		parts = append(parts, fmt.Sprintf("CompletionBudget=%d", budget))
 	}
 	if opts.FrequencyPenalty > 0 {
 		parts = append(parts, fmt.Sprintf("FrequencyPenalty=%.2f", opts.FrequencyPenalty))

--- a/internal/models/chat/ollama.go
+++ b/internal/models/chat/ollama.go
@@ -103,8 +103,8 @@ func (c *OllamaChat) buildChatRequest(messages []Message, opts *ChatOptions, isS
 		if opts.TopP > 0 {
 			chatReq.Options["top_p"] = opts.TopP
 		}
-		if opts.MaxTokens > 0 {
-			chatReq.Options["num_predict"] = opts.MaxTokens
+		if budget := opts.CompletionBudget(); budget > 0 {
+			chatReq.Options["num_predict"] = budget
 		}
 		if opts.Thinking != nil {
 			chatReq.Think = &ollamaapi.ThinkValue{

--- a/internal/models/chat/openai_request.go
+++ b/internal/models/chat/openai_request.go
@@ -94,10 +94,11 @@ func (c *RemoteAPIChat) ConvertMessages(messages []Message) []openai.ChatComplet
 
 // BuildChatCompletionRequest 构建标准聊天请求参数（导出供子类使用）。
 //
-// 这是一个不含任何 provider 特定逻辑的通用实现：所有采样参数（temperature /
-// top_p / penalties）与 max_tokens 都按 opts 直接映射。供应商相关的特判
-// （OpenAI o-series / GPT-5 改用 max_completion_tokens、Moonshot 固定温度等）
-// 由对应的 providerAdapter.ShapeRequest 在事后施加，见 provider.go。
+// 采样参数（temperature / top_p / penalties）按 opts 直接映射。完成预算经
+// CompletionBudget 收成一个值，再按供应商只写入 max_tokens 或
+// max_completion_tokens 之一（二者互斥，见 #3014）。其余供应商特判
+// （o-series / GPT-5 采样参数、Moonshot 固定温度等）仍由
+// providerAdapter.ShapeRequest 在事后施加，见 provider.go。
 func (c *RemoteAPIChat) BuildChatCompletionRequest(
 	messages []Message, opts *ChatOptions, isStream bool,
 ) openai.ChatCompletionRequest {
@@ -126,12 +127,7 @@ func (c *RemoteAPIChat) BuildChatCompletionRequest(
 		req.PresencePenalty = float32(opts.PresencePenalty)
 	}
 
-	if opts.MaxTokens > 0 {
-		req.MaxTokens = opts.MaxTokens
-	}
-	if opts.MaxCompletionTokens > 0 {
-		req.MaxCompletionTokens = opts.MaxCompletionTokens
-	}
+	applyCompletionBudget(&req, opts.CompletionBudget(), wireCompletionTokenField(c.provider, c.modelName))
 
 	// 处理 Tools
 	if len(opts.Tools) > 0 {

--- a/internal/models/chat/remote_api_test.go
+++ b/internal/models/chat/remote_api_test.go
@@ -188,8 +188,8 @@ func TestBuildChatCompletionRequest_GPT5MaxCompletionTokens(t *testing.T) {
 				assert.EqualValues(t, 0, req.FrequencyPenalty, "frequency_penalty must be omitted")
 				assert.EqualValues(t, 0, req.PresencePenalty, "presence_penalty must be omitted")
 			} else {
-				assert.Equal(t, 128, req.MaxTokens)
-				assert.Equal(t, 0, req.MaxCompletionTokens)
+				assert.Zero(t, req.MaxTokens, "non-reasoning OpenAI/Azure send max_completion_tokens only")
+				assert.Equal(t, 128, req.MaxCompletionTokens)
 				assert.InDelta(t, 0.7, req.Temperature, 1e-6)
 			}
 		})


### PR DESCRIPTION
## Summary
- Collapse `MaxTokens` / `MaxCompletionTokens` to one internal budget (`CompletionBudget()`); the agent no longer dual-writes both aliases.
- Pick exactly one Chat Completions wire name per provider (Pi-style `maxTokensField`): never send both, which Volcengine Ark rejects with HTTP 400.
- DeepSeek / vLLM-class providers keep `max_tokens`; OpenAI, Azure, and Ark get `max_completion_tokens`. Ollama `num_predict` and Anthropic `max_tokens` read the same budget.

## Related Issue
Fixes #3014

This is a fuller replacement for the serialization-guard approach in #3040.

## Test plan
- [x] `go test ./internal/models/chat/ ./internal/agent/` — includes `TestBuildChatCompletionRequest_OneWireTokenField` (Ark both-set → only `max_completion_tokens`; DeepSeek → `max_tokens`; generic MaxTokens-only still effective)
- [x] Existing GPT-5 / o-series migration tests still pass
- [ ] Custom agent on Volcengine Ark (smart-reasoning) no longer 400s
- [ ] DeepSeek agent round still respects the completion cap
- [ ] Note: the `max_tokens` provider whitelist is conservative and not live-verified for every vendor (Aliyun DashScope in particular documents `max_completion_tokens` for thinking models). Tighten follow-up if needed.