### PR TITLE
feat(chat): accept extra attachment formats via deploy-time config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -510,6 +510,11 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434
 # 附件 VLM OCR 调优（扫描件/图片型文档）：并发数 / 最大页数。
 # WEKNORA_CHAT_ATTACHMENT_OCR_CONCURRENCY=8
 # WEKNORA_CHAT_ATTACHMENT_OCR_MAX_PAGES=8
+# 聊天附件额外放行的扩展名（逗号分隔，如 ".msg,.seq,.ab1"）：清单内的格式可在对话框上传，
+# 不走解析流水线，原样存入 Agent 沙箱 /workspace/input 供 skill/MCP 工具读取（前端由 config.js
+# 同步放行）。须同时传给 app 与 frontend 两个服务，属部署期配置，改后重启两端生效。
+# 可执行格式（exe/dll/so/bat/cmd/jar 等）在硬黑名单内，配置也不放行。
+# WEKNORA_CHAT_ATTACHMENT_EXTRA_EXTENSIONS=.msg,.seq,.ab1
 
 # ========== E9. 飞书云文档解析模式 ==========
 # 控制飞书云盘 / 飞书知识库同步新版云文档（docx）时的解析路径：

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
       - MAX_SKILL_BUNDLE_SIZE_MB=${MAX_SKILL_BUNDLE_SIZE_MB:-256}
       - DEFAULT_LOCALE=${DEFAULT_LOCALE:-}
+      # 聊天附件额外放行的扩展名（逗号分隔，须与 app 同值；注入 config.js 供前端放行）
+      - WEKNORA_CHAT_ATTACHMENT_EXTRA_EXTENSIONS=${WEKNORA_CHAT_ATTACHMENT_EXTRA_EXTENSIONS:-}
       - APP_HOST=${APP_HOST:-app}
       # APP_BACKEND_PORT: the port NGINX proxies to (default 8080).
       # For local deployment this is the App container's listening port, independent of host-mapped APP_PORT.
@@ -329,6 +331,10 @@ services:
       - WEKNORA_CHAT_ATTACHMENT_WAIT_TIMEOUT_SEC=${WEKNORA_CHAT_ATTACHMENT_WAIT_TIMEOUT_SEC:-60}
       - WEKNORA_CHAT_ATTACHMENT_OCR_CONCURRENCY=${WEKNORA_CHAT_ATTACHMENT_OCR_CONCURRENCY:-8}
       - WEKNORA_CHAT_ATTACHMENT_OCR_MAX_PAGES=${WEKNORA_CHAT_ATTACHMENT_OCR_MAX_PAGES:-8}
+      # 聊天附件额外放行的扩展名（逗号分隔，如 ".msg,.seq,.ab1"）：原样透传存进沙箱供 skill/MCP
+      # 读取，不走解析流水线；须与 frontend 服务同值，改后重启两端生效。
+      # 可执行格式（exe/dll/bat 等）在硬黑名单内，配置也不放行。
+      - WEKNORA_CHAT_ATTACHMENT_EXTRA_EXTENSIONS=${WEKNORA_CHAT_ATTACHMENT_EXTRA_EXTENSIONS:-}
       # Agent LLM call timeout
       - WEKNORA_AGENT_LLM_TIMEOUT=${WEKNORA_AGENT_LLM_TIMEOUT:-}
       - WEKNORA_AGENT_TOOL_APPROVAL_TIMEOUT=${WEKNORA_AGENT_TOOL_APPROVAL_TIMEOUT:-}

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -16,11 +16,17 @@ if [ "$SKILL_MB" -gt 512 ] 2>/dev/null; then
   SKILL_MB=512
 fi
 
