### PR TITLE
fix(knowledge): hide mutation controls on read-only shared knowledge bases

### DIFF
--- a/frontend/src/utils/kbPermission.test.ts
+++ b/frontend/src/utils/kbPermission.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { permissionCanEditKB, permissionCanManageKB } from './kbPermission.ts'
+
+test('editor-level grants allow knowledge mutations', () => {
+  assert.equal(permissionCanEditKB('owner'), true)
+  assert.equal(permissionCanEditKB('admin'), true)
+  assert.equal(permissionCanEditKB('editor'), true)
+})
+
+test('viewer grant (read-only share) never allows mutations (#3098)', () => {
+  assert.equal(permissionCanEditKB('viewer'), false)
+})
+
+test('missing permission does not answer the question', () => {
+  // Callers must fall through to their own-tenant logic for '' / null.
+  assert.equal(permissionCanEditKB(''), false)
+  assert.equal(permissionCanEditKB(null), false)
+  assert.equal(permissionCanEditKB(undefined), false)
+})
+
+test('manage requires admin-level grant', () => {
+  assert.equal(permissionCanManageKB('owner'), true)
+  assert.equal(permissionCanManageKB('admin'), true)
+  assert.equal(permissionCanManageKB('editor'), false)
+  assert.equal(permissionCanManageKB('viewer'), false)
+  assert.equal(permissionCanManageKB(''), false)
+  assert.equal(permissionCanManageKB(undefined), false)
+})

--- a/frontend/src/utils/kbPermission.ts
+++ b/frontend/src/utils/kbPermission.ts
@@ -1,0 +1,23 @@
+/**
+ * Decision table for org-share / shared-agent permission grants on
+ * knowledge bases.
+ *
+ * Cross-tenant KBs always carry an explicit effective permission
+ * (`min(share.permission, org_role, tenant_role_cap)` resolved server-side,
+ * surfaced as `permission` on shared cards and `my_permission` on the KB
+ * detail payload). When such a grant exists it is the ONLY thing that
+ * counts: the browsing user's local tenant role (e.g. being an admin of
+ * their own personal workspace) must never upgrade it, because the
+ * backend RBAC cap would 403 the mutation anyway — showing the buttons
+ * just produces dead ends (#3098).
+ */
+
+/** Editor-level grant: knowledge/chunk mutations (upload, edit, delete chunks). */
+export function permissionCanEditKB(permission: string | null | undefined): boolean {
+  return permission === 'owner' || permission === 'admin' || permission === 'editor'
+}
+
+/** Admin-level grant: KB settings and destructive KB operations (delete). */
+export function permissionCanManageKB(permission: string | null | undefined): boolean {
+  return permission === 'owner' || permission === 'admin'
+}

--- a/frontend/src/views/knowledge/KnowledgeBase.vue
+++ b/frontend/src/views/knowledge/KnowledgeBase.vue
@@ -13,6 +13,7 @@ import { useMenuStore } from '@/stores/menu';
 import { useUIStore } from '@/stores/ui';
 import { useOrganizationStore } from '@/stores/organization';
 import { useAuthStore } from '@/stores/auth';
+import { permissionCanEditKB, permissionCanManageKB } from '@/utils/kbPermission';
 import { useChatResourcesStore } from '@/stores/chatResources';
 import { useEditorResourcesStore } from '@/stores/editorResources';
 import KnowledgeBaseEditorModal from './KnowledgeBaseEditorModal.vue';
