### PR TITLE
fix qdrant collection matching

### DIFF
--- a/internal/application/repository/retriever/qdrant/repository.go
+++ b/internal/application/repository/retriever/qdrant/repository.go
@@ -3,6 +3,7 @@ package qdrant
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -50,6 +51,16 @@ func NewQdrantRetrieveEngineRepository(client *qdrant.Client, indexCfg *types.In
 // getCollectionName returns the collection name for a specific dimension
 func (q *qdrantRepository) getCollectionName(dimension int) string {
 	return fmt.Sprintf("%s_%d", q.collectionBaseName, dimension)
+}
+
+// matchesCollectionName accepts only names generated for a positive dimension.
+func (q *qdrantRepository) matchesCollectionName(collectionName string) bool {
+	suffix, ok := strings.CutPrefix(collectionName, q.collectionBaseName+"_")
+	if !ok {
+		return false
+	}
+	dimension, err := strconv.Atoi(suffix)
+	return err == nil && dimension > 0 && suffix == strconv.Itoa(dimension)
 }
 
 // ensureCollection ensures the collection exists for the given dimension
@@ -392,9 +403,7 @@ func (q *qdrantRepository) BatchUpdateChunkEnabledStatus(ctx context.Context, ch
 
 	// Update in all matching collections
 	for _, collectionName := range collections {
-		// Only process collections that start with our base name
-		if len(collectionName) <= len(q.collectionBaseName) ||
-			collectionName[:len(q.collectionBaseName)] != q.collectionBaseName {
+		if !q.matchesCollectionName(collectionName) {
 			continue
 		}
 
@@ -460,9 +469,7 @@ func (q *qdrantRepository) BatchUpdateChunkTagID(ctx context.Context, chunkTagMa
 
 	// Update in all matching collections
 	for _, collectionName := range collections {
-		// Only process collections that start with our base name
-		if len(collectionName) <= len(q.collectionBaseName) ||
-			collectionName[:len(q.collectionBaseName)] != q.collectionBaseName {
+		if !q.matchesCollectionName(collectionName) {
 			continue
 		}
 
@@ -642,9 +649,7 @@ func (q *qdrantRepository) KeywordsRetrieve(ctx context.Context,
 	// Search in all matching collections
 	for _, collectionName := range collections {
 		log.Debugf("[Qdrant] Checking collection: %s", collectionName)
-		// Only process collections that start with our base name
-		if len(collectionName) <= len(q.collectionBaseName) ||
-			collectionName[:len(q.collectionBaseName)] != q.collectionBaseName {
+		if !q.matchesCollectionName(collectionName) {
 			log.Debugf("[Qdrant] Skipping collection %s (doesn't match base name %s)", collectionName, q.collectionBaseName)
 			continue
 		}

--- a/internal/application/repository/retriever/qdrant/repository_test.go
+++ b/internal/application/repository/retriever/qdrant/repository_test.go
@@ -1,9 +1,64 @@
 package qdrant
 
 import (
+	"strconv"
 	"testing"
 	"unicode/utf8"
 )
+
+func TestMatchesCollectionName(t *testing.T) {
+	tests := []struct {
+		name       string
+		base       string
+		collection string
+		want       bool
+	}{
+		{"minimum dimension", "embeddings", "embeddings_1", true},
+		{"typical dimension", "weknora_embeddings", "weknora_embeddings_768", true},
+		{"custom base", "team_42_vectors", "team_42_vectors_1536", true},
+		{"base ending in underscore", "vectors_", "vectors__768", true},
+		{"longer base", "vectors", "vectors_extra_768", false},
+		{"backup collection", "weknora_embeddings", "weknora_embeddings_backup_768", false},
+		{"backup suffix", "vectors", "vectors_768_backup", false},
+		{"missing separator", "vectors", "vectors768", false},
+		{"missing dimension", "vectors", "vectors_", false},
+		{"base only", "vectors", "vectors", false},
+		{"short name", "vectors", "vec", false},
+		{"empty name", "vectors", "", false},
+		{"different base", "vectors", "other_768", false},
+		{"case mismatch", "vectors", "Vectors_768", false},
+		{"zero dimension", "vectors", "vectors_0", false},
+		{"negative dimension", "vectors", "vectors_-768", false},
+		{"explicit plus", "vectors", "vectors_+768", false},
+		{"leading zero", "vectors", "vectors_0768", false},
+		{"fraction", "vectors", "vectors_7.68", false},
+		{"non decimal", "vectors", "vectors_0x300", false},
+		{"leading space", "vectors", "vectors_ 768", false},
+		{"trailing space", "vectors", "vectors_768 ", false},
+		{"unicode digits", "vectors", "vectors_７６８", false},
+		{"overflow", "vectors", "vectors_999999999999999999999999999999999", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &qdrantRepository{collectionBaseName: tt.base}
+			if got := repo.matchesCollectionName(tt.collection); got != tt.want {
+				t.Errorf("matchesCollectionName(%q) = %v, want %v", tt.collection, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesGeneratedCollectionNames(t *testing.T) {
+	repo := &qdrantRepository{collectionBaseName: "custom_vectors"}
+	for _, dimension := range []int{1, 384, 768, 1536, int(^uint(0) >> 1)} {
+		t.Run(strconv.Itoa(dimension), func(t *testing.T) {
+			name := repo.getCollectionName(dimension)
+			if !repo.matchesCollectionName(name) {
+				t.Errorf("generated collection name %q was rejected", name)
+			}
+		})
+	}
+}
 
 func TestNewQdrantValueMapSanitizesInvalidUTF8AndNUL(t *testing.T) {
 	malformed := "prefix" + string([]byte{0xff}) + "\x00suffix"


### PR DESCRIPTION
fix: match only intended qdrant collections

  ## description

  qdrant searches and chunk updates could include backup collections or other collections with similar names. this change checks the full expected name so those operations only use the intended collections.

  ## type of change

  - [x] bug fix
  - [ ] ✨ new feature
  - [ ] breaking change
  - [ ] documentation update
  - [ ] refactor
  - [ ] ⚡ performance improvement
  - [x] test
  - [ ] configuration / build / ci

  ## related issue

  none.

  ## testing

  passed:
  - `go test ./internal/application/repository/retriever/qdrant`
  - `git diff --check origin/main...HEAD`

  tests cover valid names, similar prefixes, backup names, missing separators and invalid dimensions.

  diff-scoped lint and full-repository checks were not run. testing was limited to the affected package.

  ## checklist

  - [x] `git diff --check origin/main...HEAD` passes
  - [x] changed source files are formatted
  - [x] targeted tests for the changed packages/components pass
  - [ ] diff-scoped lint passes where applicable
  - [ ] full-repository checks were run, or any unrelated/environment-dependent failures are documented above
  - [x] self-reviewed the code
  - [x] added/updated tests covering the change
  - [ ] updated related documentation — not needed
  - [ ] breaking changes are clearly called out — none

  ## screenshots / recordings

  not applicable; no ui changes.