+# Extra chat attachment extensions (comma-separated, e.g. ".msg,.seq,.ab1").
+# Whitelist characters so an env value can't inject JS into config.js; empty
+# keeps the built-in attachment whitelist unchanged.
+CHAT_EXTRA_EXT=$(printf '%s' "${WEKNORA_CHAT_ATTACHMENT_EXTRA_EXTENSIONS:-}" | tr -cd 'a-zA-Z0-9.,_-' | cut -c1-512)
+
 cat > /usr/share/nginx/html/config.js << EOF
 window.__RUNTIME_CONFIG__ = {
   MAX_FILE_SIZE_MB: ${FILE_MB},
   MAX_SKILL_BUNDLE_SIZE_MB: ${SKILL_MB},
-  DEFAULT_LOCALE: "${RUNTIME_DEFAULT_LOCALE}"
+  DEFAULT_LOCALE: "${RUNTIME_DEFAULT_LOCALE}",
+  CHAT_ATTACHMENT_EXTRA_EXTENSIONS: "${CHAT_EXTRA_EXT}"
 };
 EOF
 

--- a/frontend/public/config.js
+++ b/frontend/public/config.js
@@ -6,4 +6,8 @@ window.__RUNTIME_CONFIG__ = {
   EMBED_BASE_URL: '',
   // Optional: default UI locale for first-time visitors (zh-CN | en-US | ru-RU | ko-KR | ja-JP)
   DEFAULT_LOCALE: '',
+  // Optional: extra chat attachment extensions, comma-separated (e.g. '.msg,.seq,.ab1').
+  // Mirrors WEKNORA_CHAT_ATTACHMENT_EXTRA_EXTENSIONS; uploaded files skip parsing
+  // and are staged into the agent sandbox for skills / MCP tools.
+  CHAT_ATTACHMENT_EXTRA_EXTENSIONS: '',
 };

--- a/frontend/src/components/AttachmentUpload.vue
+++ b/frontend/src/components/AttachmentUpload.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { MessagePlugin } from 'tdesign-vue-next';
 import { useI18n } from 'vue-i18n';
-import { MAX_FILE_SIZE_MB } from '@/utils';
+import { MAX_FILE_SIZE_MB, CHAT_ATTACHMENT_EXTRA_EXTENSIONS } from '@/utils';
 import { getParserEngines } from '@/api/system';
 import {
   deleteTemporaryAttachment,
@@ -57,6 +57,9 @@ const supportedTypes = ref([
 	'.jpg', '.jpeg', '.png', '.gif', '.bmp', '.tiff', '.webp',
   // Audio
   '.mp3', '.wav', '.m4a', '.flac', '.ogg', '.aac',
+  // Deploy-time extra extensions (WEKNORA_CHAT_ATTACHMENT_EXTRA_EXTENSIONS):
+  // uploaded as raw files for skills / MCP tools; the backend skips parsing.
+  ...CHAT_ATTACHMENT_EXTRA_EXTENSIONS,
 ]);
 
 onMounted(async () => {

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -9,6 +9,7 @@ declare global {
       MAX_FILE_SIZE_MB?: number;
       MAX_SKILL_BUNDLE_SIZE_MB?: number;
       DEFAULT_LOCALE?: string;
+      CHAT_ATTACHMENT_EXTRA_EXTENSIONS?: string;
     };
   }
 }
@@ -40,6 +41,39 @@ export const MAX_SKILL_BUNDLE_SIZE_MB = Math.min(
   ),
 )
 export const MAX_SKILL_BUNDLE_SIZE_BYTES = MAX_SKILL_BUNDLE_SIZE_MB * 1024 * 1024
