### PR TITLE
fix(files): authorize legacy images from shared knowledge bases

### DIFF
--- a/internal/router/files.go
+++ b/internal/router/files.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/Tencent/WeKnora/internal/middleware"
+	"github.com/Tencent/WeKnora/internal/searchutil"
 	"github.com/Tencent/WeKnora/internal/types"
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	secutils "github.com/Tencent/WeKnora/internal/utils"
@@ -124,8 +125,19 @@ func (a messageKBShareAuthorizer) resourceAccessibleViaSharedKB(
 	if !ok {
 		return false
 	}
+	return a.referenceAccessibleViaSharedKB(ctx, message, handle, resource.TenantID, callerTenantID, callerTenantRole)
+}
 
-	kbIDs := a.collectSharedKBEvidenceIDs(ctx, message, handle)
+// reference is either a catalog handle or an exact legacy provider path.
+// Neither a message's answer text nor its selected KB list is retrieval proof.
+func (a messageKBShareAuthorizer) referenceAccessibleViaSharedKB(
+	ctx context.Context, message *types.Message, reference string,
+	ownerTenantID, callerTenantID uint64, callerTenantRole types.TenantRole,
+) bool {
+	if a.ShareGuard == nil || a.KBs == nil || message == nil || ownerTenantID == 0 {
+		return false
+	}
+	kbIDs := a.collectSharedKBEvidenceIDs(ctx, message, reference)
 	if len(kbIDs) == 0 {
 		return false
 	}
@@ -135,7 +147,7 @@ func (a messageKBShareAuthorizer) resourceAccessibleViaSharedKB(
 		return false
 	}
 	for _, kb := range kbs {
-		if kb == nil || kb.TenantID != resource.TenantID {
+		if kb == nil || kb.TenantID != ownerTenantID {
 			continue
 		}
 		shared, err := a.ShareGuard.HasTenantKBPermission(
@@ -205,6 +217,20 @@ func searchResultHasResourceHandle(ref *types.SearchResult, handle string) bool 
 
 func textHasResourceHandle(text, handle string) bool {
 	if text == "" || handle == "" {
+		return false
+	}
+	if secutils.ParseTenantIDFromStoragePath(handle) != 0 {
+		// Old OCR records contain provider paths instead of resource handles.
+		// Match complete image destinations or individual structured URL values,
+		// never a substring such as chart.png matching chart.png-other.
+		if text == handle {
+			return true
+		}
+		for _, image := range searchutil.MarkdownImageRegex.FindAllStringSubmatch(text, -1) {
+			if strings.TrimSpace(image[2]) == handle {
+				return true
+			}
+		}
 		return false
 	}
 	want := types.BuildResourcePath(handle)
@@ -794,6 +820,17 @@ func newMessageScopedFileServeHandler(
 
 		ownerTenantID := message.AgentTenantID
 		kbShareAuthorized := false
+		if resource == nil {
+			pathTenantID := secutils.ParseTenantIDFromStoragePath(resolvedPath)
+			if pathTenantID != 0 && pathTenantID != ownerTenantID &&
+				secutils.ValidateKBScopedStoragePath(resolvedPath, pathTenantID) == nil {
+				kbShareAuthorized = kbShareAuth.referenceAccessibleViaSharedKB(
+					ctx, message, resolvedPath, pathTenantID, callerTenantID, types.TenantRoleFromContext(ctx))
+				if kbShareAuthorized {
+					ownerTenantID = pathTenantID
+				}
+			}
+		}
 		if resource != nil {
 			ownerTenantID = resource.TenantID
 			// A modern message records its source tenant. A resource from any

--- a/internal/router/router_files_test.go
+++ b/internal/router/router_files_test.go
@@ -882,6 +882,81 @@ func orgSharedKBFileRequest() *http.Request {
 			url.QueryEscape("resource://ShArEdKbHaNdLe00000000"), nil)
 }
 
+func TestMessageScopedFilesLegacySharedKBPaths(t *testing.T) {
+	const path = "local://7/exports/chart.png"
+	for _, tc := range []struct {
+		name, path, evidence string
+		shared               bool
+		kbTenant             uint64
+		want                 int
+	}{
+		{"shared", path, "![chart](" + path + ")", true, 7, 200},
+		{"structured URL", path, path, true, 7, 200},
+		{"revoked", path, "![chart](" + path + ")", false, 7, 403},
+		{"unrelated resource", path, "![chart](" + path + "-other)", true, 7, 403},
+		{"wrong KB owner", path, "![chart](" + path + ")", true, 8, 403},
+		{"answer text is not proof", path, "", true, 7, 403},
+		{"private upload", "local://7/uploads/private.png", "local://7/uploads/private.png", true, 7, 403},
+		{"traversal", "local://7/exports/../private.png", "local://7/exports/../private.png", true, 7, 400},
+		{"minio", "minio://bucket/7/exports/chart.png", "![chart](minio://bucket/7/exports/chart.png)", true, 7, 200},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("STORAGE_TYPE", "local")
+			if strings.HasPrefix(tc.path, "minio:") {
+				t.Setenv("STORAGE_TYPE", "minio")
+			}
+			message := &types.Message{AgentTenantID: 42, Content: "![forged](" + tc.path + ")",
+				ExecutionContext: types.MessageExecutionContext{KnowledgeBaseIDs: []string{"kb"}},
+				AgentSteps: types.AgentSteps{{ToolCalls: []types.ToolCall{{Result: &types.ToolResult{
+					Data: map[string]interface{}{"results": []interface{}{map[string]interface{}{
+						"knowledge_base_id": "kb", "content": tc.evidence,
+					}}},
+				}}}}},
+			}
+			read := false
+			engine := newMessageScopedFilesTestEngine(42,
+				&stubMessageFileLookup{get: func(context.Context, string, string) (*types.Message, error) {
+					return message, nil
+				}},
+				nil,
+				&stubTenantService{get: func(_ context.Context, id uint64) (*types.Tenant, error) {
+					if id != 7 {
+						t.Fatalf("wrong storage tenant %d", id)
+					}
+					return &types.Tenant{ID: id}, nil
+				}},
+				&stubFileService{getFile: func(_ context.Context, p string) (io.ReadCloser, error) {
+					read = true
+					if p != tc.path {
+						t.Fatalf("wrong path %q", p)
+					}
+					return io.NopCloser(strings.NewReader("image")), nil
+				}}, nil,
+				messageKBShareAuthorizer{
+					KBs: &stubKBTenantLookup{kbs: []*types.KnowledgeBase{{ID: "kb", TenantID: tc.kbTenant}}},
+					ShareGuard: &stubKBShareGuard{hasPermission: func(
+						_ context.Context, kb string, caller uint64, _ types.TenantRole, role types.OrgMemberRole,
+					) (bool, error) {
+						if kb != "kb" || caller != 42 || role != types.OrgRoleViewer {
+							t.Fatal("incorrect permission scope")
+						}
+						return tc.shared, nil
+					}},
+				},
+			)
+			recorder := httptest.NewRecorder()
+			engine.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet,
+				"/sessions/s/messages/m/files?file_path="+url.QueryEscape(tc.path), nil))
+			if recorder.Code != tc.want {
+				t.Fatalf("status=%d, want=%d, body=%s", recorder.Code, tc.want, recorder.Body.String())
+			}
+			if read != (tc.want == 200) {
+				t.Fatalf("unexpected file read: %v", read)
+			}
+		})
+	}
+}
+
 func TestMessageScopedFilesServesOrgSharedKBResource(t *testing.T) {
 	engine, requestedPath := newOrgSharedKBTestEngine(t, true,
 		types.References{{


### PR DESCRIPTION
## Description

Follow up on #3069 / #3022 for historical OCR images that still use provider paths (for example `minio://bucket/7/exports/chart.png`) rather than registered `resource://` handles.

The message-file proxy currently takes the agent's tenant for a legacy path. A caller-owned agent answering from an org-shared knowledge base consequently receives 403, even when the persisted retrieval evidence contains the exact image and the KB is still shared.

- Reuse the existing retrieval-evidence and current org-share permission check for exact legacy image references.
- Resolve the source tenant from the validated storage path, require the referenced KB to belong to that tenant, and use its storage service.
- Apply the existing KB file-proxy `exports` restriction; do not authorize from message answer text, selected KB IDs, path prefixes or arbitrary owner-tenant paths.
- Keep resource-catalog and shared-agent behavior unchanged.

## Type of Change

- [x] Bug fix
- [x] Test

## Testing

- `go test ./internal/router -count=1` passes against current main (Go 1.26.5, CGO enabled).
- Table tests cover local and MinIO paths, structured URL values, revoked shares, unrelated/prefix paths, mismatched KB owners, forged answer-only references, private uploads and traversal. Rejected cases never read the file service.
- Removing the legacy-path fix makes the valid shared/local/MinIO cases return 403 in the same tests.
- `git diff --check` passes. Source is gofmt-formatted. Full-repository tests were not run. Local golangci-lint release download was blocked by connectivity; CI lint is still needed.

No database migration, resource backfill, new route or permission relaxation is required. Legacy paths without persisted retrieval evidence still fail closed.