@@ -276,6 +277,11 @@ const currentSharedKb = computed(() =>
 // in the share list is the authoritative signal.
 const isViaShare = computed(() => !!currentSharedKb.value);
 
+// Effective permission: from direct org share list or from GET /knowledge-bases/:id (e.g. agent-visible KB).
+// Declared first: the canEdit / canManage gates below treat an explicit
+// cross-tenant grant as the single source of truth.
+const effectiveKBPermission = computed(() => orgStore.getKBPermission(kbId.value) || kbInfo.value?.my_permission || '');
+
 // Can edit: when accessed via an organization share, ONLY the share grant
 // counts — even if the current user happens to be the original creator of
 // the KB. The backend's RBAC middleware authorizes based on the active
@@ -283,19 +289,29 @@ const isViaShare = computed(() => !!currentSharedKb.value);
 // different tenant context will be 403'd on write. Otherwise: KB creator
 // (any role) or tenant Admin+ in the home tenant.
 //
+// A resolved cross-tenant permission (org share or shared-agent visibility,
+// already capped server-side by effective = min(share, org_role, tenant_role))
+// outranks every local signal: without this priority rule a personal-workspace
+// admin browsing a read-only shared KB saw edit entries that only led to 403s
+// (#3098).
+//
 // hasRole('contributor') is intentionally NOT here — being a Contributor
 // in a tenant does not by itself grant edit on someone else's KB.
 const canEdit = computed(() => {
+  const permission = effectiveKBPermission.value;
+  if (permission) return permissionCanEditKB(permission);
   if (isViaShare.value) return orgStore.canEditKB(kbId.value, false);
   if (isOwner.value) return true;
   if (authStore.hasRole('admin')) return true;
   return orgStore.canEditKB(kbId.value, false);
 });
 
-// Can manage (delete, settings, etc.): same isViaShare-first rule. For
+// Can manage (delete, settings, etc.): same permission-first rule. For
 // shared KBs only an 'admin' share grant qualifies — editor/viewer (and
 // even being the creator viewed via share) never grant delete/settings.
 const canManage = computed(() => {
+  const permission = effectiveKBPermission.value;
+  if (permission) return permissionCanManageKB(permission);
   if (isViaShare.value) return orgStore.canManageKB(kbId.value, false);
   if (isOwner.value) return true;
   if (authStore.hasRole('admin')) return true;
@@ -319,9 +335,6 @@ const canMutateKnowledge = computed(() => {
   if (authStore.hasRole('admin')) return true;
   return authStore.hasRole('contributor');
 });
-
-// Effective permission: from direct org share list or from GET /knowledge-bases/:id (e.g. agent-visible KB)
-const effectiveKBPermission = computed(() => orgStore.getKBPermission(kbId.value) || kbInfo.value?.my_permission || '');
 
 // Downloading returns the original source file, which is intentionally more
 // restrictive than viewing parsed content or using the preview tab. A tenant

--- a/frontend/src/views/knowledge/KnowledgeBaseList.vue
+++ b/frontend/src/views/knowledge/KnowledgeBaseList.vue
@@ -797,6 +797,7 @@ import ShareKnowledgeBaseDialog from '@/components/ShareKnowledgeBaseDialog.vue'
 import ListSpaceSidebar from '@/components/ListSpaceSidebar.vue'
 import ResourceOriginBadge from '@/components/ResourceOriginBadge.vue'
 import { shouldShowResourceOriginBadge } from '@/utils/card-list-badge'
+import { permissionCanManageKB } from '@/utils/kbPermission'
 import ContextualGuide from '@/components/ContextualGuide.vue'
 import { isContextualGuideDone, markContextualGuideDone } from '@/config/contextualGuides'
 import { useTenantModelReadiness } from '@/composables/useTenantModelReadiness'
@@ -1352,6 +1353,17 @@ const handleSettings = (kb: KB) => {
 // those as tenant-owned (Admin+ may manage) so existing KBs aren't
 // suddenly unmanageable for everyone.
 function canManageKBCard(kb: KB): boolean {
+  // Shared-space cards carry the org-share permission; when it exists it is
+  // the only signal that counts. A read-only (viewer) or editor share must
+  // not surface Settings/Delete even when the browsing user is an admin of
+  // their own personal workspace — the backend 3-D permission cap would 403
+  // the call anyway (#3098).
+  const sharePermission = (kb as any).permission as string | undefined
+  if (sharePermission) return permissionCanManageKB(sharePermission)
+  // Shared-card shapes that lost their permission field (pin/recents merges)
+  // are marked isMine === false; they must not fall through to the local
+  // admin/creator fallbacks either.
+  if ((kb as any).isMine === false) return false
   const userId = authStore.user?.id || ''
   if (kb.creator_id && userId && kb.creator_id === userId) return true
   return authStore.hasRole('admin')


### PR DESCRIPTION
## Description

Fixes #3098

The issue reports that a user who joined an organization and opened a **read-only** shared knowledge base could still see (and click) document upload/edit, chunk editing, list-row delete, and KB settings/delete controls. Code-level confirmation:

- `frontend/src/views/knowledge/KnowledgeBase.vue` — `canEdit` / `canManage` only consulted the org share list via `isViaShare`; when the share list did not cover the KB (deep link, per-org scoping, agent-visible KB), they fell back to `authStore.hasRole('admin')` — the user's role in their **own personal workspace**, which is `admin` for typical users. Edit entries rendered even though the backend denies every mutation.
- `frontend/src/views/knowledge/KnowledgeBaseList.vue` — `canManageKBCard` (gates the card menu's Settings/Delete) never consulted the share permission at all: creator match or the same local-admin fallback showed destructive entries on read-only shared cards.

The backend is already correct: `RequireKBAccess(..., OrgRoleEditor, ...)` plus the 3-D cap `effective = min(share.Permission, org_role, tenant_role_cap)` (`internal/application/service/kbshare.go`, `internal/middleware/kb_access.go`) rejects these writes — the UI simply surfaced buttons the user has no authority to use.

### Change

- New pure decision table `frontend/src/utils/kbPermission.ts`: `permissionCanEditKB` (owner/admin/editor) and `permissionCanManageKB` (owner/admin).
- `KnowledgeBase.vue`: `effectiveKBPermission` (org share list entry, else `my_permission` from `GET /knowledge-bases/:id` — both already capped server-side) is now declared first and checked **before** every local signal in `canEdit` / `canManage`. The local creator/admin fallbacks remain only for own-tenant KBs, so no previously working action is hidden.
- `KnowledgeBaseList.vue`: `canManageKBCard` checks the card's share permission first; cards marked `isMine === false` whose permission field went missing in the pin/recents merges are treated as read-only instead of falling through to the local admin role.

Agent-visible KBs (`my_permission: "viewer"`) had the same dead-end buttons before; they are covered by the same fix.

### Type of Change

- [x] 🐛 Bug fix

### Related Issue

- Fixes #3098

### Testing

- New tests: `frontend/src/utils/kbPermission.test.ts` — 4 cases covering editor-level grants, viewer (read-only) denial, missing-permission fall-through (callers keep their own-tenant logic), and the admin-level manage table.
- `node --experimental-strip-types --test src/utils/kbPermission.test.ts` — 4/4 pass (repo runner is `tsx --test`; no node_modules in this environment, so the dependency-free util test runs on the node type-stripping flag).
- Behavior matrix re-verified by hand for regressions: own KB (permission empty → unchanged fallbacks), org-share editor (edit yes / manage no, same as before), org-share viewer (nothing, was broken), agent-visible viewer (nothing, was broken), personal admin on a shared KB (no longer sees dead-end controls).
- Pre-existing issue note: none — frontend-only change; no Go packages touched.

### Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Breaking changes are clearly called out in the description above — none