+
+// Deploy-time extra chat attachment extensions (comma-separated, e.g.
+// ".msg,.seq,.ab1"; the frontend entrypoint mirrors
+// WEKNORA_CHAT_ATTACHMENT_EXTRA_EXTENSIONS into the runtime config). Files
+// with these extensions are accepted by the chat attachment picker and
+// uploaded as raw attachments: the backend stages them into the agent sandbox
+// instead of parsing, so skills / MCP tools read the originals directly.
+export const CHAT_ATTACHMENT_EXTRA_EXTENSIONS = parseChatAttachmentExtraExtensions(
+  window.__RUNTIME_CONFIG__?.CHAT_ATTACHMENT_EXTRA_EXTENSIONS
+    ?? import.meta.env.VITE_CHAT_ATTACHMENT_EXTRA_EXTENSIONS,
+)
+
+// Executable formats the backend refuses even when listed in the extra
+// extensions config (chat attachments land in agent sandboxes). Mirrored from
+// temporaryDocumentBlockedExtensions in temporary_document.go — filtering here
+// keeps the picker from offering files the upload would only reject.
+const CHAT_ATTACHMENT_BLOCKED_EXTENSIONS = new Set([
+  '.exe', '.dll', '.so', '.dylib', '.msi',
+  '.com', '.scr', '.bat', '.cmd', '.jar',
+  '.ps1', '.vbs', '.hta',
+])
+
+function parseChatAttachmentExtraExtensions(raw: string | undefined | null): string[] {
+  if (!raw) return []
+  return [...new Set(
+    raw
+      .split(',')
+      .map(ext => ext.trim().toLowerCase())
+      .filter(Boolean)
+      .map(ext => (ext.startsWith('.') ? ext : `.${ext}`))
+      .filter(ext => !CHAT_ATTACHMENT_BLOCKED_EXTENSIONS.has(ext)),
+  )]
+}
 
 export function generateRandomString(length: number) {
   let result = "";

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -42,6 +42,16 @@ export const MAX_SKILL_BUNDLE_SIZE_MB = Math.min(
 )
 export const MAX_SKILL_BUNDLE_SIZE_BYTES = MAX_SKILL_BUNDLE_SIZE_MB * 1024 * 1024
 
+// Executable formats the backend refuses even when listed in the extra
+// extensions config (chat attachments land in agent sandboxes). Mirrored from
+// temporaryDocumentBlockedExtensions in temporary_document.go — filtering here
+// keeps the picker from offering files the upload would only reject.
+const CHAT_ATTACHMENT_BLOCKED_EXTENSIONS = new Set([
+  '.exe', '.dll', '.so', '.dylib', '.msi',
+  '.com', '.scr', '.bat', '.cmd', '.jar',
+  '.ps1', '.vbs', '.hta',
+])
+
 // Deploy-time extra chat attachment extensions (comma-separated, e.g.
 // ".msg,.seq,.ab1"; the frontend entrypoint mirrors
 // WEKNORA_CHAT_ATTACHMENT_EXTRA_EXTENSIONS into the runtime config). Files
@@ -52,16 +62,6 @@ export const CHAT_ATTACHMENT_EXTRA_EXTENSIONS = parseChatAttachmentExtraExtensio
   window.__RUNTIME_CONFIG__?.CHAT_ATTACHMENT_EXTRA_EXTENSIONS
     ?? import.meta.env.VITE_CHAT_ATTACHMENT_EXTRA_EXTENSIONS,
 )
