### PR TITLE
fix(frontend): keep agent editor dependency loading alive for contributors

### DIFF
--- a/frontend/src/stores/editorResources.ts
+++ b/frontend/src/stores/editorResources.ts
@@ -15,6 +15,7 @@ import { listMCPServices, type MCPService } from '@/api/mcp-service'
 import { listSkillCatalog, listSkills, type SkillCatalogItem, type SkillInfo } from '@/api/skill'
 import { getAgentTypePresets, getPlaceholders, type AgentTypePreset, type PlaceholdersResponse } from '@/api/agent'
 import { getTenantRetrievalConfig } from '@/api/retrieval'
+import { isStorageConfigDenied } from './storageEngineAccess'
 
 const CACHE_TTL_MS = 60_000
 
@@ -87,7 +88,15 @@ export const useEditorResourcesStore = defineStore('editorResources', () => {
   async function ensureStorageEngine(force = false): Promise<void> {
     return runOnce('storageEngine', force, async () => {
       const [configRes, statusRes] = await Promise.all([
-        getStorageEngineConfig(),
+        // The config endpoint is admin-only (it carries integration secrets),
+        // while every creator — Contributors included — needs the status list
+        // to pick a usable provider. A permission rejection on the config
+        // call must therefore degrade to "no admin config", not break the
+        // whole editor dependency chain (#2991).
+        getStorageEngineConfig().catch((error: unknown) => {
+          if (isStorageConfigDenied(error)) return null
+          throw error
+        }),
         getStorageEngineStatus(),
       ])
       storageConfig.value = configRes?.data ?? null

--- a/frontend/src/stores/storageEngineAccess.test.ts
+++ b/frontend/src/stores/storageEngineAccess.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { isStorageConfigDenied } from './storageEngineAccess.ts'
+
+/** Mirrors withHttpStatus in utils/request.ts: rejected values carry a
+ * non-enumerable `status` property on the payload. */
+function rejectedWithStatus(status: number, message = 'forbidden'): unknown {
+  const payload: Record<string, unknown> = { message }
+  Object.defineProperty(payload, 'status', { value: status, enumerable: false })
+  return payload
+}
+
+test('isStorageConfigDenied accepts permission rejections', () => {
+  assert.equal(isStorageConfigDenied(rejectedWithStatus(403)), true)
+  assert.equal(isStorageConfigDenied(rejectedWithStatus(401)), true)
+})
+
+test('isStorageConfigDenied rejects other failures so they stay fatal', () => {
+  assert.equal(isStorageConfigDenied(rejectedWithStatus(500)), false)
+  assert.equal(isStorageConfigDenied(rejectedWithStatus(404)), false)
+  assert.equal(isStorageConfigDenied(new Error('network down')), false)
+  assert.equal(isStorageConfigDenied(null), false)
+  assert.equal(isStorageConfigDenied(undefined), false)
+  assert.equal(isStorageConfigDenied('403'), false)
+})

--- a/frontend/src/stores/storageEngineAccess.ts
+++ b/frontend/src/stores/storageEngineAccess.ts
@@ -1,0 +1,18 @@
+/**
+ * Whether a storage-engine config request was rejected for permissions.
+ *
+ * The tenant KV key `storage-engine-config` is admin-only (it carries
+ * integration secrets), while every agent creator — Contributors included —
+ * needs the Viewer-safe status list to pick a usable provider. The store's
+ * ensureStorageEngine therefore downgrades a permission rejection on the
+ * config call to "no admin config" instead of failing the whole editor
+ * dependency chain (#2991).
+ *
+ * The rejected value carries a non-enumerable `status` property (see
+ * `withHttpStatus` in utils/request.ts); only 401/403 mean "this caller
+ * may not read the admin-only config". Anything else stays fatal.
+ */
+export function isStorageConfigDenied(error: unknown): boolean {
+  const status = (error as { status?: unknown } | null | undefined)?.status
+  return status === 401 || status === 403
+}


### PR DESCRIPTION
Fixes #2991

## Problem

A **Contributor** (editor role) opening the agent editor gets empty model / knowledge-base / web-search dropdowns and cannot create agents at all. The browser console shows `GET /api/v1/tenants/kv/storage-engine-config` → 403, and the whole dependency load aborts.

## Root cause

Two halves, only one of which is a bug:

- **Backend (deliberate)**: the tenant KV key `storage-engine-config` requires admin (`internal/handler/tenant.go`, `CanViewIntegrationSecrets`) — it carries integration secrets, so this ACL is intentional and unchanged.
- **Frontend (bug)**: `editorResources.ensureStorageEngine` awaited the admin-only config call and the Viewer-safe `storage-engine-status` call in one `Promise.all`. A Contributor's 403 rejects that, which rejects `prefetchAgentEditorDeps`, which rejects `AgentEditorModal.loadDependencies`' `Promise.all` — and because the dropdown population sits *after* that await, every list stays empty.

Reproduced on current main (API level): Contributor token → `GET /tenants/kv/storage-engine-config` → 403 `integration configuration requires admin access`; Owner → 200.

## Change

`ensureStorageEngine` now treats a **permission rejection (401/403) on the config call** as "no admin config" instead of a fatal error; everything else (network, 5xx) stays fatal so genuine failures still surface. The Viewer-safe status call remains required — it is what actually drives provider pickability (`resolveUsableStorageProvider` reads `storageStatus`/`storageAllowedProviders`, not the config).

The only consumer of `storageConfig` (`KnowledgeBaseEditorModal`'s `loadTenantDefaultStorageProvider`) already null-tolerates it and falls back to the status-based pick, so Contributors degrade to exactly that path.

The 401/403 predicate lives in a dependency-free module (`storageEngineAccess.ts`) so it is unit-testable with `tsx --test`, following the existing `*State.ts` store-helper pattern.

## Tests

- `frontend/src/stores/storageEngineAccess.test.ts`: permission rejections (401/403, mirroring the non-enumerable `status` the request layer attaches) are recognized; 500/404/`Error`/null/undefined/string are not.
- Full frontend suite: 194 pass (192 existing + 2 new), typecheck and production build clean.