### PR TITLE
fix: report qdrant update failures

### DIFF
--- a/internal/application/repository/retriever/qdrant/repository.go
+++ b/internal/application/repository/retriever/qdrant/repository.go
@@ -2,6 +2,7 @@ package qdrant
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"unicode/utf8"
@@ -371,11 +372,15 @@ func (q *qdrantRepository) BatchUpdateChunkEnabledStatus(ctx context.Context, ch
 
 	log.Infof("[Qdrant] Batch updating chunk enabled status, count: %d", len(chunkStatusMap))
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Get all collections that match our base name pattern
 	collections, err := q.client.ListCollections(ctx)
 	if err != nil {
 		log.Errorf("[Qdrant] Failed to list collections: %v", err)
-		return fmt.Errorf("failed to list collections: %w", err)
+		return fmt.Errorf("failed to list collections: %w", errors.Join(err, ctx.Err()))
 	}
 
 	// Group chunks by enabled status for batch updates
@@ -390,6 +395,7 @@ func (q *qdrantRepository) BatchUpdateChunkEnabledStatus(ctx context.Context, ch
 		}
 	}
 
+	var updateErr error
 	// Update in all matching collections
 	for _, collectionName := range collections {
 		// Only process collections that start with our base name
@@ -400,6 +406,9 @@ func (q *qdrantRepository) BatchUpdateChunkEnabledStatus(ctx context.Context, ch
 
 		// Update enabled chunks
 		if len(enabledChunkIDs) > 0 {
+			if err := ctx.Err(); err != nil {
+				return errors.Join(updateErr, err)
+			}
 			_, err := q.client.SetPayload(ctx, &qdrant.SetPayloadPoints{
 				CollectionName: collectionName,
 				Payload:        newQdrantValueMap(map[string]any{fieldIsEnabled: true}),
@@ -411,11 +420,15 @@ func (q *qdrantRepository) BatchUpdateChunkEnabledStatus(ctx context.Context, ch
 			})
 			if err != nil {
 				log.Warnf("[Qdrant] Failed to update enabled chunks in %s: %v", collectionName, err)
+				updateErr = errors.Join(updateErr, fmt.Errorf("enable chunks in collection %s: %w", collectionName, err))
 			}
 		}
 
 		// Update disabled chunks
 		if len(disabledChunkIDs) > 0 {
+			if err := ctx.Err(); err != nil {
+				return errors.Join(updateErr, err)
+			}
 			_, err := q.client.SetPayload(ctx, &qdrant.SetPayloadPoints{
 				CollectionName: collectionName,
 				Payload:        newQdrantValueMap(map[string]any{fieldIsEnabled: false}),
@@ -427,8 +440,13 @@ func (q *qdrantRepository) BatchUpdateChunkEnabledStatus(ctx context.Context, ch
 			})
 			if err != nil {
 				log.Warnf("[Qdrant] Failed to update disabled chunks in %s: %v", collectionName, err)
+				updateErr = errors.Join(updateErr, fmt.Errorf("disable chunks in collection %s: %w", collectionName, err))
 			}
 		}
+	}
+
+	if err := errors.Join(updateErr, ctx.Err()); err != nil {
+		return err
 	}
 
 	log.Infof("[Qdrant] Batch update chunk enabled status completed")
@@ -445,11 +463,15 @@ func (q *qdrantRepository) BatchUpdateChunkTagID(ctx context.Context, chunkTagMa
 
 	log.Infof("[Qdrant] Batch updating chunk tag ID, count: %d", len(chunkTagMap))
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Get all collections that match our base name pattern
 	collections, err := q.client.ListCollections(ctx)
 	if err != nil {
 		log.Errorf("[Qdrant] Failed to list collections: %v", err)
-		return fmt.Errorf("failed to list collections: %w", err)
+		return fmt.Errorf("failed to list collections: %w", errors.Join(err, ctx.Err()))
 	}
 
 	// Group chunks by tag ID for batch updates
@@ -458,6 +480,7 @@ func (q *qdrantRepository) BatchUpdateChunkTagID(ctx context.Context, chunkTagMa
 		tagGroups[tagID] = append(tagGroups[tagID], chunkID)
 	}
 
+	var updateErr error
 	// Update in all matching collections
 	for _, collectionName := range collections {
 		// Only process collections that start with our base name
@@ -468,6 +491,9 @@ func (q *qdrantRepository) BatchUpdateChunkTagID(ctx context.Context, chunkTagMa
 
 		// Update chunks for each tag ID
 		for tagID, chunkIDs := range tagGroups {
+			if err := ctx.Err(); err != nil {
+				return errors.Join(updateErr, err)
+			}
 			_, err := q.client.SetPayload(ctx, &qdrant.SetPayloadPoints{
 				CollectionName: collectionName,
 				Payload:        newQdrantValueMap(map[string]any{fieldTagID: tagID}),
@@ -479,8 +505,14 @@ func (q *qdrantRepository) BatchUpdateChunkTagID(ctx context.Context, chunkTagMa
 			})
 			if err != nil {
 				log.Warnf("[Qdrant] Failed to update chunks with tag_id %s in %s: %v", tagID, collectionName, err)
+				updateErr = errors.Join(updateErr,
+					fmt.Errorf("set chunk tag_id %q in collection %s: %w", tagID, collectionName, err))
 			}
 		}
+	}
+
+	if err := errors.Join(updateErr, ctx.Err()); err != nil {
+		return err
 	}
 
 	log.Infof("[Qdrant] Batch update chunk tag ID completed")

--- a/internal/application/repository/retriever/qdrant/repository_test.go
+++ b/internal/application/repository/retriever/qdrant/repository_test.go
@@ -1,8 +1,16 @@
 package qdrant
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
+
+	"github.com/qdrant/go-client/qdrant"
+	"google.golang.org/grpc"
 )
 
 func TestNewQdrantValueMapSanitizesInvalidUTF8AndNUL(t *testing.T) {
@@ -76,5 +84,194 @@ func TestCreatePayloadSanitizesAllStringFields(t *testing.T) {
 	}
 	if got := payload[fieldIsEnabled].GetBoolValue(); !got {
 		t.Error("is_enabled changed during payload creation")
+	}
+}
+
+// Intercept the SDK's RPCs so failures and cancellation need no live server.
+func newPayloadUpdateTestRepository(t *testing.T, collections []string, listErr error,
+	setPayload func(context.Context, *qdrant.SetPayloadPoints) error,
+) *qdrantRepository {
+	t.Helper()
+	client, err := qdrant.NewClient(&qdrant.Config{
+		Host:                   "localhost",
+		PoolSize:               1,
+		SkipCompatibilityCheck: true,
+		GrpcOptions: []grpc.DialOption{grpc.WithUnaryInterceptor(func(
+			ctx context.Context, method string, req, reply any, _ *grpc.ClientConn,
+			_ grpc.UnaryInvoker, _ ...grpc.CallOption,
+		) error {
+			switch request := req.(type) {
+			case *qdrant.ListCollectionsRequest:
+				if listErr != nil {
+					return listErr
+				}
+				response := reply.(*qdrant.ListCollectionsResponse)
+				for _, name := range collections {
+					response.Collections = append(response.Collections, &qdrant.CollectionDescription{Name: name})
+				}
+				return nil
+			case *qdrant.SetPayloadPoints:
+				return setPayload(ctx, request)
+			default:
+				return fmt.Errorf("unexpected RPC %s", method)
+			}
+		})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	return &qdrantRepository{client: client, collectionBaseName: "vectors"}
+}
+
+func TestBatchPayloadUpdates(t *testing.T) {
+	operations := []struct {
+		name   string
+		groups int
+		run    func(context.Context, *qdrantRepository) error
+	}{
+		{"enable", 1, func(ctx context.Context, repo *qdrantRepository) error {
+			return repo.BatchUpdateChunkEnabledStatus(ctx, map[string]bool{"chunk": true})
+		}},
+		{"disable", 1, func(ctx context.Context, repo *qdrantRepository) error {
+			return repo.BatchUpdateChunkEnabledStatus(ctx, map[string]bool{"chunk": false})
+		}},
+		{"mixed status", 2, func(ctx context.Context, repo *qdrantRepository) error {
+			return repo.BatchUpdateChunkEnabledStatus(ctx, map[string]bool{"on": true, "off": false})
+		}},
+		{"tags", 2, func(ctx context.Context, repo *qdrantRepository) error {
+			return repo.BatchUpdateChunkTagID(ctx, map[string]string{"one": "tag-a", "two": "tag-b"})
+		}},
+	}
+	for _, operation := range operations {
+		t.Run(operation.name, func(t *testing.T) {
+			modes := []string{"success", "partial failure", "all failures", "list failure", "no collections"}
+			for _, mode := range modes {
+				t.Run(mode, func(t *testing.T) {
+					collections := []string{"vectors_768", "unrelated_768", "vectors_1536"}
+					if mode == "no collections" {
+						collections = []string{"unrelated_768"}
+					}
+					var listErr error
+					if mode == "list failure" {
+						listErr = errors.New("list unavailable")
+					}
+					calls := 0
+					var failures []error
+					var descriptions []string
+					repo := newPayloadUpdateTestRepository(t, collections, listErr,
+						func(_ context.Context, request *qdrant.SetPayloadPoints) error {
+							calls++
+							if request.CollectionName == "unrelated_768" {
+								t.Error("updated an unrelated collection")
+							}
+							fail := mode == "all failures" ||
+								(mode == "partial failure" && request.CollectionName == "vectors_768")
+							if !fail {
+								return nil
+							}
+							failure := fmt.Errorf("failure %d", calls)
+							failures = append(failures, failure)
+							description := fmt.Sprintf("set chunk tag_id %q",
+								request.Payload[fieldTagID].GetStringValue())
+							if enabled, ok := request.Payload[fieldIsEnabled]; ok {
+								description = "disable chunks"
+								if enabled.GetBoolValue() {
+									description = "enable chunks"
+								}
+							}
+							descriptions = append(descriptions, description+" in collection "+request.CollectionName)
+							return failure
+						})
+					err := operation.run(context.Background(), repo)
+					wantCalls := 2 * operation.groups
+					if mode == "list failure" || mode == "no collections" {
+						wantCalls = 0
+					}
+					if calls != wantCalls {
+						t.Fatalf("got %d updates, want %d", calls, wantCalls)
+					}
+					if listErr != nil && !errors.Is(err, listErr) {
+						t.Fatalf("lost list failure: %v", err)
+					}
+					if listErr == nil && len(failures) == 0 && err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+					for i, failure := range failures {
+						if !errors.Is(err, failure) {
+							t.Errorf("lost failure %v in %v", failure, err)
+						}
+						if err == nil || !strings.Contains(err.Error(), descriptions[i]) {
+							t.Errorf("missing operation/collection %q in %v", descriptions[i], err)
+						}
+					}
+				})
+			}
+
+			t.Run("cancellation retains earlier failures", func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				failure := errors.New("first update failed")
+				calls := 0
+				repo := newPayloadUpdateTestRepository(t, []string{"vectors_768", "vectors_1536", "vectors_384"}, nil,
+					func(context.Context, *qdrant.SetPayloadPoints) error {
+						calls++
+						if calls == 1 {
+							return failure
+						}
+						cancel()
+						return ctx.Err()
+					})
+				err := operation.run(ctx, repo)
+				if calls != 2 || !errors.Is(err, failure) || !errors.Is(err, context.Canceled) {
+					t.Fatalf("calls=%d, err=%v; want 2 calls and both errors", calls, err)
+				}
+			})
+
+			t.Run("canceled before starting", func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				if err := operation.run(ctx, &qdrantRepository{}); !errors.Is(err, context.Canceled) {
+					t.Fatalf("expected cancellation before any RPC, got %v", err)
+				}
+			})
+			t.Run("canceled during final update", func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				calls := 0
+				repo := newPayloadUpdateTestRepository(t, []string{"vectors_768"}, nil,
+					func(context.Context, *qdrant.SetPayloadPoints) error {
+						calls++
+						if calls == operation.groups {
+							cancel()
+						}
+						return nil
+					})
+				if err := operation.run(ctx, repo); !errors.Is(err, context.Canceled) {
+					t.Fatalf("expected cancellation instead of success, got %v", err)
+				}
+			})
+			t.Run("expired deadline", func(t *testing.T) {
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+				defer cancel()
+				if err := operation.run(ctx, &qdrantRepository{}); !errors.Is(err, context.DeadlineExceeded) {
+					t.Fatalf("expected deadline error before any RPC, got %v", err)
+				}
+			})
+		})
+	}
+}
+
+func TestBatchPayloadUpdatesEmptyInput(t *testing.T) {
+	repo := &qdrantRepository{}
+	if err := repo.BatchUpdateChunkEnabledStatus(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.BatchUpdateChunkTagID(context.Background(), nil); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
fix: report qdrant update failures

  ## description

  changing chunk tags or enabled status could fail in qdrant while the app still treated the operation as successful.

  this change returns those failures so callers can detect incomplete updates. it also stops further updates when the request is canceled and preserves any earlier failures.

  ## type of change

  - [x] bug fix
  - [ ] ✨ new feature
  - [ ] breaking change
  - [ ] documentation update
  - [ ] refactor
  - [ ] ⚡ performance improvement
  - [x] test
  - [ ] configuration / build / ci

  ## related issue

  none.

  ## testing

  passed:
  - `go test ./internal/application/repository/retriever/qdrant`
  - `git diff --check origin/main...HEAD`

  tests cover successful updates, partial and total failures, collection-list failures, empty input, cancellation and expired deadlines. tests use simulated sdk calls; no live qdrant server is required.

  diff-scoped lint and full-repository checks were not run. testing was scoped to the affected package.

  ## checklist

  - [x] `git diff --check origin/main...HEAD` passes
  - [x] changed source files are formatted
  - [x] targeted tests for the changed packages/components pass
  - [ ] diff-scoped lint passes where applicable
  - [ ] full-repository checks were run, or any unrelated/environment-dependent failures are documented above
  - [x] self-reviewed the code
  - [x] added/updated tests covering the change
  - [ ] updated related documentation — not needed
  - [ ] breaking changes are clearly called out — none

  ## screenshots / recordings

  not applicable; no ui changes.