-
-// Executable formats the backend refuses even when listed in the extra
-// extensions config (chat attachments land in agent sandboxes). Mirrored from
-// temporaryDocumentBlockedExtensions in temporary_document.go — filtering here
-// keeps the picker from offering files the upload would only reject.
-const CHAT_ATTACHMENT_BLOCKED_EXTENSIONS = new Set([
-  '.exe', '.dll', '.so', '.dylib', '.msi',
-  '.com', '.scr', '.bat', '.cmd', '.jar',
-  '.ps1', '.vbs', '.hta',
-])
 
 function parseChatAttachmentExtraExtensions(raw: string | undefined | null): string[] {
   if (!raw) return []

--- a/internal/application/service/temporary_document.go
+++ b/internal/application/service/temporary_document.go
@@ -93,6 +93,52 @@ var temporaryTextExtensions = map[string]struct{}{
 	".md": {}, ".markdown": {}, ".txt": {}, ".csv": {}, ".json": {}, ".xml": {}, ".yaml": {}, ".yml": {}, ".log": {},
 }
 
+// chatAttachmentExtraExtensionsEnv lists comma-separated file extensions chat
+// attachments accept beyond the built-in whitelist (e.g. ".msg,.seq,.ab1").
+// Extensions configured here have no parser: the raw bytes are stored and
+// staged into the agent sandbox's session input directory, where skills and
+// MCP tools read them directly, so no parse task is scheduled.
+const chatAttachmentExtraExtensionsEnv = "WEKNORA_CHAT_ATTACHMENT_EXTRA_EXTENSIONS"
+
+// temporaryDocumentBlockedExtensions is the hard deny-list that no extra
+// configuration can override. Attachments land in agent sandboxes, so formats
+// a platform can execute directly (binaries, double-click launchers and
+// scripts) stay rejected even when an operator lists them. The frontend
+// filters the same set in parseChatAttachmentExtraExtensions (utils/index.ts).
+var temporaryDocumentBlockedExtensions = map[string]struct{}{
+	".exe": {}, ".dll": {}, ".so": {}, ".dylib": {}, ".msi": {},
+	".com": {}, ".scr": {}, ".bat": {}, ".cmd": {}, ".jar": {},
+	".ps1": {}, ".vbs": {}, ".hta": {},
+}
+
+// chatAttachmentExtraExtensions parses WEKNORA_CHAT_ATTACHMENT_EXTRA_EXTENSIONS
+// into a normalized extension set (lowercase, leading dot, deny-listed entries
+// dropped). Returns nil when unset or effectively empty.
+func chatAttachmentExtraExtensions() map[string]struct{} {
+	raw := strings.TrimSpace(os.Getenv(chatAttachmentExtraExtensionsEnv))
+	if raw == "" {
+		return nil
+	}
+	out := make(map[string]struct{})
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.ToLower(strings.TrimSpace(entry))
+		if entry == "" {
+			continue
+		}
+		if !strings.HasPrefix(entry, ".") {
+			entry = "." + entry
+		}
+		if _, blocked := temporaryDocumentBlockedExtensions[entry]; blocked {
+			continue
+		}
+		out[entry] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 type temporaryDocumentService struct {
 	repo            interfaces.TemporaryDocumentRepository
 	fileService     interfaces.FileService
@@ -154,7 +200,8 @@ func (s *temporaryDocumentService) Create(
 	if resourceTenantID == 0 {
 		resourceTenantID = tenantID
 	}
-	if !s.supportsExtension(ctx, resourceTenantID, ext) {
+	supported, passthrough := s.extensionSupport(ctx, resourceTenantID, ext)
+	if !supported {
 		return nil, fmt.Errorf("unsupported file type: %s", ext)
 	}
 	maxSize := secutils.GetMaxFileSizeMB() * 1024 * 1024
@@ -195,6 +242,22 @@ func (s *temporaryDocumentService) Create(
 			return nil, fmt.Errorf("bind attachment resource: %w", err)
 		}
 	}
+	if passthrough {
+		// Extra-configured extensions have no parser: store the raw bytes and
+		// mark the document ready immediately. The agent sandbox stages the
+		// original file into the session input directory for skills / MCP
+		// tools, so no parse task is scheduled.
+		metadataJSON, _ := json.Marshal(map[string]string{"parser": "passthrough"})
+		if err := s.repo.MarkReady(ctx, tenantID, document.ID, "",
+			types.JSON("[]"), types.JSON("[]"), types.JSON(metadataJSON), 0, 0, time.Now()); err != nil {
+			_ = s.repo.MarkFailed(ctx, tenantID, document.ID, "failed to finalize passthrough attachment")
+			document.Status = types.TemporaryDocumentStatusFailed
+			document.ErrorMessage = "failed to finalize passthrough attachment"
+			return document, fmt.Errorf("finalize passthrough attachment: %w", err)
+		}
+		document.Status = types.TemporaryDocumentStatusReady
+		return document, nil
+	}
 	payload, _ := json.Marshal(types.TemporaryDocumentTaskPayload{TenantID: tenantID, DocumentID: document.ID})
 	queue, _ := types.QueueForTaskType(types.TypeTemporaryDocumentProcess)
 	if _, err := s.taskEnqueuer.Enqueue(
@@ -209,16 +272,35 @@ func (s *temporaryDocumentService) Create(
 	return document, nil
 }
 
-func (s *temporaryDocumentService) supportsExtension(ctx context.Context, tenantID uint64, ext string) bool {
+// extensionSupport classifies an extension in one engine lookup: supported
+// says whether the upload is accepted, passthrough says the file is stored raw
+// for the agent sandbox instead of being parsed. Built-in and parser-engine
+// extensions always parse; an extra-configured extension only passthroughs
+// when no parser engine declares it.
+func (s *temporaryDocumentService) extensionSupport(ctx context.Context, tenantID uint64, ext string) (supported, passthrough bool) {
 	if _, ok := temporaryDocumentExtensions[ext]; ok {
-		return true
+		return true, false
 	}
+	if _, ok := chatAttachmentExtraExtensions()[ext]; !ok {
+		return s.engineSupportsExtension(ctx, tenantID, ext), false
+	}
+	if s.engineSupportsExtension(ctx, tenantID, ext) {
+		return true, false
+	}
+	return true, true
+}
+
+// engineSupportsExtension reports whether an available parser engine declares
+// the extension in its FileTypes.
+func (s *temporaryDocumentService) engineSupportsExtension(ctx context.Context, tenantID uint64, ext string) bool {
 	if s.documentReader == nil {
 		return false
 	}
 	var overrides map[string]string
-	if tenant, err := s.tenantService.GetTenantByID(ctx, tenantID); err == nil && tenant != nil {
-		overrides = tenant.ParserEngineConfig.ToOverridesMap()
+	if s.tenantService != nil {
+		if tenant, err := s.tenantService.GetTenantByID(ctx, tenantID); err == nil && tenant != nil {
+			overrides = tenant.ParserEngineConfig.ToOverridesMap()
+		}
 	}
 	engines, err := s.documentReader.ListEngines(ctx, overrides)
 	if err != nil {

--- a/internal/application/service/temporary_document_test.go
+++ b/internal/application/service/temporary_document_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Tencent/WeKnora/internal/models/vlm"
 	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
 )
 
 // fakeVLM is a minimal VLM stub that records calls and returns a fixed response.
@@ -266,5 +267,81 @@ func TestVisualDocumentQueryDetection(t *testing.T) {
 	}
 	if isVisualDocumentQuery("总结退款政策") {
 		t.Fatal("plain text query should not request visual context")
+	}
+}
+
+// stubEngineReader answers ListEngines from a fixed engine table. The embedded
+// interface stays nil: extensionSupport only calls ListEngines on this path.
+type stubEngineReader struct {
+	interfaces.DocumentReader
+	engines []types.ParserEngineInfo
+}
+
+func (r *stubEngineReader) ListEngines(context.Context, map[string]string) ([]types.ParserEngineInfo, error) {
+	return r.engines, nil
+}
+
+func TestChatAttachmentExtraExtensionsParsing(t *testing.T) {
+	t.Setenv(chatAttachmentExtraExtensionsEnv, " .MSG, seq ,AB1,.exe, ,dll,exe,ps1,vbs,hta")
+	got := chatAttachmentExtraExtensions()
+	want := map[string]struct{}{".msg": {}, ".seq": {}, ".ab1": {}}
+	if len(got) != len(want) {
+		t.Fatalf("parsed extensions = %v, want %v", got, want)
+	}
+	for ext := range want {
+		if _, ok := got[ext]; !ok {
+			t.Fatalf("parsed extensions missing %q: %v", ext, got)
+		}
+	}
+}
+
+func TestChatAttachmentExtraExtensionsEmptyWhenUnset(t *testing.T) {
+	if got := chatAttachmentExtraExtensions(); got != nil {
+		t.Fatalf("unset env should yield nil, got %v", got)
+	}
+	t.Setenv(chatAttachmentExtraExtensionsEnv, " , ,, ")
+	if got := chatAttachmentExtraExtensions(); got != nil {
+		t.Fatalf("blank entries only should yield nil, got %v", got)
+	}
+}
+
+func TestExtensionSupportClassifiesPassthrough(t *testing.T) {
+	// documentReader == nil disables the engine lookup, isolating the
+	// static + extra classification.
+	svc := &temporaryDocumentService{}
+	t.Setenv(chatAttachmentExtraExtensionsEnv, ".msg,.exe")
+
+	cases := []struct {
+		ext                  string
+		supported, passthru  bool
+	}{
+		{".pdf", true, false},  // built-in: parses
+		{".msg", true, true},   // extra only: raw passthrough
+		{".zip", false, false}, // unknown: rejected
+		{".exe", false, false}, // deny-listed: rejected even though listed
+	}
+	for _, tc := range cases {
+		supported, passthrough := svc.extensionSupport(context.Background(), 1, tc.ext)
+		if supported != tc.supported || passthrough != tc.passthru {
+			t.Fatalf("extensionSupport(%q) = (%v, %v), want (%v, %v)",
+				tc.ext, supported, passthrough, tc.supported, tc.passthru)
+		}
+	}
+}
+
+func TestExtensionSupportEngineWinsOverExtraForParsing(t *testing.T) {
+	// A parser engine declaring the extension still parses it, so adding a
+	// type to the extra list doesn't silently downgrade parsing once an
+	// engine learns the format.
+	svc := &temporaryDocumentService{documentReader: &stubEngineReader{
+		engines: []types.ParserEngineInfo{{Name: "anydoc", Available: true, FileTypes: []string{"msg"}}},
+	}}
+	t.Setenv(chatAttachmentExtraExtensionsEnv, ".msg,.ab1")
+
+	if _, passthrough := svc.extensionSupport(context.Background(), 1, ".msg"); passthrough {
+		t.Fatal("engine-declared extension must parse, not passthrough")
+	}
+	if _, passthrough := svc.extensionSupport(context.Background(), 1, ".ab1"); !passthrough {
+		t.Fatal("extra extension without engine support must passthrough")
 	}
 }

--- a/internal/handler/session/attachment_processor.go
+++ b/internal/handler/session/attachment_processor.go
@@ -302,6 +302,10 @@ func (p *AttachmentProcessor) applyLineTruncation(ctx context.Context, content s
 
 // isValidFileType reports whether fileName has a supported extension.
 // Kept in sync with the frontend SUPPORTED_TYPES list in AttachmentUpload.vue.
+// The pre-upload chat path additionally accepts the deploy-time extra
+// extensions (WEKNORA_CHAT_ATTACHMENT_EXTRA_EXTENSIONS, see
+// temporary_document.go); this inline/embed path intentionally does not —
+// those files are raw passthrough and only meaningful to agent sessions.
 func isValidFileType(fileName string) bool {
 	ext := strings.ToLower(filepath.Ext(fileName))
 	if ext == "" {


### PR DESCRIPTION
Chat attachments are gated by a hardcoded extension whitelist, so industry formats like .msg/.seq/.ab1 cannot be uploaded even when an agent's skills or MCP tools know how to process them (#3087).

Add WEKNORA_CHAT_ATTACHMENT_EXTRA_EXTENSIONS (comma-separated, deploy-time like MAX_FILE_SIZE_MB): the app validates it on upload, and the frontend entrypoint mirrors it into config.js so the picker accepts the same set. Listed extensions bypass the parse pipeline: the raw file is stored, marked ready immediately, and staged read-only into the agent sandbox session input directory where skills/MCP tools read it. Built-in and parser-engine extensions keep their normal parsing; executable formats (exe/dll/bat/jar/ps1...) stay on a hard deny-list that the config cannot override.

<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
<!-- Briefly describe the purpose and changes of this PR -->

## Type of Change
<!-- Check applicable items -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
<!-- If this PR resolves an issue, use "Fixes #123" or "Closes #123" -->
Fixes #

## Testing
<!-- Describe how these changes were tested. Include reproduction or verification steps. -->
<!--
For a focused change, run checks scoped to the files/packages you changed.
See the Contributing section in README.md for examples. If a full-repository
check is blocked by unrelated baseline or environment failures, record the
exact command and failure here.
-->

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
