### PR TITLE
fix(agent): preserve truncated answers across streaming and history

### DIFF
--- a/frontend/src/composables/useChatStreamHandler.test.mjs
+++ b/frontend/src/composables/useChatStreamHandler.test.mjs
@@ -1,8 +1,63 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import test from 'node:test'
+import vm from 'node:vm'
+import ts from 'typescript'
 
 const source = readFileSync(new URL('./useChatStreamHandler.ts', import.meta.url), 'utf8')
+
+// Execute the real composable while replacing only Vue/app lifecycle imports.
+function streamHarness(content = '') {
+  const module = { exports: {} }
+  vm.runInNewContext(ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+  }).outputText, {
+    exports: module.exports,
+    require: (name) => {
+      if (name === 'vue') return { markRaw: (v) => v, nextTick: (fn) => Promise.resolve().then(fn) }
+      if (name === 'vue-i18n') return { useI18n: () => ({ t: (key) => key }) }
+      return new Proxy({}, { get: () => () => {} })
+    },
+    console,
+  })
+  const messages = [{ id: 'message', role: 'assistant', content, isAgentMode: true }]
+  const ref = (value) => ({ value })
+  const handler = module.exports.useChatStreamHandler({
+    messagesList: messages, loading: ref(false), isReplying: ref(true),
+    currentAssistantMessageId: ref('message'), fullContent: ref(content),
+    isAgentStreamSession: () => true, scrollToBottom: () => {},
+  })
+  return {
+    message: messages[0],
+    send: (id, text, done = false) => handler.processStreamChunk({
+      id: 'message', response_type: 'answer', content: text, done, data: { event_id: id },
+    }),
+  }
+}
+
+test('distinct answer events append each segment exactly once', () => {
+  const { message, send } = streamHarness()
+  send('a', 'first ')
+  send('b', 'second ')
+  send('c', 'third')
+  send('c', '', true)
+  assert.equal(message.content, 'first second third')
+})
+
+test('continued chunks share an event and preserve whitespace', () => {
+  const { message, send } = streamHarness()
+  send('a', 'first ')
+  send('a', 'second')
+  send('a', '', true)
+  assert.equal(message.content, 'first second')
+})
+
+test('resume from persisted content seeds only the first live answer', () => {
+  const { message, send } = streamHarness('saved ')
+  send('a', 'continued ')
+  send('b', 'tail')
+  assert.equal(message.content, 'saved continued tail')
+})
 
 test('failed tool results keep stdout/output instead of replacing it with the short error', () => {
   assert.match(source, /toolCallEvent\.output = dataPayload\.output \|\| data\.content/)

--- a/frontend/src/composables/useChatStreamHandler.ts
+++ b/frontend/src/composables/useChatStreamHandler.ts
@@ -825,7 +825,7 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
           }
           if (responseType === 'error' && !toolName) {
             const errorMsg = String(data.content || t('chat.processError'))
-            message.content = errorMsg
+            message.content = message.content || errorMsg
             message.is_completed = true
             isReplying.value = false
             loading.value = false
@@ -836,7 +836,7 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
           }
         } else if (responseType === 'error') {
           const errorMsg = String(data.content || t('chat.processError'))
-          message.content = errorMsg
+          message.content = message.content || errorMsg
           message.is_completed = true
           isReplying.value = false
           loading.value = false
@@ -863,7 +863,10 @@ export function useChatStreamHandler(options: UseChatStreamHandlerOptions) {
           stream.push(answerEvent)
           if (eventId) eventMap.set(eventId, answerEvent)
         }
-        if (!answerEvent.content && message.content && String(message.content).trim()) {
+        if (
+          !answerEvent.content && message.content && String(message.content).trim() &&
+          !stream.some((event) => event !== answerEvent && event.type === 'answer' && !event.superseded)
+        ) {
           answerEvent.content = message.content
         }
         if (data.content) {

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -709,6 +709,30 @@ func (e *AgentEngine) runReActIteration(
 		return iterOutcomeBreak, nil
 	}
 
+	// A token-limited plain answer must be continued, not treated as another
+	// reasoning round (which rewrites the answer and persists only its tail).
+	if len(response.ToolCalls) == 0 && isLengthFinishReason(response.FinishReason) {
+		state.RoundSteps = append(state.RoundSteps, step)
+		messages := append([]chat.Message(nil), (*messagesPtr)...)
+		prompt := "Please provide your complete answer now as plain text."
+		if response.Content != "" {
+			messages = append(messages, chat.Message{Role: "assistant", Content: response.Content})
+			prompt = finalAnswerContinuationPrompt
+		}
+		messages = append(messages, chat.Message{Role: "user", Content: prompt})
+		answerID := response.AnswerEventID
+		if answerID == "" {
+			answerID = generateEventID("answer")
+		}
+		err := e.streamAnswerSegments(ctx, messages, state, sessionID, answerID,
+			response.Content, maxFinalAnswerSegments-1)
+		if err != nil && ctx.Err() == nil && state.FinalAnswer == "" {
+			state.FinalAnswer = "Sorry, I was unable to generate a complete answer."
+		}
+		state.IsComplete = err == nil
+		return iterOutcomeBreak, err
+	}
+
 	// 2. Analyze: Check for stop conditions (natural stop with no tool calls)
 	verdict := e.analyzeResponse(ctx, response, step, state.CurrentRound, sessionID, roundStart)
 	if verdict.isDone {

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -884,10 +884,224 @@ func TestStreamFinalAnswerToEventBus_EmitsDoneWhenProviderEndsWithEmptyChunk(t *
 	err := engine.streamFinalAnswerToEventBus(context.Background(), "test query", state, "sess-1")
 
 	require.NoError(t, err)
-	require.Len(t, finalAnswerEvents, 2)
+	require.GreaterOrEqual(t, len(finalAnswerEvents), 2)
 	assert.False(t, finalAnswerEvents[0].Done)
-	assert.True(t, finalAnswerEvents[1].Done)
-	assert.Equal(t, "final answer", finalAnswerEvents[0].Content+finalAnswerEvents[1].Content,
+	assert.True(t, finalAnswerEvents[len(finalAnswerEvents)-1].Done)
+	var answerContent string
+	var doneCount int
+	for _, answerEvent := range finalAnswerEvents {
+		answerContent += answerEvent.Content
+		if answerEvent.Done {
+			doneCount++
+		}
+	}
+	assert.Equal(t, 1, doneCount)
+	assert.Equal(t, "final answer", answerContent,
 		"a decoder may hold a short suffix until Done to rule out a split model handle")
 	assert.Equal(t, "final answer", state.FinalAnswer)
+}
+
+func TestStreamFinalAnswerToEventBus_ContinuesLengthLimitedAnswer(t *testing.T) {
+	mock := &mockChat{
+		responses: []mockResponse{
+			{chunks: []types.StreamResponse{{
+				ResponseType: types.ResponseTypeAnswer,
+				Content:      "first half ",
+				Done:         true,
+				FinishReason: "length",
+				Usage:        &types.TokenUsage{CompletionTokens: 10, TotalTokens: 20},
+			}}},
+			{chunks: []types.StreamResponse{{
+				ResponseType: types.ResponseTypeAnswer,
+				Content:      "second half",
+				Done:         true,
+				FinishReason: "stop",
+				Usage:        &types.TokenUsage{CompletionTokens: 5, TotalTokens: 10},
+			}}},
+		},
+	}
+
+	engine := newTestEngine(t, mock)
+	var answerContent string
+	var doneCount int
+	engine.eventBus.On(event.EventAgentFinalAnswer, func(_ context.Context, evt event.Event) error {
+		data, ok := evt.Data.(event.AgentFinalAnswerData)
+		require.True(t, ok)
+		answerContent += data.Content
+		if data.Done {
+			doneCount++
+		}
+		return nil
+	})
+
+	state := &types.AgentState{}
+	err := engine.streamFinalAnswerToEventBus(context.Background(), "test query", state, "sess-1")
+
+	require.NoError(t, err)
+	require.Len(t, mock.calls, 2)
+	assert.Equal(t, "first half second half", answerContent)
+	assert.Equal(t, "first half second half", state.FinalAnswer)
+	assert.Equal(t, 1, doneCount, "continuation segments must share one completion marker")
+	assert.Equal(t, 15, state.TurnUsage.CompletionTokens)
+	assert.Equal(t, 30, state.TurnUsage.TotalTokens)
+
+	continuedMessages := mock.calls[1]
+	require.GreaterOrEqual(t, len(continuedMessages), 2)
+	assert.Equal(t, "assistant", continuedMessages[len(continuedMessages)-2].Role)
+	assert.Equal(t, "first half ", continuedMessages[len(continuedMessages)-2].Content)
+	assert.Equal(t, "user", continuedMessages[len(continuedMessages)-1].Role)
+	assert.Equal(t, finalAnswerContinuationPrompt, continuedMessages[len(continuedMessages)-1].Content)
+}
+
+func TestStreamFinalAnswerToEventBus_BoundsLengthContinuations(t *testing.T) {
+	responses := make([]mockResponse, maxFinalAnswerSegments)
+	for i := range responses {
+		responses[i] = mockResponse{chunks: []types.StreamResponse{{
+			ResponseType: types.ResponseTypeAnswer,
+			Content:      fmt.Sprintf("part-%d ", i+1),
+			Done:         true,
+			FinishReason: "length",
+		}}}
+	}
+	mock := &mockChat{responses: responses}
+	engine := newTestEngine(t, mock)
+	var doneCount int
+	engine.eventBus.On(event.EventAgentFinalAnswer, func(_ context.Context, evt event.Event) error {
+		if data, ok := evt.Data.(event.AgentFinalAnswerData); ok && data.Done {
+			doneCount++
+		}
+		return nil
+	})
+
+	state := &types.AgentState{}
+	err := engine.streamFinalAnswerToEventBus(context.Background(), "test query", state, "sess-1")
+
+	require.ErrorContains(t, err, "continuation limit")
+	assert.Equal(t, maxFinalAnswerSegments, mock.callCount)
+	assert.Equal(t, "part-1 part-2 part-3 part-4", state.FinalAnswer)
+	assert.Equal(t, 0, doneCount, "an exhausted continuation must not signal successful completion")
+}
+
+func TestExecuteLoop_ContinuesTruncatedAnswerWithoutAnotherReasoningRound(t *testing.T) {
+	model := &mockChat{responses: []mockResponse{
+		{chunks: []types.StreamResponse{{Content: "first half ", Done: true, FinishReason: "length"}}},
+		{chunks: []types.StreamResponse{{Content: "second half", Done: true, FinishReason: "stop"}}},
+	}}
+	engine := newTestEngine(t, model)
+	var streamed, persisted string
+	ids := map[string]bool{}
+	doneCount := 0
+	engine.eventBus.On(event.EventAgentFinalAnswer, func(_ context.Context, evt event.Event) error {
+		data := evt.Data.(event.AgentFinalAnswerData)
+		streamed += data.Content
+		ids[evt.ID] = true
+		if data.Done {
+			doneCount++
+		}
+		return nil
+	})
+	engine.eventBus.On(event.EventAgentComplete, func(_ context.Context, evt event.Event) error {
+		persisted = evt.Data.(event.AgentCompleteData).FinalAnswer
+		return nil
+	})
+	state, err := engine.executeLoop(context.Background(), &types.AgentState{},
+		"query", emptyMessages(), emptyTools(), "session", "message")
+	require.NoError(t, err)
+	require.Equal(t, "first half second half", state.FinalAnswer)
+	require.Equal(t, state.FinalAnswer, streamed)
+	require.Equal(t, state.FinalAnswer, persisted)
+	require.Len(t, state.RoundSteps, 1)
+	require.Len(t, ids, 1)
+	require.Equal(t, 1, doneCount)
+	require.Equal(t, 2, model.callCount)
+	require.Empty(t, model.opts[1].Tools)
+	require.NotNil(t, model.opts[1].Thinking)
+	require.False(t, *model.opts[1].Thinking)
+	require.Equal(t, finalAnswerContinuationPrompt, model.calls[1][len(model.calls[1])-1].Content)
+}
+
+func TestStreamFinalAnswerRejectsThinkingOnlyCompletion(t *testing.T) {
+	model := &mockChat{responses: []mockResponse{{chunks: []types.StreamResponse{
+		{ResponseType: types.ResponseTypeThinking, Content: "reasoning only", Done: true, FinishReason: "stop"},
+	}}}}
+	engine := newTestEngine(t, model)
+	state := &types.AgentState{}
+	err := engine.streamFinalAnswerToEventBus(context.Background(), "query", state, "session")
+	require.ErrorContains(t, err, "no answer content")
+	require.Empty(t, state.FinalAnswer)
+}
+
+func TestExecuteLoopEmptyContinuationPersistsFailureMessage(t *testing.T) {
+	model := &mockChat{responses: []mockResponse{
+		{chunks: []types.StreamResponse{{Done: true, FinishReason: "length"}}},
+		{chunks: []types.StreamResponse{{Done: true, FinishReason: "stop"}}},
+	}}
+	engine := newTestEngine(t, model)
+	state, err := engine.executeLoop(context.Background(), &types.AgentState{},
+		"query", emptyMessages(), emptyTools(), "session", "message")
+	require.ErrorContains(t, err, "no answer content")
+	require.NotEmpty(t, state.FinalAnswer)
+	require.False(t, state.IsComplete)
+	require.Equal(t, 2, model.callCount)
+}
+
+func TestStreamAnswerSegmentsCancelledDoesNotStartAnotherCall(t *testing.T) {
+	model := &mockChat{}
+	engine := newTestEngine(t, model)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	state := &types.AgentState{}
+	err := engine.streamAnswerSegments(ctx, emptyMessages(), state, "session", "answer", "partial answer", 3)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, model.callCount)
+	require.Equal(t, "partial answer", state.FinalAnswer)
+}
+
+func TestStreamAnswerSegmentsPreservesPartialOnProviderError(t *testing.T) {
+	model := &mockChat{responses: []mockResponse{{chunks: []types.StreamResponse{
+		{Content: "next part"},
+		{ResponseType: types.ResponseTypeError, Content: "upstream disconnected"},
+	}}}}
+	engine := newTestEngine(t, model)
+	state := &types.AgentState{}
+	err := engine.streamAnswerSegments(context.Background(), emptyMessages(), state,
+		"session", "answer", "first part ", 3)
+	require.ErrorContains(t, err, "upstream disconnected")
+	require.Equal(t, "first part next part", state.FinalAnswer)
+	require.Equal(t, 1, model.callCount)
+}
+
+func TestEmptyContinuationDoesNotDeclarePrefixComplete(t *testing.T) {
+	model := &mockChat{responses: []mockResponse{{chunks: []types.StreamResponse{
+		{Done: true, FinishReason: "stop"},
+	}}}}
+	engine := newTestEngine(t, model)
+	state := &types.AgentState{}
+	err := engine.streamAnswerSegments(context.Background(), emptyMessages(), state,
+		"session", "answer", "unfinished prefix", 3)
+	require.ErrorContains(t, err, "no answer content")
+	require.Equal(t, "unfinished prefix", state.FinalAnswer)
+}
+
+func TestExecuteLoopThinkingOnlyLengthSwitchesToAnswer(t *testing.T) {
+	model := &mockChat{responses: []mockResponse{
+		{chunks: []types.StreamResponse{{
+			ResponseType: types.ResponseTypeThinking, Content: "reasoning", Done: true, FinishReason: "length",
+		}}},
+		{chunks: []types.StreamResponse{{
+			Content: "<think>hidden</think>complete answer", Done: true, FinishReason: "stop",
+		}}},
+	}}
+	engine := newTestEngine(t, model)
+	var streamed string
+	engine.eventBus.On(event.EventAgentFinalAnswer, func(_ context.Context, evt event.Event) error {
+		streamed += evt.Data.(event.AgentFinalAnswerData).Content
+		return nil
+	})
+	state, err := engine.executeLoop(context.Background(), &types.AgentState{},
+		"query", emptyMessages(), emptyTools(), "session", "message")
+	require.NoError(t, err)
+	require.Equal(t, "complete answer", state.FinalAnswer)
+	require.Equal(t, state.FinalAnswer, streamed)
+	require.Equal(t, 2, model.callCount)
 }

--- a/internal/agent/finalize.go
+++ b/internal/agent/finalize.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	agenttools "github.com/Tencent/WeKnora/internal/agent/tools"
@@ -13,6 +14,12 @@ import (
 	"github.com/Tencent/WeKnora/internal/searchutil"
 	"github.com/Tencent/WeKnora/internal/types"
 )
+
+const maxFinalAnswerSegments = 4
+
+const finalAnswerContinuationPrompt = "The previous assistant message was cut off by the output token limit. " +
+	"Continue exactly where it stopped. Do not repeat or summarize earlier content. " +
+	"Preserve the original language and structure, and finish the answer."
 
 func finalAnswerImageRequirement(hasRetrievedImage bool) string {
 	if !hasRetrievedImage {
@@ -94,73 +101,130 @@ Now generate the final answer:`, query, imageRequirement)
 
 	// Generate a single ID for this entire final answer stream
 	answerID := generateEventID("answer")
-	logger.Debugf(ctx, "[Agent][FinalAnswer] AnswerID: %s", answerID)
-	answerDoneEmitted := false
+	return e.streamAnswerSegments(ctx, messages, state, sessionID, answerID, "", maxFinalAnswerSegments)
+}
 
-	budget := e.clampCompletionBudgetToContext(e.tokenEstimator.EstimateMessages(messages))
-	llmResult, err := e.streamLLMToEventBus(
-		ctx,
-		messages,
-		&chat.ChatOptions{
-			Temperature:         e.config.Temperature,
-			MaxCompletionTokens: budget,
-			PromptCacheKey:      sessionID,
-		}, // Thinking disabled for final answer synthesis
-		func(chunk *types.StreamResponse, fullContent string) {
-			// Defensive filter: only emit answer content, skip thinking chunks
-			if chunk.ResponseType == types.ResponseTypeThinking {
+// streamAnswerSegments keeps a truncated answer in one stream and one persisted
+// value. Continuations have no tools: an output limit is not another ReAct step.
+func (e *AgentEngine) streamAnswerSegments(
+	ctx context.Context, messages []chat.Message, state *types.AgentState,
+	sessionID, answerID, prefix string, maxSegments int,
+) error {
+	logger.Debugf(ctx, "[Agent][FinalAnswer] AnswerID: %s", answerID)
+	fullAnswer := prefix
+	finishReason := ""
+	segments := 0
+	thinking := false
+	for segment := 0; segment < maxSegments; segment++ {
+		if err := ctx.Err(); err != nil {
+			state.FinalAnswer = fullAnswer
+			return err
+		}
+		budget := e.clampCompletionBudgetToContext(e.tokenEstimator.EstimateMessages(messages))
+		splitter := agenttools.NewThinkStreamSplitter()
+		var segmentContent strings.Builder
+		emitAnswer := func(content string) {
+			if content == "" {
 				return
 			}
-			if chunk.Content != "" {
-				logger.Debugf(ctx, "[Agent][FinalAnswer] Emitting answer chunk: %d chars", len(chunk.Content))
-				e.eventBus.Emit(ctx, event.Event{
-					ID:        answerID,
-					Type:      event.EventAgentFinalAnswer,
-					SessionID: sessionID,
-					Data: event.AgentFinalAnswerData{
-						Content: chunk.Content,
-						Done:    chunk.Done,
-					},
-				})
-				if chunk.Done {
-					answerDoneEmitted = true
+			segmentContent.WriteString(content)
+			_ = e.eventBus.Emit(ctx, event.Event{
+				ID: answerID, Type: event.EventAgentFinalAnswer, SessionID: sessionID,
+				Data: event.AgentFinalAnswerData{Content: content, Done: false},
+			})
+		}
+		llmResult, err := e.streamLLMToEventBus(
+			ctx,
+			messages,
+			&chat.ChatOptions{
+				Temperature:         e.config.Temperature,
+				MaxCompletionTokens: budget,
+				PromptCacheKey:      sessionID,
+				Thinking:            &thinking,
+			}, // Thinking disabled for final answer synthesis
+			func(chunk *types.StreamResponse, _ string) {
+				// Defensive filter: only emit answer content, skip thinking chunks.
+				// The provider's Done marker closes one segment, not necessarily the
+				// whole answer: length-limited segments are continued below.
+				if chunk.ResponseType == types.ResponseTypeThinking || chunk.Content == "" {
+					return
 				}
-			}
-		},
-	)
-	if err != nil {
-		logger.Errorf(ctx, "[Agent][FinalAnswer] Final answer generation failed: %v", err)
-		common.PipelineError(ctx, "Agent", "final_answer_stream_failed", map[string]interface{}{
-			"session_id": sessionID,
-			"error":      err.Error(),
-		})
-		return err
-	}
-
-	if !answerDoneEmitted {
-		e.eventBus.Emit(ctx, event.Event{
-			ID:        answerID,
-			Type:      event.EventAgentFinalAnswer,
-			SessionID: sessionID,
-			Data: event.AgentFinalAnswerData{
-				Content: "",
-				Done:    true,
+				_, answer := splitter.Feed(chunk.Content)
+				emitAnswer(answer)
 			},
-		})
-	}
+		)
+		_, tail := splitter.Flush()
+		emitAnswer(tail)
+		fullAnswer += segmentContent.String()
+		// Keep already generated text even when the provider fails mid-stream.
+		if llmResult != nil && llmResult.Usage != nil {
+			state.TurnUsage.Accumulate(*llmResult.Usage)
+		}
+		state.FinalAnswer = agenttools.StripThinkBlocks(fullAnswer)
+		if err == nil {
+			err = ctx.Err()
+		}
+		if err != nil {
+			logger.Errorf(ctx, "[Agent][FinalAnswer] Final answer generation failed: %v", err)
+			common.PipelineError(ctx, "Agent", "final_answer_stream_failed", map[string]interface{}{
+				"session_id": sessionID,
+				"error":      err.Error(),
+			})
+			return err
+		}
 
-	// The synthesis call is often the largest of the turn — fold its usage
-	// into the turn aggregate like every ReAct round.
-	if llmResult.Usage != nil {
-		state.TurnUsage.Accumulate(*llmResult.Usage)
-	}
+		segments++
+		finishReason = llmResult.FinishReason
 
-	// Safety net: strip any residual <think> blocks that may have leaked through
-	fullAnswer := agenttools.StripThinkBlocks(llmResult.Content)
+		// Preserve segment-edge whitespace until every continuation is joined.
+		// StripThinkBlocks trims its input, so applying it per segment would turn
+		// "first half " + "second half" into "first halfsecond half".
+		segmentAnswer := segmentContent.String()
+		if strings.TrimSpace(segmentAnswer) == "" {
+			return fmt.Errorf("final answer generation returned no answer content (finish_reason=%s)", finishReason)
+		}
+		if !isLengthFinishReason(finishReason) {
+			break
+		}
+		if segments >= maxSegments {
+			logger.Warnf(ctx, "[Agent][FinalAnswer] Still length-limited after %d segments; stopping continuation",
+				segments)
+			common.PipelineWarn(ctx, "Agent", "final_answer_continuation_exhausted", map[string]interface{}{
+				"session_id": sessionID,
+				"segments":   segments,
+			})
+			return fmt.Errorf("answer reached the continuation limit; partial answer was preserved")
+		}
+
+		logger.Infof(ctx, "[Agent][FinalAnswer] Segment %d hit the completion-token cap; continuing", segments)
+		if segmentAnswer != "" {
+			messages = append(messages, chat.Message{Role: "assistant", Content: segmentAnswer})
+		}
+		messages = append(messages, chat.Message{Role: "user", Content: finalAnswerContinuationPrompt})
+	}
+	// Safety net: strip residual inline <think> blocks once, after segment
+	// boundaries have been preserved.
+	fullAnswer = agenttools.StripThinkBlocks(fullAnswer)
+
+	// Close the single user-visible answer stream only after every continuation
+	// segment has finished. Closing each provider segment made the UI persist a
+	// partial answer before the continuation could arrive.
+	_ = e.eventBus.Emit(ctx, event.Event{
+		ID:        answerID,
+		Type:      event.EventAgentFinalAnswer,
+		SessionID: sessionID,
+		Data: event.AgentFinalAnswerData{
+			Content: "",
+			Done:    true,
+		},
+	})
+
 	logger.Infof(ctx, "[Agent][FinalAnswer] Final answer generated: %d characters", len(fullAnswer))
 	common.PipelineInfo(ctx, "Agent", "final_answer_done", map[string]interface{}{
-		"session_id": sessionID,
-		"answer_len": len(fullAnswer),
+		"session_id":    sessionID,
+		"answer_len":    len(fullAnswer),
+		"segments":      segments,
+		"finish_reason": finishReason,
 	})
 	state.FinalAnswer = fullAnswer
 	return nil
@@ -183,7 +247,9 @@ func (e *AgentEngine) handleMaxIterations(
 		common.PipelineError(ctx, "Agent", "final_answer_failed", map[string]interface{}{
 			"error": err.Error(),
 		})
-		state.FinalAnswer = "Sorry, I was unable to generate a complete answer."
+		if state.FinalAnswer == "" {
+			state.FinalAnswer = "Sorry, I was unable to generate a complete answer."
+		}
 	}
 	state.IsComplete = true
 }

--- a/internal/agent/think.go
+++ b/internal/agent/think.go
@@ -278,6 +278,7 @@ func (e *AgentEngine) streamThinkingToEventBus(
 	splitter := agenttools.NewThinkStreamSplitter()
 	thinkingOpen := false
 	answerStreamed := false
+	var streamedAnswer strings.Builder
 
 	emitThought := func(content string, done bool) {
 		if content == "" && !done {
@@ -320,6 +321,7 @@ func (e *AgentEngine) streamThinkingToEventBus(
 		}
 		closeThinking()
 		answerStreamed = true
+		streamedAnswer.WriteString(content)
 		emittedEventTypes["final_answer_chunk"]++
 		e.eventBus.Emit(ctx, event.Event{
 			ID:        answerID,
@@ -444,6 +446,10 @@ func (e *AgentEngine) streamThinkingToEventBus(
 		iteration+1, len(llmResult.Content), len(llmResult.ToolCalls), emittedEventTypes)
 
 	fullContent := agenttools.StripThinkBlocks(llmResult.Content)
+	if answerStreamed && isLengthFinishReason(llmResult.FinishReason) {
+		// Preserve whitespace at the continuation boundary exactly as streamed.
+		fullContent = streamedAnswer.String()
+	}
 
 	// Use actual finish_reason from LLM stream instead of hardcoding "stop".
 	// Fallback to "stop" when the stream did not report a finish_reason


### PR DESCRIPTION
## Description

Keep a token-limited, tool-free ReAct answer as one answer rather than feeding it back into another reasoning round. The old path streams all segments, but only places the last `stop` response in `AgentCompleteData.FinalAnswer`, so reloading loses the prefix. The frontend also seeds every new answer event with the already-composed message, multiplying the visible text.

- Continue with the original answer event ID, previous assistant content and an explicit continuation instruction; disable tools and thinking for these answer-only calls.
- Share bounded continuation with max-iteration synthesis (four total segments); preserve whitespace, usage and already-generated text on failure/cancellation.
- Reject empty synthesis and report an exhausted continuation limit instead of silently declaring success.
- Seed a resumed frontend answer only when there is no other visible answer event; do not replace received text with a stream error.

## Type of Change

- [x] Bug fix
- [x] Test

## Reproduction and testing

Use a mock stream returning `first half ` with `finish_reason=length`, then `second half` with `stop`.

| Check | Before | After |
|---|---|---|
| Final answer / completion payload | `second half` | `first half second half` |
| Three distinct frontend answer events | `first first second first first second third` | `first second third` |

- `go test ./internal/agent -count=1` passes on the current main-based branch (Go 1.26.5, CGO enabled).
- `node --test src/composables/useChatStreamHandler.test.mjs` passes from `frontend/`.
- Tests cover a single done/event ID, thinking-only length responses, empty answers, bounded continuation, usage, whitespace, cancellation and provider errors preserving partial text.
- The same regression tests fail against the unpatched code, as shown above.
- `git diff --check` passes. Source is gofmt-formatted. Full-repository tests were not run. A local golangci-lint binary download was blocked by release-asset connectivity; CI lint is still needed.

## Scope

No configuration, dependencies, schema, deployment files or existing stored conversations are changed. This cannot reconstruct previously lost answers. A provider can still refuse or fail a continuation; partial content is retained and the error is surfaced. Cancellation never starts a new model call.
