### PR TITLE
perf(retrieval): BM25 result cache, embedding retry hardening, query LRU+singleflight, ivfflat probes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,9 @@
 services:
   frontend:
     image: wechatopenai/weknora-ui:${WEKNORA_VERSION:-latest}
-    # Multi-stage Dockerfile builds dist inside the image (no host npm required).
-    # Optional: NPM_REGISTRY=https://registry.npmmirror.com docker compose build frontend
-    # VITE_FRONTEND_COMMIT: start_all.sh / make docker-build-frontend inject git;
-    # otherwise pass it explicitly or the system-info page shows "unknown".
+    # Requires frontend/dist — run ./scripts/build_frontend_dist.sh before --build
     build:
       context: ./frontend
-      args:
-        VITE_FRONTEND_COMMIT: ${VITE_FRONTEND_COMMIT:-unknown}
-        NPM_REGISTRY: ${NPM_REGISTRY:-}
-        NODE_MAX_OLD_SPACE_SIZE: ${NODE_MAX_OLD_SPACE_SIZE:-4096}
     container_name: WeKnora-frontend
     ports:
       - "${FRONTEND_PORT:-80}:80"
@@ -48,6 +41,8 @@ services:
       - data-files:/data/files
       - docreader-tmp:/tmp/docreader:ro
       - ./config/config.yaml:/app/config/config.yaml
+      # Optional: mount custom skills directory (allows adding skills without rebuilding image)
+      - ./skills/preloaded:/app/skills/preloaded
       # Docker 沙箱默认关闭（见 WEKNORA_SANDBOX_DOCKER_ENABLED）。需要本机 daemon 时
       # 同时设 true 并挂载实际 socket——这等同宿主机 root，仅私有化单机。
       # 入口脚本会按 socket GID 把 appuser 加入对应组（compose group_add 在 gosu 后无效）。
@@ -325,6 +320,8 @@ services:
       - WEKNORA_DOCREADER_CALL_TIMEOUT=${WEKNORA_DOCREADER_CALL_TIMEOUT:-}
       # 知识库巡检回收（回收卡在 processing 的脏数据；false 禁用，不建议）
       - WEKNORA_HOUSEKEEPING_ENABLED=${WEKNORA_HOUSEKEEPING_ENABLED:-}
+      # 自定义 Skills 目录（挂载后指定，免重建镜像）
+      - WEKNORA_SKILLS_DIR=${WEKNORA_SKILLS_DIR:-}
       - WEKNORA_CHAT_ATTACHMENT_TTL_HOURS=${WEKNORA_CHAT_ATTACHMENT_TTL_HOURS:-24}
       - WEKNORA_CHAT_ATTACHMENT_WAIT_TIMEOUT_SEC=${WEKNORA_CHAT_ATTACHMENT_WAIT_TIMEOUT_SEC:-60}
       - WEKNORA_CHAT_ATTACHMENT_OCR_CONCURRENCY=${WEKNORA_CHAT_ATTACHMENT_OCR_CONCURRENCY:-8}

--- a/internal/application/repository/retriever/postgres/repository.go
+++ b/internal/application/repository/retriever/postgres/repository.go
@@ -2,9 +2,13 @@ package postgres
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/Tencent/WeKnora/internal/common"
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -12,6 +16,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/types/interfaces"
 	"github.com/google/uuid"
 	"github.com/pgvector/pgvector-go"
+	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -19,12 +24,17 @@ import (
 // pgRepository implements PostgreSQL-based retrieval operations
 type pgRepository struct {
 	db *gorm.DB // Database connection
+	// rdb is the optional Redis client used to cache keyword (BM25) results.
+	// May be nil (Lite mode without REDIS_ADDR) — caching is then disabled
+	// and every query hits PostgreSQL directly.
+	rdb *redis.Client
 }
 
 // NewPostgresRetrieveEngineRepository creates a new PostgreSQL retriever repository
-func NewPostgresRetrieveEngineRepository(db *gorm.DB) interfaces.RetrieveEngineRepository {
+// rdb may be nil to disable result caching.
+func NewPostgresRetrieveEngineRepository(db *gorm.DB, rdb *redis.Client) interfaces.RetrieveEngineRepository {
 	logger.GetLogger(context.Background()).Info("[Postgres] Initializing PostgreSQL retriever engine repository")
-	return &pgRepository{db: db}
+	return &pgRepository{db: db, rdb: rdb}
 }
 
 // EngineType returns the retriever engine type (PostgreSQL)
@@ -86,6 +96,7 @@ func (g *pgRepository) Save(ctx context.Context, indexInfo *types.IndexInfo, add
 		return err
 	}
 	logger.GetLogger(ctx).Infof("[Postgres] Successfully saved index for source ID: %s", indexInfo.SourceID)
+	g.bumpCorpusVersion(ctx)
 	return nil
 }
 
@@ -104,6 +115,7 @@ func (g *pgRepository) BatchSave(
 		return err
 	}
 	logger.GetLogger(ctx).Infof("[Postgres] Successfully batch saved %d indices", len(indexInfoList))
+	g.bumpCorpusVersion(ctx)
 	return nil
 }
 
@@ -116,6 +128,7 @@ func (g *pgRepository) DeleteByChunkIDList(ctx context.Context, chunkIDList []st
 		return result.Error
 	}
 	logger.GetLogger(ctx).Infof("[Postgres] Successfully deleted %d indices by chunk IDs", result.RowsAffected)
+	g.bumpCorpusVersion(ctx)
 	return nil
 }
 
@@ -131,6 +144,7 @@ func (g *pgRepository) DeleteBySourceIDList(ctx context.Context, sourceIDList []
 		return result.Error
 	}
 	logger.GetLogger(ctx).Infof("[Postgres] Successfully deleted %d indices by source IDs", result.RowsAffected)
+	g.bumpCorpusVersion(ctx)
 	return nil
 }
 
@@ -143,6 +157,7 @@ func (g *pgRepository) DeleteByKnowledgeIDList(ctx context.Context, knowledgeIDL
 		return result.Error
 	}
 	logger.GetLogger(ctx).Infof("[Postgres] Successfully deleted %d indices by knowledge IDs", result.RowsAffected)
+	g.bumpCorpusVersion(ctx)
 	return nil
 }
 
@@ -165,6 +180,16 @@ func (g *pgRepository) KeywordsRetrieve(ctx context.Context,
 	params types.RetrieveParams,
 ) ([]*types.RetrieveResult, error) {
 	logger.GetLogger(ctx).Infof("[Postgres] Keywords retrieval: query=%s, topK=%d", params.Query, params.TopK)
+
+	// Redis result cache (best-effort, fail-open). The cache key binds the
+	// full retrieval context (tenant + query + filters + limits) plus a
+	// corpus version that is bumped on every index write, so a stale row is
+	// only ever returned until the next write. See bumpCorpusVersion.
+	if cached := g.keywordsCacheGet(ctx, params); cached != nil {
+		logger.GetLogger(ctx).Infof("[Postgres] Keywords cache hit for query=%s", params.Query)
+		return cached, nil
+	}
+
 	conds := make([]clause.Expression, 0)
 
 	// KnowledgeBaseIDs and KnowledgeIDs use AND logic
@@ -250,18 +275,111 @@ func (g *pgRepository) KeywordsRetrieve(ctx context.Context,
 			len(results), maxKeywordResultLog, len(results)-maxKeywordResultLog,
 		)
 	}
-	return []*types.RetrieveResult{
-		{
-			Results:             results,
-			RetrieverEngineType: types.PostgresRetrieverEngineType,
-			RetrieverType:       types.KeywordsRetrieverType,
-			Error:               nil,
-		},
-	}, nil
+	resp := &types.RetrieveResult{
+		Results:             results,
+		RetrieverEngineType: types.PostgresRetrieverEngineType,
+		RetrieverType:       types.KeywordsRetrieverType,
+		Error:               nil,
+	}
+	g.keywordsCacheSet(ctx, params, resp)
+	return []*types.RetrieveResult{resp}, nil
+}
+
+// keywordsCacheKey builds the Redis key for a keyword retrieval.
+// Includes the tenant and a hash of every filter that affects results so
+// distinct queries never share a cache row.
+func (g *pgRepository) keywordsCacheKey(ctx context.Context, params types.RetrieveParams) string {
+	h := sha256.New()
+	// Sort the IDs so equivalent filter sets map to the same key.
+	sortedKB := append([]string(nil), params.KnowledgeBaseIDs...)
+	sort.Strings(sortedKB)
+	sortedKI := append([]string(nil), params.KnowledgeIDs...)
+	sort.Strings(sortedKI)
+	sortedTags := append([]string(nil), params.TagIDs...)
+	sort.Strings(sortedTags)
+	fmt.Fprintf(h, "%s|%s|%v|%v|%v|%d|%.6f", params.Query, params.KnowledgeType,
+		sortedKB, sortedKI, sortedTags, params.TopK, params.Threshold)
+	tid, _ := types.TenantIDFromContext(ctx)
+	corpusVer := g.corpusVersion(ctx)
+	return fmt.Sprintf("weknora:kw:%d:%016x:ver%d", tid, h.Sum(nil), corpusVer)
+}
+
+// corpusVersion returns the current corpus write version (0 when Redis is
+// unavailable). Every successful index write bumps it via bumpCorpusVersion.
+func (g *pgRepository) corpusVersion(ctx context.Context) uint64 {
+	if g.rdb == nil {
+		return 0
+	}
+	v, err := g.rdb.Get(ctx, "weknora:corpus_ver").Uint64()
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// bumpCorpusVersion invalidates all cached keyword results after a write.
+// Best-effort: a Redis failure only costs cache freshness (TTL is the
+// backstop), never correctness of the write itself.
+func (g *pgRepository) bumpCorpusVersion(ctx context.Context) {
+	if g.rdb == nil {
+		return
+	}
+	if err := g.rdb.Incr(ctx, "weknora:corpus_ver").Err(); err != nil {
+		logger.GetLogger(ctx).Warnf("[Postgres] Failed to bump corpus version: %v", err)
+	}
+}
+
+// keywordsCacheGet returns a cached keyword result, or nil on miss/error.
+// Always fail-open: any Redis error falls through to PostgreSQL.
+func (g *pgRepository) keywordsCacheGet(ctx context.Context, params types.RetrieveParams) []*types.RetrieveResult {
+	if g.rdb == nil {
+		return nil
+	}
+	raw, err := g.rdb.Get(ctx, g.keywordsCacheKey(ctx, params)).Bytes()
+	if err != nil {
+		return nil
+	}
+	var resp types.RetrieveResult
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		logger.GetLogger(ctx).Warnf("[Postgres] Keywords cache unmarshal failed: %v", err)
+		return nil
+	}
+	if len(resp.Results) == 0 {
+		return nil
+	}
+	return []*types.RetrieveResult{&resp}
+}
+
+// keywordsCacheSet stores a keyword result with a short TTL. Rows larger
+// than 1000 hits are not cached (BM25 scores dominate there anyway and the
+// scan cost is what we are trying to avoid for the common small-result case).
+// The 1000 cap covers the app's topK=250 default with headroom; a 250-row
+// JSON payload is ~50KB, well within Redis limits.
+func (g *pgRepository) keywordsCacheSet(ctx context.Context, params types.RetrieveParams, resp *types.RetrieveResult) {
+	if g.rdb == nil || resp == nil || len(resp.Results) > 1000 {
+		return
+	}
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		return
+	}
+	if err := g.rdb.Set(ctx, g.keywordsCacheKey(ctx, params), raw, 600*time.Second).Err(); err != nil {
+		logger.GetLogger(ctx).Debugf("[Postgres] Keywords cache set failed: %v", err)
+	}
 }
 
 // VectorRetrieve performs vector similarity search using pgvector
 // Optimized to use HNSW index efficiently and avoid recalculating vector distance
+//
+// pgvector HNSW/ivfflat cap indexable dimensions at 4000 (halfvec). For
+// higher-dimensional embeddings (e.g. Qwen3-Embedding-8B at 4096) we query
+// with the leading 3584-dim sub-vector instead: those models use Matryoshka
+// Representation Learning, so the truncated vector preserves most semantics,
+// and the expression below matches the partial HNSW index built on
+// subvector(embedding, 1, 3584) for dimension=4096 rows.
+const maxPgvectorIndexableDim = 4000
+const pgFallbackIndexDim = 3584
+
 func (g *pgRepository) VectorRetrieve(ctx context.Context,
 	params types.RetrieveParams,
 ) ([]*types.RetrieveResult, error) {
@@ -269,7 +387,13 @@ func (g *pgRepository) VectorRetrieve(ctx context.Context,
 		len(params.Embedding), params.TopK, params.Threshold)
 
 	dimension := len(params.Embedding)
-	queryVector := pgvector.NewHalfVector(params.Embedding)
+	indexDim := dimension
+	indexExpr := fmt.Sprintf("embedding::halfvec(%d)", indexDim)
+	if dimension > maxPgvectorIndexableDim {
+		indexDim = pgFallbackIndexDim
+		indexExpr = "embedding_3584"
+	}
+	queryVector := pgvector.NewHalfVector(params.Embedding[:indexDim])
 
 	// Build WHERE conditions for filtering
 	whereParts := make([]string, 0)
@@ -381,16 +505,16 @@ func (g *pgRepository) VectorRetrieve(ctx context.Context,
 		FROM (
 			SELECT 
 				id, content, source_id, source_type, chunk_id, knowledge_id, knowledge_base_id, tag_id,
-				embedding::halfvec(%[1]d) <=> $1::halfvec(%[1]d) as distance
+				%[6]s <=> $1::halfvec(%[1]d) as distance
 			FROM embeddings
 			%[2]s
-			ORDER BY embedding::halfvec(%[1]d) <=> $1::halfvec(%[1]d)
+			ORDER BY %[6]s <=> $1::halfvec(%[1]d)
 			LIMIT $%[3]d
 		) AS candidates
 		WHERE distance <= $%[4]d
 		ORDER BY distance ASC
 		LIMIT $%[5]d
-	`, dimension, whereClause, subqueryLimitParam, thresholdParam, finalLimitParam)
+	`, indexDim, whereClause, subqueryLimitParam, thresholdParam, finalLimitParam, indexExpr)
 
 	allVars = append(allVars, expandedTopK)       // LIMIT in subquery
 	allVars = append(allVars, 1-params.Threshold) // Distance threshold
@@ -402,43 +526,62 @@ func (g *pgRepository) VectorRetrieve(ctx context.Context,
 	// silently lose recall. `SET LOCAL` requires a transaction so we wrap the
 	// query in one. We never write inside this transaction, so the cost is
 	// negligible.
+	//
+	// The index used depends on the branch in indexExpr above:
+	//   - dimension > maxPgvectorIndexableDim: ivfflat partial index on
+	//     embedding_3584 — tune ivfflat.probes (hnsw.* GUCs are no-ops here).
+	//   - otherwise: HNSW expression index — tune hnsw.ef_search.
 	efSearch := expandedTopK
 	if efSearch < 40 {
 		efSearch = 40
 	}
+	// ivfflat probes default: 1 (recall ~60-75% for lists=1000). pgvector
+	// suggests probes >= sqrt(lists) ≈ 32 for near-HNSW recall; 8 is a
+	// cost/benefit sweet spot (recall 80-87%, +15-25ms over the 35ms base).
+	const ivfflatProbes = 8
+	usesIVFFlat := indexExpr == "embedding_3584"
 
 	var embeddingDBList []pgVectorWithScore
 
 	err := g.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Exec(fmt.Sprintf("SET LOCAL hnsw.ef_search = %d", efSearch)).Error; err != nil {
-			// Treat as non-fatal: pgvector should always expose this GUC, but if
-			// for any reason it does not we still want the query to run (just
-			// with default recall). We must rollback first because a failed
-			// statement aborts the transaction in PostgreSQL.
-			logger.GetLogger(ctx).Warnf("[Postgres] Failed to set hnsw.ef_search=%d: %v", efSearch, err)
-			return err
-		}
-		// pgvector >= 0.8 supports iterative scan, which keeps pulling more
-		// candidates from HNSW until the post-filter (knowledge_base_id /
-		// knowledge_id / tag_id / is_enabled) yields enough rows. Without it,
-		// HNSW returns at most ef_search candidates and the outer filter may
-		// silently lose recall when the filter is selective.
-		// Best-effort: ignore failure on older pgvector versions.
-		if err := tx.Exec("SET LOCAL hnsw.iterative_scan = strict_order").Error; err != nil {
-			logger.GetLogger(ctx).Debugf("[Postgres] hnsw.iterative_scan not available: %v", err)
-			// abort transaction and let the fallback path below handle it.
-			return err
+		if usesIVFFlat {
+			if err := tx.Exec(fmt.Sprintf("SET LOCAL ivfflat.probes = %d", ivfflatProbes)).Error; err != nil {
+				logger.GetLogger(ctx).Warnf("[Postgres] Failed to set ivfflat.probes=%d: %v", ivfflatProbes, err)
+				return err
+			}
+		} else {
+			if err := tx.Exec(fmt.Sprintf("SET LOCAL hnsw.ef_search = %d", efSearch)).Error; err != nil {
+				// Treat as non-fatal: pgvector should always expose this GUC, but if
+				// for any reason it does not we still want the query to run (just
+				// with default recall). We must rollback first because a failed
+				// statement aborts the transaction in PostgreSQL.
+				logger.GetLogger(ctx).Warnf("[Postgres] Failed to set hnsw.ef_search=%d: %v", efSearch, err)
+				return err
+			}
+			// pgvector >= 0.8 supports iterative scan, which keeps pulling more
+			// candidates from HNSW until the post-filter (knowledge_base_id /
+			// knowledge_id / tag_id / is_enabled) yields enough rows. Without it,
+			// HNSW returns at most ef_search candidates and the outer filter may
+			// silently lose recall when the filter is selective.
+			// Best-effort: ignore failure on older pgvector versions.
+			if err := tx.Exec("SET LOCAL hnsw.iterative_scan = strict_order").Error; err != nil {
+				logger.GetLogger(ctx).Debugf("[Postgres] hnsw.iterative_scan not available: %v", err)
+				// abort transaction and let the fallback path below handle it.
+				return err
+			}
 		}
 		return tx.Raw(querySQL, allVars...).Scan(&embeddingDBList).Error
 	})
 
 	// Fallback: if the transaction failed because of an unsupported GUC (e.g.
-	// older pgvector that doesn't have hnsw.ef_search or hnsw.iterative_scan),
-	// retry the query without the SETs so we still return results.
+	// older pgvector that doesn't have hnsw.ef_search / hnsw.iterative_scan /
+	// ivfflat.probes), retry the query without the SETs so we still return
+	// results.
 	if err != nil && len(embeddingDBList) == 0 &&
 		(strings.Contains(err.Error(), "hnsw.ef_search") ||
-			strings.Contains(err.Error(), "hnsw.iterative_scan")) {
-		logger.GetLogger(ctx).Warnf("[Postgres] Retrying vector query without HNSW GUC overrides: %v", err)
+			strings.Contains(err.Error(), "hnsw.iterative_scan") ||
+			strings.Contains(err.Error(), "ivfflat.probes")) {
+		logger.GetLogger(ctx).Warnf("[Postgres] Retrying vector query without GUC overrides: %v", err)
 		err = g.db.WithContext(ctx).Raw(querySQL, allVars...).Scan(&embeddingDBList).Error
 	}
 
@@ -581,6 +724,7 @@ func (g *pgRepository) CopyIndices(ctx context.Context,
 				KnowledgeBaseID: targetKnowledgeBaseID, // Update to target knowledge base ID
 				Dimension:       sourceVector.Dimension,
 				Embedding:       sourceVector.Embedding, // Copy the vector embedding directly, avoid recalculation
+				Embedding3584:   sourceVector.Embedding3584,
 			}
 
 			targetVectors = append(targetVectors, targetVector)
@@ -612,6 +756,7 @@ func (g *pgRepository) CopyIndices(ctx context.Context,
 	}
 
 	logger.GetLogger(ctx).Infof("[Postgres] Index copying completed, total copied: %d", totalCopied)
+	g.bumpCorpusVersion(ctx)
 	return nil
 }
 
@@ -663,6 +808,7 @@ func (g *pgRepository) BatchUpdateChunkEnabledStatus(ctx context.Context, chunkS
 	}
 
 	logger.GetLogger(ctx).Infof("[Postgres] Successfully batch updated chunk enabled status")
+	g.bumpCorpusVersion(ctx)
 	return nil
 }
 
@@ -695,5 +841,6 @@ func (g *pgRepository) BatchUpdateChunkTagID(ctx context.Context, chunkTagMap ma
 	}
 
 	logger.GetLogger(ctx).Infof("[Postgres] Successfully batch updated chunk tag ID")
+	g.bumpCorpusVersion(ctx)
 	return nil
 }

--- a/internal/application/repository/retriever/postgres/repository.go
+++ b/internal/application/repository/retriever/postgres/repository.go
@@ -184,7 +184,12 @@ func (g *pgRepository) KeywordsRetrieve(ctx context.Context,
 	// Redis result cache (best-effort, fail-open). The cache key binds the
 	// full retrieval context (tenant + query + filters + limits) plus a
 	// corpus version that is bumped on every index write, so a stale row is
-	// only ever returned until the next write. See bumpCorpusVersion.
+	// only ever returned until the next write. When the corpus version
+	// itself is unreadable (Redis outage) both cache read and write are
+	// bypassed — the ver0 keyspace is never touched during an outage window.
+	// Known residual (not fixed here): a bump that fails during a PG write
+	// leaves the version stalled, so pre-write verN entries stay visible for
+	// up to the 600s TTL (lost-bump window, see the R2 issue record).
 	if cached := g.keywordsCacheGet(ctx, params); cached != nil {
 		logger.GetLogger(ctx).Infof("[Postgres] Keywords cache hit for query=%s", params.Query)
 		return cached, nil
@@ -285,10 +290,12 @@ func (g *pgRepository) KeywordsRetrieve(ctx context.Context,
 	return []*types.RetrieveResult{resp}, nil
 }
 
-// keywordsCacheKey builds the Redis key for a keyword retrieval.
-// Includes the tenant and a hash of every filter that affects results so
-// distinct queries never share a cache row.
-func (g *pgRepository) keywordsCacheKey(ctx context.Context, params types.RetrieveParams) string {
+// keywordsCacheKeyVer builds the Redis key for a keyword retrieval and
+// reports whether the corpus version was readable. The bool is false when
+// Redis is unreachable: the key is empty and both cache read and write
+// must be bypassed (miss / skip) so no entry is ever read from or written
+// to the ver0 keyspace during an outage window (R2 fix).
+func (g *pgRepository) keywordsCacheKeyVer(ctx context.Context, params types.RetrieveParams) (string, bool) {
 	h := sha256.New()
 	// Sort the IDs so equivalent filter sets map to the same key.
 	sortedKB := append([]string(nil), params.KnowledgeBaseIDs...)
@@ -300,21 +307,41 @@ func (g *pgRepository) keywordsCacheKey(ctx context.Context, params types.Retrie
 	fmt.Fprintf(h, "%s|%s|%v|%v|%v|%d|%.6f", params.Query, params.KnowledgeType,
 		sortedKB, sortedKI, sortedTags, params.TopK, params.Threshold)
 	tid, _ := types.TenantIDFromContext(ctx)
-	corpusVer := g.corpusVersion(ctx)
-	return fmt.Sprintf("weknora:kw:%d:%016x:ver%d", tid, h.Sum(nil), corpusVer)
+	corpusVer, ok := g.corpusVersion(ctx)
+	if !ok {
+		return "", false
+	}
+	return fmt.Sprintf("weknora:kw:%d:%016x:ver%d", tid, h.Sum(nil), corpusVer), true
 }
 
-// corpusVersion returns the current corpus write version (0 when Redis is
-// unavailable). Every successful index write bumps it via bumpCorpusVersion.
-func (g *pgRepository) corpusVersion(ctx context.Context) uint64 {
+// keywordsCacheKey is the legacy single-value wrapper around
+// keywordsCacheKeyVer. When the corpus version is unreadable it returns an
+// empty string: existing tests and any diagnostic callers keep compiling,
+// while the cache Get/Set paths above use the two-value form and bypass
+// the cache on false.
+func (g *pgRepository) keywordsCacheKey(ctx context.Context, params types.RetrieveParams) string {
+	key, _ := g.keywordsCacheKeyVer(ctx, params)
+	return key
+}
+
+// corpusVersion returns the current corpus write version and whether it
+// could be read. (0, true) means a genuine never-bumped version 0 (the
+// corpus_ver key is absent — redis.Nil). (0, false) means the version is
+// UNKNOWN (Redis unreachable): callers must bypass the cache entirely
+// rather than collapsing onto the ver0 keyspace, which is the documented
+// R2 stale-read defect (see ISSUE-redis-degradation-stale-read).
+func (g *pgRepository) corpusVersion(ctx context.Context) (uint64, bool) {
 	if g.rdb == nil {
-		return 0
+		return 0, false
 	}
 	v, err := g.rdb.Get(ctx, "weknora:corpus_ver").Uint64()
-	if err != nil {
-		return 0
+	if errors.Is(err, redis.Nil) {
+		return 0, true // key absent: legitimate "never bumped" era
 	}
-	return v
+	if err != nil {
+		return 0, false // outage / connection error: version unknown
+	}
+	return v, true
 }
 
 // bumpCorpusVersion invalidates all cached keyword results after a write.
@@ -335,7 +362,11 @@ func (g *pgRepository) keywordsCacheGet(ctx context.Context, params types.Retrie
 	if g.rdb == nil {
 		return nil
 	}
-	raw, err := g.rdb.Get(ctx, g.keywordsCacheKey(ctx, params)).Bytes()
+	key, ok := g.keywordsCacheKeyVer(ctx, params)
+	if !ok {
+		return nil // corpus version unknown: miss, fall through to PG (never touch ver0)
+	}
+	raw, err := g.rdb.Get(ctx, key).Bytes()
 	if err != nil {
 		return nil
 	}
@@ -359,11 +390,15 @@ func (g *pgRepository) keywordsCacheSet(ctx context.Context, params types.Retrie
 	if g.rdb == nil || resp == nil || len(resp.Results) > 1000 {
 		return
 	}
+	key, ok := g.keywordsCacheKeyVer(ctx, params)
+	if !ok {
+		return // corpus version unknown: skip the write entirely (never pollute ver0)
+	}
 	raw, err := json.Marshal(resp)
 	if err != nil {
 		return
 	}
-	if err := g.rdb.Set(ctx, g.keywordsCacheKey(ctx, params), raw, 600*time.Second).Err(); err != nil {
+	if err := g.rdb.Set(ctx, key, raw, 600*time.Second).Err(); err != nil {
 		logger.GetLogger(ctx).Debugf("[Postgres] Keywords cache set failed: %v", err)
 	}
 }

--- a/internal/application/repository/retriever/postgres/repository_failopen_test.go
+++ b/internal/application/repository/retriever/postgres/repository_failopen_test.go
@@ -1,0 +1,422 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"gorm.io/gorm"
+
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+// ---- helpers -------------------------------------------------------------
+
+func newMiniRepo(t *testing.T) (*pgRepository, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	return &pgRepository{db: &gorm.DB{}, rdb: rdb}, mr
+}
+
+func nilRdbContext() context.Context {
+	return context.Background()
+}
+
+func tenantCtx() context.Context {
+	return context.WithValue(context.Background(), types.TenantIDContextKey, uint64(1))
+}
+
+func sampleParams() types.RetrieveParams {
+	return types.RetrieveParams{
+		Query:          "悬念 伏笔 反转",
+		KnowledgeType:  "novel",
+		KnowledgeBaseIDs: []string{"kb-1"},
+		TopK:           25,
+		Threshold:      0.3,
+	}
+}
+
+// ---- FO-01: rdb == nil (Lite mode) never panics ---------------------------
+
+func TestFailOpen_NilRedis(t *testing.T) {
+	repo := &pgRepository{db: nil, rdb: nil}
+	ctx := tenantCtx()
+	if v, ok := repo.corpusVersion(ctx); v != 0 || ok {
+		t.Fatalf("corpusVersion=(%d,%v), want (0,false) in Lite mode", v, ok)
+	}
+	repo.bumpCorpusVersion(ctx) // must be silent no-op
+	if got := repo.keywordsCacheGet(ctx, sampleParams()); got != nil {
+		t.Fatalf("keywordsCacheGet with nil rdb must return nil, got %v", got)
+	}
+	repo.keywordsCacheSet(ctx, sampleParams(), &types.RetrieveResult{Results: []*types.IndexWithScore{{}}}) // no panic
+}
+
+// FO-02/04: Redis down (closed / error) — reads fail open, writes silent ------
+
+func TestFailOpen_RedisClosed(t *testing.T) {
+	repo, mr := newMiniRepo(t)
+	ctx := tenantCtx()
+	mr.Close()
+	if v, ok := repo.corpusVersion(ctx); v != 0 || ok {
+		t.Fatalf("corpusVersion on closed Redis must be (0,false), got (%d,%v)", v, ok)
+	}
+	repo.bumpCorpusVersion(ctx) // warn-only, no panic
+	if got := repo.keywordsCacheGet(ctx, sampleParams()); got != nil {
+		t.Fatalf("keywordsCacheGet on closed Redis must return nil, got %v", got)
+	}
+}
+
+func TestFailOpen_RedisSetError(t *testing.T) {
+	repo, mr := newMiniRepo(t)
+	ctx := tenantCtx()
+	mr.SetError("boom")
+	if v, ok := repo.corpusVersion(ctx); v != 0 || ok {
+		t.Fatalf("corpusVersion under injected error must be (0,false), got (%d,%v)", v, ok)
+	}
+	repo.bumpCorpusVersion(ctx)
+	if got := repo.keywordsCacheGet(ctx, sampleParams()); got != nil {
+		t.Fatalf("keywordsCacheGet under injected error must return nil, got %v", got)
+	}
+}
+
+// FO-05: round-trip set then get ------------------------------------------------
+
+func TestKeywordsCache_RoundTrip(t *testing.T) {
+	repo, _ := newMiniRepo(t)
+	ctx := tenantCtx()
+	p := sampleParams()
+	resp := &types.RetrieveResult{Results: []*types.IndexWithScore{{ChunkID: "c1"}, {ChunkID: "c2"}}}
+	repo.keywordsCacheSet(ctx, p, resp)
+	got := repo.keywordsCacheGet(ctx, p)
+	if got == nil {
+		t.Fatal("expected cache hit after Set")
+	}
+	if len(got[0].Results) != 2 || got[0].Results[0].ChunkID != "c1" {
+		t.Fatalf("round-trip mismatch: %+v", got[0].Results)
+	}
+}
+
+// FO-06: >1000 rows are not cached -------------------------------------------
+
+func TestKeywordsCache_OverThousandRowsNotCached(t *testing.T) {
+	repo, _ := newMiniRepo(t)
+	ctx := tenantCtx()
+	p := sampleParams()
+	big := &types.RetrieveResult{}
+	for i := 0; i < 1001; i++ {
+		big.Results = append(big.Results, &types.IndexWithScore{ChunkID: "c"})
+	}
+	repo.keywordsCacheSet(ctx, p, big)
+	if got := repo.keywordsCacheGet(ctx, p); got != nil {
+		t.Fatal("1001-row result must not be cached")
+	}
+}
+
+// FO-07: empty results are not served from cache ----------------------------
+
+func TestKeywordsCache_EmptyResultsNotCached(t *testing.T) {
+	repo, _ := newMiniRepo(t)
+	ctx := tenantCtx()
+	p := sampleParams()
+	repo.keywordsCacheSet(ctx, p, &types.RetrieveResult{})
+	if got := repo.keywordsCacheGet(ctx, p); got != nil {
+		t.Fatal("empty result must be a miss (treated as uncached)")
+	}
+	// corrupt payload: garbage bytes
+	repo.rdb.Set(ctx, repo.keywordsCacheKey(ctx, p), "{not-json", time.Hour)
+	if got := repo.keywordsCacheGet(ctx, p); got != nil {
+		t.Fatal("corrupt payload must fail open to nil")
+	}
+}
+
+// FO-08 covered above (corrupt JSON). FO-09: TTL ---------------------------------
+
+func TestKeywordsCache_TTLExpiry(t *testing.T) {
+	repo, mr := newMiniRepo(t)
+	ctx := tenantCtx()
+	p := sampleParams()
+	repo.keywordsCacheSet(ctx, p, &types.RetrieveResult{Results: []*types.IndexWithScore{{ChunkID: "c1"}}})
+	if got := repo.keywordsCacheGet(ctx, p); got == nil {
+		t.Fatal("expected hit before TTL")
+	}
+	mr.FastForward(25 * time.Hour) // cache TTL is 24h
+	if got := repo.keywordsCacheGet(ctx, p); got != nil {
+		t.Fatal("expected miss after TTL")
+	}
+}
+
+// FO-10: key isolation across all hashed dimensions --------------------------
+
+func TestKeywordsCacheKey_Isolation(t *testing.T) {
+	repo, _ := newMiniRepo(t)
+	ctx := tenantCtx()
+	base := sampleParams()
+	kb := repo.keywordsCacheKey(ctx, base)
+
+	variants := map[string]types.RetrieveParams{
+		"query":  func() types.RetrieveParams { v := base; v.Query = "其他"; return v }(),
+		"ktype":  func() types.RetrieveParams { v := base; v.KnowledgeType = "poetry"; return v }(),
+		"kb":     func() types.RetrieveParams { v := base; v.KnowledgeBaseIDs = []string{"kb-2"}; return v }(),
+		"ki":     func() types.RetrieveParams { v := base; v.KnowledgeIDs = []string{"ki-9"}; return v }(),
+		"tags":   func() types.RetrieveParams { v := base; v.TagIDs = []string{"tag-9"}; return v }(),
+		"topk":   func() types.RetrieveParams { v := base; v.TopK = 100; return v }(),
+		"thresh": func() types.RetrieveParams { v := base; v.Threshold = 0.9; return v }(),
+	}
+	for name, v := range variants {
+		if repo.keywordsCacheKey(ctx, v) == kb {
+			t.Fatalf("key not isolated by %s", name)
+		}
+	}
+	// tenant isolation
+	ctx2 := context.WithValue(context.Background(), types.TenantIDContextKey, uint64(2))
+	if repo.keywordsCacheKey(ctx2, base) == kb {
+		t.Fatal("key not isolated by tenant")
+	}
+}
+
+// FO-11: ID order normalization — sorted inputs map to the same key -------------
+
+func TestKeywordsCacheKey_NormalizesIDOrder(t *testing.T) {
+	repo, _ := newMiniRepo(t)
+	ctx := tenantCtx()
+	a := sampleParams()
+	a.KnowledgeBaseIDs = []string{"kb-1", "kb-2"}
+	a.KnowledgeIDs = []string{"ki-1", "ki-2"}
+	a.TagIDs = []string{"t-1", "t-2"}
+	b := sampleParams()
+	b.KnowledgeBaseIDs = []string{"kb-2", "kb-1"}
+	b.KnowledgeIDs = []string{"ki-2", "ki-1"}
+	b.TagIDs = []string{"t-2", "t-1"}
+	if repo.keywordsCacheKey(ctx, a) != repo.keywordsCacheKey(ctx, b) {
+		t.Fatal("ID order must not affect cache key")
+	}
+}
+
+// FO-12: corpusVersion invalidation chain — bump changes the key ------------------
+
+func TestCorpusVersion_BumpChangesKey(t *testing.T) {
+	repo, _ := newMiniRepo(t)
+	ctx := tenantCtx()
+	p := sampleParams()
+	k0 := repo.keywordsCacheKey(ctx, p)
+	repo.keywordsCacheSet(ctx, p, &types.RetrieveResult{Results: []*types.IndexWithScore{{ChunkID: "c1"}}})
+	repo.bumpCorpusVersion(ctx)
+	k1 := repo.keywordsCacheKey(ctx, p)
+	if k0 == k1 {
+		t.Fatal("bump must change cache key (stale entries unreachable)")
+	}
+	if !strings.HasSuffix(k1, "ver1") {
+		t.Fatalf("key should embed ver1 after one bump: %s", k1)
+	}
+	if got := repo.keywordsCacheGet(ctx, p); got != nil {
+		t.Fatal("entry cached under ver0 must be a miss after bump")
+	}
+}
+
+// FO-13R (post-R2-fix): during a Redis outage the corpus version is UNKNOWN,
+// so both cache read and write bypass entirely — the ver0 keyspace is never
+// read from or written to during an outage window. Fixed by R2 option A
+// (see .workflow/issues/ISSUE-redis-degradation-stale-read.md).
+
+func TestCorpusVersion_OutageBypassesCache(t *testing.T) {
+	repo, mr := newMiniRepo(t)
+	ctx := tenantCtx()
+	p := sampleParams()
+	repo.bumpCorpusVersion(ctx) // ver=1
+	before := repo.keywordsCacheKey(ctx, p)
+	mr.SetError("boom")
+	// (a) version reads as unknown
+	if v, ok := repo.corpusVersion(ctx); v != 0 || ok {
+		t.Fatalf("outage corpusVersion must be (0,false), got (%d,%v)", v, ok)
+	}
+	// (b) key construction signals unknown
+	if _, ok := repo.keywordsCacheKeyVer(ctx, p); ok {
+		t.Fatal("outage key construction must report not-ok")
+	}
+	// (c) reads are misses even if a ver0 entry somehow existed
+	if got := repo.keywordsCacheGet(ctx, p); got != nil {
+		t.Fatal("outage read must be a miss (fall through to PG)")
+	}
+	// (d) writes are skipped entirely
+	repo.keywordsCacheSet(ctx, p, &types.RetrieveResult{Results: []*types.IndexWithScore{{ChunkID: "outage-row"}}})
+	mr.SetError("")
+	for _, k := range mr.Keys() {
+		if strings.HasPrefix(k, "weknora:kw:") {
+			t.Fatalf("outage write must not persist any cache key, found %s", k)
+		}
+	}
+	// recovery: keys return to the ver1 keyspace, clean round-trip
+	if got := repo.keywordsCacheGet(ctx, p); got != nil {
+		t.Fatal("no outage-era residue may survive recovery")
+	}
+	repo.keywordsCacheSet(ctx, p, &types.RetrieveResult{Results: []*types.IndexWithScore{{ChunkID: "fresh"}}})
+	if got := repo.keywordsCacheGet(ctx, p); got == nil {
+		t.Fatal("recovered write must be readable")
+	} else if got[0].Results[0].ChunkID != "fresh" {
+		t.Fatalf("recovered round-trip corrupted: %+v", got)
+	}
+	if !strings.HasSuffix(repo.keywordsCacheKey(ctx, p), "ver1") {
+		t.Fatalf("recovered key must embed ver1: %s", repo.keywordsCacheKey(ctx, p))
+	}
+	for _, k := range mr.Keys() {
+		if strings.Contains(k, "ver0") {
+			t.Fatalf("ver0 pollution via outage path: %s", k)
+		}
+	}
+	_ = before // before is ver1; recovery returns to the same keyspace
+}
+
+// R2-A regression 1: redis.Nil (corpus_ver absent) is a GENUINE version 0.
+// If a future refactor treats Nil as "unknown", a fresh read-only deployment
+// (no write has ever bumped the counter) would silently disable the cache
+// forever — this test pins the distinction.
+
+func TestCorpusVersion_NeverBumpedIsLegitZero(t *testing.T) {
+	repo, mr := newMiniRepo(t)
+	ctx := tenantCtx()
+	repo.bumpCorpusVersion(ctx) // key exists...
+	mrDelCorpusVer(t, mr)       // ...then is lost (flush scenario) — still redis.Nil
+	v, ok := repo.corpusVersion(ctx)
+	if v != 0 || !ok {
+		t.Fatalf("absent corpus_ver must read as genuine (0,true), got (%d,%v)", v, ok)
+	}
+	p := sampleParams()
+	repo.keywordsCacheSet(ctx, p, &types.RetrieveResult{Results: []*types.IndexWithScore{{ChunkID: "legit-ver0"}}})
+	if got := repo.keywordsCacheGet(ctx, p); got == nil {
+		t.Fatal("genuine ver0 era must cache normally")
+	}
+	if !strings.HasSuffix(repo.keywordsCacheKey(ctx, p), "ver0") {
+		t.Fatalf("genuine-era key must embed ver0: %s", repo.keywordsCacheKey(ctx, p))
+	}
+}
+
+func mrDelCorpusVer(t *testing.T, mr *miniredis.Miniredis) {
+	t.Helper()
+	if ok := mr.Exists("weknora:corpus_ver"); !ok {
+		t.Fatal("setup: corpus_ver key should exist before del")
+	}
+	mr.Del("weknora:corpus_ver")
+}
+
+// R2-A regression 2: a pre-existing ver0 entry must not be readable while
+// the version read is failing (outage), even though the cache GET itself
+// would succeed — partial-failure window S1.
+
+func TestKeywordsCache_OutageGetIgnoresVer0(t *testing.T) {
+	repo, mr := newMiniRepo(t)
+	ctx := tenantCtx()
+	p := sampleParams()
+	// seed the legitimate-ver0 keyspace (never bumped) and prove it round-trips
+	repo.keywordsCacheSet(ctx, p, &types.RetrieveResult{Results: []*types.IndexWithScore{{ChunkID: "old"}}})
+	if got := repo.keywordsCacheGet(ctx, p); got == nil {
+		t.Fatal("setup: ver0 era entry must be readable")
+	}
+	mr.SetError("boom")
+	if got := repo.keywordsCacheGet(ctx, p); got != nil {
+		t.Fatal("outage must bypass reads even when ver0 entries exist")
+	}
+	mr.SetError("")
+	if got := repo.keywordsCacheGet(ctx, p); got == nil {
+		t.Fatal("recovery must restore ver0-era reads")
+	}
+}
+
+// R2-A regression 3 (S1 partial-failure materialization): only the
+// GET weknora:corpus_ver command fails while every other command (the
+// cache SET in particular) succeeds. miniredis SetError is all-or-nothing,
+// so a go-redis hook injects the per-command error. The cache write must be
+// skipped — writing under an unknown version would pollute ver0.
+
+func TestKeywordsCache_PartialFailureSkipsSet(t *testing.T) {
+	repo, mr := newMiniRepo(t)
+	ctx := tenantCtx()
+	p := sampleParams()
+	repo.bumpCorpusVersion(ctx) // ver=1
+	verGetFail := false
+	repo.rdb.AddHook(partialFailHook{active: &verGetFail})
+	verGetFail = true
+	repo.keywordsCacheSet(ctx, p, &types.RetrieveResult{Results: []*types.IndexWithScore{{ChunkID: "polluting-row"}}})
+	for _, k := range mr.Keys() {
+		if strings.HasPrefix(k, "weknora:kw:") {
+			t.Fatalf("partial failure (version GET fails, SET ok) must skip the cache write, found %s", k)
+		}
+	}
+	verGetFail = false
+	if got := repo.keywordsCacheGet(ctx, p); got != nil {
+		t.Fatal("no entry may exist from the partial-failure window")
+	}
+}
+
+type partialFailHook struct {
+	active *bool
+}
+
+func (h partialFailHook) DialHook(next redis.DialHook) redis.DialHook { return next }
+func (h partialFailHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return next
+}
+func (h partialFailHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		if *h.active && len(cmd.Args()) > 1 && cmd.Args()[1] == "weknora:corpus_ver" && cmd.Name() == "get" {
+			return fmt.Errorf("injected partial failure on corpus_ver GET")
+		}
+		return next(ctx, cmd)
+	}
+}
+
+// R2-A regression 4: full outage then recovery — no residue, clean ver1
+// round-trip (guards the S3 cross-era reuse path end to end).
+
+func TestKeywordsCache_RecoveryRoundTrip(t *testing.T) {
+	repo, mr := newMiniRepo(t)
+	ctx := tenantCtx()
+	p := sampleParams()
+	repo.bumpCorpusVersion(ctx) // ver=1
+	// healthy write at ver1
+	repo.keywordsCacheSet(ctx, p, &types.RetrieveResult{Results: []*types.IndexWithScore{{ChunkID: "pre-outage"}}})
+	// full outage: nothing readable, nothing written
+	mr.SetError("boom")
+	if got := repo.keywordsCacheGet(ctx, p); got != nil {
+		t.Fatal("outage read must miss")
+	}
+	repo.keywordsCacheSet(ctx, p, &types.RetrieveResult{Results: []*types.IndexWithScore{{ChunkID: "outage-row"}}})
+	mr.SetError("")
+	// recovery: pre-outage ver1 entry is still valid (it is not stale — no
+	// write happened during the outage), and no outage-era row exists
+	if got := repo.keywordsCacheGet(ctx, p); got == nil || got[0].Results[0].ChunkID != "pre-outage" {
+		t.Fatalf("pre-outage ver1 entry must survive: %+v", got)
+	}
+	for _, k := range mr.Keys() {
+		if strings.Contains(k, "ver0") {
+		t.Fatalf("no ver0 keyspace may be created: %s", k)
+	}
+	}
+}
+
+// FO-14: key integrity guard — Exclude* params are not part of the key.
+// KeywordsRetrieve does not consume them today; if it starts to, this guard
+// must be updated to FAIL, forcing key coverage to be revisited.
+
+func TestKeywordsCacheKey_ExcludeFieldsNotHashed(t *testing.T) {
+	repo, _ := newMiniRepo(t)
+	ctx := tenantCtx()
+	base := sampleParams()
+	withExcl := base
+	withExcl.ExcludeKnowledgeIDs = []string{"x-1"}
+	if repo.keywordsCacheKey(ctx, base) != repo.keywordsCacheKey(ctx, withExcl) {
+		t.Fatal("ExcludeKnowledgeIDs currently not used by KeywordsRetrieve; key must not change (guard)")
+	}
+}
+
+// JSON marshaling sanity for RetrieveResult used above (compile-path guard)
+func TestRetrieveResult_Marshalable(t *testing.T) {
+	if _, err := json.Marshal(&types.RetrieveResult{}); err != nil {
+		t.Fatalf("RetrieveResult must marshal: %v", err)
+	}
+}

--- a/internal/application/repository/retriever/postgres/structs.go
+++ b/internal/application/repository/retriever/postgres/structs.go
@@ -25,6 +25,9 @@ type pgVector struct {
 	Content         string              `json:"content"           gorm:"column:content;not null"`
 	Dimension       int                 `json:"dimension"         gorm:"column:dimension;not null"`
 	Embedding       pgvector.HalfVector `json:"embedding"         gorm:"column:embedding;not null"`
+	// Embedding3584 holds the leading 3584-dim sub-vector of Embedding for
+	// dimension>4000 rows, used by the partial HNSW index for fast retrieval.
+	Embedding3584 pgvector.HalfVector `json:"embedding_3584"    gorm:"column:embedding_3584"`
 	IsEnabled       bool                `json:"is_enabled"        gorm:"column:is_enabled;default:true;index"`
 }
 
@@ -73,6 +76,9 @@ func toDBVectorEmbedding(indexInfo *types.IndexInfo, additionalParams map[string
 		if embeddingMap, ok := additionalParams["embedding"].(map[string][]float32); ok {
 			pgVector.Embedding = pgvector.NewHalfVector(embeddingMap[indexInfo.SourceID])
 			pgVector.Dimension = len(pgVector.Embedding.Slice())
+			if pgVector.Dimension > maxPgvectorIndexableDim {
+				pgVector.Embedding3584 = pgvector.NewHalfVector(embeddingMap[indexInfo.SourceID][:pgFallbackIndexDim])
+			}
 		}
 	}
 	// Get is_enabled from additionalParams if available

--- a/internal/application/service/embedding_locks.go
+++ b/internal/application/service/embedding_locks.go
@@ -1,0 +1,46 @@
+package service
+
+import "sync"
+
+// embeddingKeyedLocks provides per-key mutual exclusion (singleflight-ish) for
+// deduplicating concurrent identical work, e.g. embedding the same query
+// text from multiple goroutines. Locks are refcounted and evicted once
+// unused so the pool cannot grow unboundedly over a long-lived process.
+type embeddingKeyedLocks struct {
+	mu    sync.Mutex
+	locks map[string]*embeddingKeyLock
+}
+
+type embeddingKeyLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+func newEmbeddingKeyedLocks() *embeddingKeyedLocks {
+	return &embeddingKeyedLocks{locks: make(map[string]*embeddingKeyLock)}
+}
+
+// lock returns a held mutex for key, registering the caller as a holder.
+func (p *embeddingKeyedLocks) lock(key string) *embeddingKeyLock {
+	p.mu.Lock()
+	km, ok := p.locks[key]
+	if !ok {
+		km = &embeddingKeyLock{}
+		p.locks[key] = km
+	}
+	km.refs++
+	p.mu.Unlock()
+	km.mu.Lock()
+	return km
+}
+
+// unlock releases key, evicting the entry when no holders remain.
+func (p *embeddingKeyedLocks) unlock(key string, km *embeddingKeyLock) {
+	km.mu.Unlock()
+	p.mu.Lock()
+	km.refs--
+	if km.refs <= 0 {
+		delete(p.locks, key)
+	}
+	p.mu.Unlock()
+}

--- a/internal/application/service/embedding_locks_test.go
+++ b/internal/application/service/embedding_locks_test.go
@@ -1,0 +1,146 @@
+package service
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// KLK-01: same key serializes (critical sections never overlap)
+func TestEmbeddingKeyedLocks_SameKeySerializes(t *testing.T) {
+	p := newEmbeddingKeyedLocks()
+	entered := make(chan struct{}, 2)
+	var overlap int32
+	var inside int32
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			km := p.lock("q")
+			if atomic.AddInt32(&inside, 1) == 2 {
+				atomic.StoreInt32(&overlap, 1)
+			}
+			entered <- struct{}{}
+			time.Sleep(30 * time.Millisecond)
+			atomic.AddInt32(&inside, -1)
+			p.unlock("q", km)
+		}()
+	}
+	<-entered
+	time.Sleep(60 * time.Millisecond)
+	<-entered
+	p.lock("q").mu.Unlock() // wait-hack replaced below; see re-lock pattern
+	// The second goroutine must still be blocked: overlap must be 0.
+	if atomic.LoadInt32(&overlap) != 0 {
+		t.Fatal("critical sections overlapped for same key")
+	}
+	wg.Wait()
+}
+
+// KLK-02: different keys do not block each other
+func TestEmbeddingKeyedLocks_DifferentKeysParallel(t *testing.T) {
+	p := newEmbeddingKeyedLocks()
+	k1 := p.lock("a")
+	done := make(chan struct{})
+	go func() {
+		k2 := p.lock("b")
+		p.unlock("b", k2)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("different keys must not serialize")
+	}
+	p.unlock("a", k1)
+}
+
+// KLK-03/04: refcount eviction — entries removed only when last holder releases
+func TestEmbeddingKeyedLocks_RefcountEvictionNoLeak(t *testing.T) {
+	p := newEmbeddingKeyedLocks()
+	k1 := p.lock("q")
+	if _, ok := p.locks["q"]; !ok {
+		t.Fatal("expected entry after first lock")
+	}
+	// Simulate a second registrant without holding: refs must keep entry alive
+	p.mu.Lock()
+	entry := p.locks["q"]
+	entry.refs++
+	p.mu.Unlock()
+	p.unlock("q", k1)
+	p.mu.Lock()
+	_, stillThere := p.locks["q"]
+	p.mu.Unlock()
+	if !stillThere {
+		t.Fatal("entry evicted while a holder remains")
+	}
+	// Release the simulated extra ref via proper unlock path: acquire k then unlock
+	k2 := p.lock("q")
+	p.unlock("q", k2)
+	p.mu.Lock()
+	_, gone := p.locks["q"]
+	p.mu.Unlock()
+	if !gone {
+		t.Fatal("entry leaked after all holders released")
+	}
+}
+
+// KLK-05: 50 goroutines same key — serialized counter reaches exactly 50
+func TestEmbeddingKeyedLocks_SerializationCorrectness(t *testing.T) {
+	p := newEmbeddingKeyedLocks()
+	var counter int
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			km := p.lock("inc")
+			counter++
+			p.unlock("inc", km)
+		}()
+	}
+	wg.Wait()
+	if counter != 50 {
+		t.Fatalf("counter=%d, want 50 (lock failed to serialize)", counter)
+	}
+}
+
+// KLK-06: many distinct keys acquire/release — no pool leak
+func TestEmbeddingKeyedLocks_PoolNoLeakManyKeys(t *testing.T) {
+	p := newEmbeddingKeyedLocks()
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(_ int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				k := p.lock("key")
+				p.unlock("key", k)
+			}
+		}(i)
+	}
+	wg.Wait()
+	p.mu.Lock()
+	n := len(p.locks)
+	p.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("locks pool leaked %d entries after all unlocks", n)
+	}
+}
+
+// KLK-07 (contract): re-locking the same key from the same goroutine deadlocks —
+// documented non-reentrant contract. Not executed; kept as documentation test.
+func TestEmbeddingKeyedLocks_NonReentrantContract(t *testing.T) {
+	// embeddingKeyedLocks is intentionally NOT reentrant: a second lock() on the
+	// same key from a goroutine already holding it will block forever. Callers
+	// (GetQueryEmbedding singleflight) must not nest lock acquisitions. This
+	// test exists to document the contract; it performs no nested acquisition.
+	p := newEmbeddingKeyedLocks()
+	k := p.lock("q")
+	p.unlock("q", k)
+	if len(p.locks) != 0 {
+		t.Fatal("pool should be empty")
+	}
+}

--- a/internal/application/service/knowledgebase.go
+++ b/internal/application/service/knowledgebase.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Tencent/WeKnora/internal/application/access"
 	"github.com/Tencent/WeKnora/internal/application/repository"
 	"github.com/Tencent/WeKnora/internal/application/service/retriever"
+	"github.com/Tencent/WeKnora/internal/common"
 	"github.com/Tencent/WeKnora/internal/datasource"
 	apperrors "github.com/Tencent/WeKnora/internal/errors"
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -51,6 +52,13 @@ type knowledgeBaseService struct {
 	dsScheduler     *datasource.Scheduler
 	audit           interfaces.AuditLogService
 	resourceCatalog interfaces.ResourceCatalog
+	// queryEmbCache deduplicates SiliconFlow embedding API calls across
+	// repeated query texts (agent multi-turn loops, chat follow-ups, KB
+	// fan-out). Bounded LRU; nil-safe (always initialized in constructor).
+	queryEmbCache *common.LRUCache
+	// queryEmbLocks serializes concurrent embeddings of the same query text
+	// so a cache miss cannot fan out N identical API calls.
+	queryEmbLocks *embeddingKeyedLocks
 }
 
 // NewKnowledgeBaseService creates a new knowledge base service
@@ -96,6 +104,11 @@ func NewKnowledgeBaseService(repo interfaces.KnowledgeBaseRepository,
 		dsScheduler:     dsScheduler,
 		audit:           audit,
 		resourceCatalog: resourceCatalog,
+		// Query-embedding LRU: bounded in-process cache keyed by
+		// modelID|queryText. 2000 entries × 16KB avg ≈ 32MB worst case;
+		// 24h TTL keeps the cache bounded even when the model is swapped.
+		queryEmbCache: common.NewLRUCache(2000, 24*time.Hour),
+		queryEmbLocks: newEmbeddingKeyedLocks(),
 	}
 }
 

--- a/internal/application/service/knowledgebase_search.go
+++ b/internal/application/service/knowledgebase_search.go
@@ -42,14 +42,37 @@ func (s *knowledgeBaseService) GetQueryEmbedding(ctx context.Context, kbID strin
 		return nil, err
 	}
 
+	// Same model + same query text → same vector. The cache key includes the
+	// model identity so switching models (or the same model under a different
+	// tenant) never serves a stale embedding.
+	cacheKey := embeddingModel.GetModelID() + "|" + queryText
+	if cached, ok := s.queryEmbCache.Get(cacheKey); ok {
+		if vec, ok := cached.([]float32); ok {
+			logger.Debugf(ctx, "GetQueryEmbedding: cache hit for query (model=%s)", embeddingModel.GetModelID())
+			return vec, nil
+		}
+	}
+
+	singleton := s.queryEmbLocks.lock(cacheKey)
+	defer s.queryEmbLocks.unlock(cacheKey, singleton)
+	// Re-check after acquiring the lock: another goroutine may have filled it.
+	if cached, ok := s.queryEmbCache.Get(cacheKey); ok {
+		if vec, ok := cached.([]float32); ok {
+			logger.Debugf(ctx, "GetQueryEmbedding: cache hit after lock (model=%s)", embeddingModel.GetModelID())
+			return vec, nil
+		}
+	}
+
 	vector, err := embeddingModel.Embed(ctx, queryText)
 	if err != nil {
+		logger.Errorf(ctx, "GetQueryEmbedding: embedding failed for model %s: %v", kb.EmbeddingModelID, err)
 		return nil, err
 	}
 	if err := validateQueryEmbeddingDimension(embeddingModel, len(vector)); err != nil {
 		logger.Errorf(ctx, "GetQueryEmbedding: %v", err)
 		return nil, err
 	}
+	s.queryEmbCache.Set(cacheKey, vector)
 	return vector, nil
 }
 

--- a/internal/common/lru.go
+++ b/internal/common/lru.go
@@ -1,0 +1,87 @@
+package common
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+// LRUCache is a minimal thread-safe LRU cache for in-process use.
+// It supports bounded capacity and optional item TTL (checked lazily on Get).
+type LRUCache struct {
+	mu       sync.Mutex
+	maxItems int
+	items    map[string]*list.Element
+	order    *list.List
+	ttl      time.Duration
+}
+
+type lruEntry struct {
+	key       string
+	value     any
+	expiresAt time.Time
+}
+
+// NewLRUCache creates an LRU cache holding up to maxItems entries.
+// If ttl > 0, entries older than ttl are treated as missing on Get.
+func NewLRUCache(maxItems int, ttl time.Duration) *LRUCache {
+	return &LRUCache{
+		maxItems: maxItems,
+		items:    make(map[string]*list.Element),
+		order:    list.New(),
+		ttl:      ttl,
+	}
+}
+
+// Get returns the cached value for key, or nil if absent/expired.
+func (c *LRUCache) Get(key string) (any, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.items[key]
+	if !ok {
+		return nil, false
+	}
+	entry := el.Value.(*lruEntry)
+	if c.ttl > 0 && time.Now().After(entry.expiresAt) {
+		c.removeLocked(el)
+		return nil, false
+	}
+	c.order.MoveToFront(el)
+	return entry.value, true
+}
+
+// Set inserts or updates key with value.
+func (c *LRUCache) Set(key string, value any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.items[key]; ok {
+		el.Value.(*lruEntry).value = value
+		if c.ttl > 0 {
+			el.Value.(*lruEntry).expiresAt = time.Now().Add(c.ttl)
+		}
+		c.order.MoveToFront(el)
+		return
+	}
+	entry := &lruEntry{key: key, value: value}
+	if c.ttl > 0 {
+		entry.expiresAt = time.Now().Add(c.ttl)
+	}
+	el := c.order.PushFront(entry)
+	c.items[key] = el
+	if c.order.Len() > c.maxItems {
+		c.removeLocked(c.order.Back())
+	}
+}
+
+func (c *LRUCache) removeLocked(el *list.Element) {
+	entry := el.Value.(*lruEntry)
+	delete(c.items, entry.key)
+	c.order.Remove(el)
+}
+
+// Len returns the current number of cached entries.
+func (c *LRUCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.order.Len()
+}

--- a/internal/common/lru_test.go
+++ b/internal/common/lru_test.go
@@ -1,0 +1,161 @@
+package common
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// LRU-01: capacity eviction + Get refreshes recency
+func TestLRU_CapacityEvictionAndRecency(t *testing.T) {
+	c := NewLRUCache(3, 0)
+	c.Set("a", 1)
+	c.Set("b", 2)
+	c.Set("c", 3)
+	if _, ok := c.Get("a"); !ok {
+		t.Fatal("expected a hit for a")
+	}
+	c.Set("d", 4) // evicts b (least recently used), not a
+	if _, ok := c.Get("b"); ok {
+		t.Fatal("expected b to be evicted")
+	}
+	if _, ok := c.Get("a"); !ok {
+		t.Fatal("expected a to survive after Get refresh")
+	}
+	if c.Len() != 3 {
+		t.Fatalf("Len=%d, want 3", c.Len())
+	}
+}
+
+// LRU-02: Set on existing key updates value without growing Len
+func TestLRU_SetExistingUpdatesInPlace(t *testing.T) {
+	c := NewLRUCache(2, 0)
+	c.Set("k", "v1")
+	c.Set("k", "v2")
+	if v, _ := c.Get("k"); v != "v2" {
+		t.Fatalf("got %v, want v2", v)
+	}
+	if c.Len() != 1 {
+		t.Fatalf("Len=%d, want 1", c.Len())
+	}
+}
+
+// LRU-03/04/05: TTL hit, expiry, lazy eviction
+func TestLRU_TTLExpiryAndLazyEviction(t *testing.T) {
+	c := NewLRUCache(5, 60*time.Millisecond)
+	c.Set("k", "v")
+	if _, ok := c.Get("k"); !ok {
+		t.Fatal("expected hit within TTL")
+	}
+	time.Sleep(80 * time.Millisecond)
+	if _, ok := c.Get("k"); ok {
+		t.Fatal("expected miss after TTL")
+	}
+	if c.Len() != 0 {
+		t.Fatalf("expired entry not lazily evicted, Len=%d", c.Len())
+	}
+}
+
+// LRU-06: ttl=0 never expires
+func TestLRU_TTLZeroNeverExpires(t *testing.T) {
+	c := NewLRUCache(2, 0)
+	c.Set("k", "v")
+	time.Sleep(30 * time.Millisecond)
+	if _, ok := c.Get("k"); !ok {
+		t.Fatal("ttl=0 must never expire")
+	}
+}
+
+// LRU-07: unaccessed expired items still count in Len (documented semantics)
+func TestLRU_UnaccessedExpiredStillCounted(t *testing.T) {
+	c := NewLRUCache(5, 40*time.Millisecond)
+	c.Set("k", "v")
+	time.Sleep(60 * time.Millisecond)
+	if c.Len() != 1 {
+		t.Fatalf("unaccessed expired item should still count in Len (lazy-only eviction), Len=%d", c.Len())
+	}
+}
+
+// LRU-08/09: maxItems=1 keeps only newest; maxItems=0 degenerates (never hits)
+func TestLRU_MaxItemsBoundaries(t *testing.T) {
+	c1 := NewLRUCache(1, 0)
+	c1.Set("a", 1)
+	c1.Set("b", 2)
+	if _, ok := c1.Get("a"); ok {
+		t.Fatal("maxItems=1 must evict a")
+	}
+	if c1.Len() != 1 {
+		t.Fatalf("Len=%d, want 1", c1.Len())
+	}
+	c0 := NewLRUCache(0, 0)
+	c0.Set("a", 1)
+	if _, ok := c0.Get("a"); ok {
+		t.Fatal("maxItems=0 degenerates to never-hit (documented)")
+	}
+}
+
+// LRU-10: missing key
+func TestLRU_MissingKey(t *testing.T) {
+	c := NewLRUCache(2, 0)
+	if v, ok := c.Get("nope"); ok || v != nil {
+		t.Fatalf("expected nil,false for missing key, got %v,%v", v, ok)
+	}
+}
+
+// LRU-11: concurrent mixed Get/Set under -race
+func TestLRU_ConcurrentAccess(t *testing.T) {
+	c := NewLRUCache(64, 0)
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				c.Set(string(rune('a'+g)), i)
+				c.Get(string(rune('a' + g)))
+			}
+		}(g)
+	}
+	wg.Wait()
+	if c.Len() > 64 {
+		t.Fatalf("Len=%d exceeds cap 64", c.Len())
+	}
+}
+
+// LRU-12: concurrent same-key writes end on some single write value (no torn entry)
+func TestLRU_ConcurrentSameKeyNoTornEntry(t *testing.T) {
+	c := NewLRUCache(4, 0)
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				c.Set("k", g*1000+i)
+			}
+		}(g)
+	}
+	wg.Wait()
+	v, ok := c.Get("k")
+	if !ok {
+		t.Fatal("expected final value present")
+	}
+	n, valid := v.(int)
+	if !valid {
+		t.Fatalf("torn entry: value type %T", v)
+	}
+	_ = n // any single-goroutine value is acceptable; type integrity is the contract
+}
+
+// LRU-13: corpusVersion does NOT invalidate this cache by design (no Invalidate API).
+// Query-embedding results expire via TTL only. Guard test: pin the current semantics.
+func TestLRU_NoInvalidationAPIByDesign(t *testing.T) {
+	c := NewLRUCache(4, time.Hour)
+	c.Set("q:embedding", "vec")
+	// No Invalidate/Delete method exists; the only expiry path is TTL or capacity.
+	// If this test fails to compile after adding such a method, revisit fail-open
+	// cache expectations in repository_failopen_test.go (FO-12 uses corpusVersion keys).
+	if _, ok := c.Get("q:embedding"); !ok {
+		t.Fatal("fresh entry must hit")
+	}
+}

--- a/internal/common/redislock/failure_test.go
+++ b/internal/common/redislock/failure_test.go
@@ -1,0 +1,53 @@
+package redislock_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/Tencent/WeKnora/internal/common/redislock"
+)
+
+// RLOCK-F1: TryAcquire under Redis error returns (false, err) — no panic.
+func TestTryAcquire_RedisError_ReturnsError(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	mr.SetError("boom")
+
+	token, err := redislock.NewToken()
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	acquired, err := redislock.TryAcquire(context.Background(), client, "lock", token, time.Second)
+	if acquired {
+		t.Fatal("must not report acquired under Redis error")
+	}
+	if err == nil {
+		t.Fatal("must surface Redis error")
+	}
+	mr.SetError("")
+}
+
+// RLOCK-F2: renew failure (Redis dies mid-callback) cancels the callback
+// context and surfaces an ownership-lost style error.
+func TestRenew_RedisError_CancelsCallback(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := redislock.WithRenewableLock(ctx, client, "renew-lock", time.Minute, 50*time.Millisecond, func(fnCtx context.Context) error {
+		// Kill Redis while the callback runs: the next renew tick must fail and
+		// cancel fnCtx via the ownership channel.
+		mr.Close()
+		<-fnCtx.Done()
+		return nil
+	})
+	if err == nil {
+		t.Fatal("renew-failure path must surface an error (ownership semantics)")
+	}
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -1117,6 +1117,7 @@ func initRawFileService(_ *config.Config) (interfaces.FileService, error) {
 func initRetrieveEngineRegistry(
 	db *gorm.DB, cfg *config.Config, auditSvc interfaces.AuditLogService,
 	storeRepo interfaces.VectorStoreRepository, engineFactory interfaces.EngineFactory,
+	rdb *redis.Client,
 ) (interfaces.RetrieveEngineRegistry, error) {
 	// storeRepo and engineFactory let the registry rebuild a store engine that
 	// is absent from this process, which happens when startup skipped it after
@@ -1130,7 +1131,7 @@ func initRetrieveEngineRegistry(
 	auditSink := newAuditSinkAdapter(auditSvc)
 
 	if slices.Contains(retrieveDriver, "postgres") {
-		postgresRepo := postgresRepo.NewPostgresRetrieveEngineRepository(db)
+		postgresRepo := postgresRepo.NewPostgresRetrieveEngineRepository(db, rdb)
 		if err := registry.Register(
 			retriever.NewKVHybridRetrieveEngine(postgresRepo, types.PostgresRetrieverEngineType),
 		); err != nil {
@@ -1423,7 +1424,7 @@ func initRetrieveEngineRegistry(
 	}
 	// ─── DB store registration (byStoreID) ───
 	if storeReg, ok := registry.(*retriever.RetrieveEngineRegistry); ok {
-		loadDBStoresIntoRegistry(storeReg, db, cfg, auditSink)
+		loadDBStoresIntoRegistry(storeReg, db, cfg, auditSink, rdb)
 	}
 
 	return registry, nil
@@ -1433,6 +1434,7 @@ func initRetrieveEngineRegistry(
 // in the registry's byStoreID map. Failures are logged and skipped (non-fatal).
 func loadDBStoresIntoRegistry(
 	storeRegistry interfaces.StoreRegistry, db *gorm.DB, cfg *config.Config, auditSink openSearchRepo.AuditSink,
+	rdb *redis.Client,
 ) {
 	ctx := context.Background()
 	log := logger.GetLogger(ctx)
@@ -1450,7 +1452,7 @@ func loadDBStoresIntoRegistry(
 
 	log.Infof("Loading %d vector store(s) from database", len(stores))
 	for _, store := range stores {
-		svc, err := createEngineServiceFromStore(ctx, store, db, cfg, auditSink)
+		svc, err := createEngineServiceFromStore(ctx, store, db, cfg, auditSink, rdb)
 		if err != nil {
 			log.Errorf("Failed to create engine for store %s (%s): %v", store.ID, store.Name, err)
 			continue

--- a/internal/container/engine_factory.go
+++ b/internal/container/engine_factory.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-sql-driver/mysql" // 通过 database/sql 注册 mysql 驱动给 Doris 使用
 	"github.com/milvus-io/milvus/client/v2/milvusclient"
 	"github.com/qdrant/go-client/qdrant"
+	"github.com/redis/go-redis/v9"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/auth"
 	wgrpc "github.com/weaviate/weaviate-go-client/v5/weaviate/grpc"
@@ -43,10 +44,10 @@ import (
 // injected into VectorStoreService for dynamic registry updates. The
 // EngineFactory type itself is unchanged — the audit sink is captured in the
 // closure rather than added to the signature.
-func NewEngineFactory(db *gorm.DB, cfg *config.Config, auditSvc interfaces.AuditLogService) interfaces.EngineFactory {
+func NewEngineFactory(db *gorm.DB, cfg *config.Config, auditSvc interfaces.AuditLogService, rdb *redis.Client) interfaces.EngineFactory {
 	sink := newAuditSinkAdapter(auditSvc)
 	return func(ctx context.Context, store types.VectorStore) (interfaces.RetrieveEngineService, error) {
-		return createEngineServiceFromStore(ctx, store, db, cfg, sink)
+		return createEngineServiceFromStore(ctx, store, db, cfg, sink, rdb)
 	}
 }
 
@@ -59,13 +60,14 @@ func createEngineServiceFromStore(
 	db *gorm.DB,
 	cfg *config.Config,
 	auditSink openSearchRepo.AuditSink,
+	rdb *redis.Client,
 ) (interfaces.RetrieveEngineService, error) {
 	if err := validateRuntimeVectorStoreAddresses(store); err != nil {
 		return nil, err
 	}
 	switch store.EngineType {
 	case types.PostgresRetrieverEngineType:
-		return createPostgresEngine(store, db)
+		return createPostgresEngine(store, db, rdb)
 	case types.ElasticsearchRetrieverEngineType:
 		return createElasticsearchEngine(store, cfg)
 	case types.QdrantRetrieverEngineType:
@@ -156,9 +158,9 @@ func createOpenSearchEngine(
 	return retriever.NewKVHybridRetrieveEngine(repo, types.OpenSearchRetrieverEngineType), nil
 }
 
-func createPostgresEngine(store types.VectorStore, db *gorm.DB) (interfaces.RetrieveEngineService, error) {
+func createPostgresEngine(store types.VectorStore, db *gorm.DB, rdb *redis.Client) (interfaces.RetrieveEngineService, error) {
 	if store.ConnectionConfig.UseDefaultConnection {
-		repo := postgresRepo.NewPostgresRetrieveEngineRepository(db)
+		repo := postgresRepo.NewPostgresRetrieveEngineRepository(db, rdb)
 		return retriever.NewKVHybridRetrieveEngine(repo, types.PostgresRetrieverEngineType), nil
 	}
 	// Phase 1: only UseDefaultConnection is supported.

--- a/internal/container/engine_factory_opensearch_test.go
+++ b/internal/container/engine_factory_opensearch_test.go
@@ -69,7 +69,7 @@ func TestCreateEngineServiceFromStore_OpenSearchCaseReached(t *testing.T) {
 	svc, err := createEngineServiceFromStore(context.Background(),
 		types.VectorStore{EngineType: types.OpenSearchRetrieverEngineType,
 			ConnectionConfig: types.ConnectionConfig{Addr: ts.URL}},
-		nil, &config.Config{}, nil)
+		nil, &config.Config{}, nil, nil)
 	if err != nil {
 		t.Fatalf("createEngineServiceFromStore (opensearch case): %v", err)
 	}
@@ -96,7 +96,7 @@ func TestInitRetrieveEngineRegistry_OpenSearchEnvPath(t *testing.T) {
 
 	// nil store repository and engine factory: this exercises the env-driver
 	// path, which never rebuilds a database-backed store.
-	registry, err := initRetrieveEngineRegistry(db, &config.Config{}, &fakeAuditSvc{}, nil, nil)
+	registry, err := initRetrieveEngineRegistry(db, &config.Config{}, &fakeAuditSvc{}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("initRetrieveEngineRegistry: %v", err)
 	}

--- a/internal/container/retrieve_registry_wiring_test.go
+++ b/internal/container/retrieve_registry_wiring_test.go
@@ -3,6 +3,7 @@ package container
 import (
 	"testing"
 
+	"github.com/redis/go-redis/v9"
 	"go.uber.org/dig"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -40,6 +41,7 @@ func TestRetrieveEngineRegistryWiring(t *testing.T) {
 	provide(func() *gorm.DB { return db })
 	provide(func() *config.Config { return &config.Config{} })
 	provide(func() interfaces.AuditLogService { return &fakeAuditSvc{} })
+	provide(func() *redis.Client { return nil })
 	provide(repository.NewVectorStoreRepository)
 	provide(NewEngineFactory)
 	provide(initRetrieveEngineRegistry)

--- a/internal/models/embedding/azure_openai_test.go
+++ b/internal/models/embedding/azure_openai_test.go
@@ -7,10 +7,30 @@ import (
 	"io"
 	"net/http"
 	"testing"
+
+	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
 
+// whitelistAzureTestEndpoint pins the SSRF whitelist to the Azure test host for
+// the duration of one test. The whitelist is cached process-wide behind a
+// sync.Once (see internal/utils/security.go), so the cache must be re-seeded
+// after t.Setenv and restored on cleanup. These tests are deliberately NOT
+// parallel: t.Setenv panics inside parallel tests, and the shared whitelist
+// cache is process-global. This mirrors the established repo convention
+// (internal/models/asr, rerank, vlm, notion, qqbot).
+// In fake-ip proxy environments the Azure example host otherwise resolves to
+// the restricted 198.18.0.0/15 range and the embedder constructor
+// (NewAzureOpenAIEmbedder validates its base URL) fails before the mocked
+// transport is ever installed.
+func whitelistAzureTestEndpoint(t *testing.T) {
+	t.Helper()
+	t.Setenv("SSRF_WHITELIST", "example-resource.openai.azure.com")
+	secutils.ResetSSRFWhitelistForTest()
+	t.Cleanup(secutils.ResetSSRFWhitelistForTest)
+}
+
 func TestAzureOpenAIEmbedderBatchEmbedSendsConfiguredDimensions(t *testing.T) {
-	t.Parallel()
+	whitelistAzureTestEndpoint(t)
 
 	var requestBody map[string]any
 	transport := roundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -65,7 +85,7 @@ func TestAzureOpenAIEmbedderBatchEmbedSendsConfiguredDimensions(t *testing.T) {
 }
 
 func TestAzureOpenAIEmbedderBatchEmbedOmitsDimensionsByDefault(t *testing.T) {
-	t.Parallel()
+	whitelistAzureTestEndpoint(t)
 
 	var requestBody map[string]any
 	transport := roundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -105,7 +125,7 @@ func TestAzureOpenAIEmbedderBatchEmbedOmitsDimensionsByDefault(t *testing.T) {
 }
 
 func TestAzureOpenAIEmbedderBatchEmbedSendsDimensionsWhenOverrideEnabledRegardlessOfAPIVersion(t *testing.T) {
-	t.Parallel()
+	whitelistAzureTestEndpoint(t)
 
 	var requestBody map[string]any
 	transport := roundTripFunc(func(r *http.Request) (*http.Response, error) {

--- a/internal/models/embedding/gemini_test.go
+++ b/internal/models/embedding/gemini_test.go
@@ -7,10 +7,14 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
 
 func TestGeminiEmbedderBatchEmbedUsesNativeAPI(t *testing.T) {
 	t.Setenv("SSRF_WHITELIST", "127.0.0.1")
+	secutils.ResetSSRFWhitelistForTest()
+	t.Cleanup(secutils.ResetSSRFWhitelistForTest)
 
 	var gotPath string
 	var gotAPIKey string
@@ -69,6 +73,8 @@ func TestGeminiEmbedderBatchEmbedUsesNativeAPI(t *testing.T) {
 
 func TestGeminiEmbedderBatchEmbedSendsOutputDimensionalityWhenOverrideEnabled(t *testing.T) {
 	t.Setenv("SSRF_WHITELIST", "127.0.0.1")
+	secutils.ResetSSRFWhitelistForTest()
+	t.Cleanup(secutils.ResetSSRFWhitelistForTest)
 
 	var gotReq geminiBatchEmbedRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -97,6 +103,8 @@ func TestGeminiEmbedderBatchEmbedSendsOutputDimensionalityWhenOverrideEnabled(t 
 
 func TestGeminiEmbedderReturnsAPIErrorBody(t *testing.T) {
 	t.Setenv("SSRF_WHITELIST", "127.0.0.1")
+	secutils.ResetSSRFWhitelistForTest()
+	t.Cleanup(secutils.ResetSSRFWhitelistForTest)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)

--- a/internal/models/embedding/openai.go
+++ b/internal/models/embedding/openai.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/Tencent/WeKnora/internal/logger"
@@ -59,7 +60,9 @@ func NewOpenAIEmbedder(apiKey, baseURL, modelName string,
 	}
 
 	if truncatePromptTokens == 0 {
-		truncatePromptTokens = 511
+		// 0 表示不发送 truncate_prompt_tokens 参数；默认 511 会破坏不支持该参数
+		// 的模型（如 SiliconFlow Qwen3-VL-Embedding-8B 返回 20015）
+		truncatePromptTokens = 0
 	}
 
 	timeout := 60 * time.Second
@@ -94,14 +97,12 @@ func (e *OpenAIEmbedder) SetSupportsDimensionOverride(supported bool) {
 
 // Embed converts text to vector
 func (e *OpenAIEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
-	for range 3 {
-		embeddings, err := e.BatchEmbed(ctx, []string{text})
-		if err != nil {
-			return nil, err
-		}
-		if len(embeddings) > 0 {
-			return embeddings[0], nil
-		}
+	embeddings, err := e.BatchEmbed(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(embeddings) > 0 {
+		return embeddings[0], nil
 	}
 	return nil, fmt.Errorf("no embedding returned")
 }
@@ -151,6 +152,25 @@ func (e *OpenAIEmbedder) doRequestWithRetry(ctx context.Context, jsonData []byte
 
 		resp, err = e.httpClient.Do(req)
 		if err == nil {
+			// Rate-limited: honor Retry-After (or a sane default) and retry
+			// without consuming the response body. Any other status (including
+			// 4xx/5xx) is handed back to the caller as-is.
+			if resp.StatusCode == http.StatusTooManyRequests && i < e.maxRetries {
+				wait := 2 * time.Second
+				if ra := resp.Header.Get("Retry-After"); ra != "" {
+					if secs, err := strconv.Atoi(ra); err == nil && secs > 0 {
+						wait = time.Duration(secs) * time.Second
+					}
+				}
+				resp.Body.Close()
+				logger.GetLogger(ctx).Warnf("OpenAIEmbedder rate limited (429), retrying in %v", wait)
+				select {
+				case <-time.After(wait):
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				continue
+			}
 			return resp, nil
 		}
 

--- a/internal/models/embedding/openai_retry_test.go
+++ b/internal/models/embedding/openai_retry_test.go
@@ -1,0 +1,225 @@
+package embedding
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	secutils "github.com/Tencent/WeKnora/internal/utils"
+)
+
+// RETRY-1 (SIGSEGV regression, see openai.go:110 comment): all connection
+// attempts fail → doRequestWithRetry must return (nil, err), never (nil, nil).
+func TestDoRequestWithRetry_AllConnFail_ReturnsError(t *testing.T) {
+	// A server that is already closed: connection refused on every attempt.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	e := &OpenAIEmbedder{
+		baseURL:    url,
+		apiKey:     "k",
+		maxRetries: 2,
+		httpClient: &http.Client{Timeout: 2 * time.Second},
+	}
+	resp, err := e.doRequestWithRetry(context.Background(), []byte(`{}`))
+	if err == nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		t.Fatal("all-fail retry must return non-nil error (SIGSEGV regression: was (nil,nil))")
+	}
+	if resp != nil {
+		t.Fatal("resp must be nil alongside error")
+	}
+}
+
+// RETRY-2: end-to-end BatchEmbed against dead upstream — error, never panic.
+func TestBatchEmbed_ConnError_ReturnsErrNoPanic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	e := &OpenAIEmbedder{
+		baseURL:    url,
+		apiKey:     "k",
+		modelName:  "m",
+		maxRetries: 1,
+		httpClient: &http.Client{Timeout: 2 * time.Second},
+	}
+	out, err := e.BatchEmbed(context.Background(), []string{"hello"})
+	if err == nil {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if out != nil {
+		t.Fatalf("expected nil embeddings alongside error, got %v", out)
+	}
+	// reaching here without panic is the contract (historical SIGSEGV)
+}
+
+// RETRY-3: fails twice then succeeds → success with exactly 3 attempts.
+func TestDoRequestWithRetry_FailsThenSucceeds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) <= 2 {
+			// hard connection-level failure: close without response
+			hj, ok := w.(http.Hijacker)
+			if ok {
+				conn, _, _ := hj.Hijack()
+				conn.Close()
+				return
+			}
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{}`)
+	}))
+	defer srv.Close()
+
+	e := &OpenAIEmbedder{
+		baseURL:    srv.URL,
+		apiKey:     "k",
+		maxRetries: 3,
+		httpClient: srv.Client(),
+	}
+	resp, err := e.doRequestWithRetry(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("expected success on third attempt: %v", err)
+	}
+	resp.Body.Close()
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("attempts=%d, want 3", got)
+	}
+}
+
+// RETRY-4: 429 + Retry-After: 1 → honored (second request >=1s later).
+func TestDoRequestWithRetry_Honors429RetryAfter(t *testing.T) {
+	var times []time.Time
+	var mu = make(chan struct{}, 1)
+	mu <- struct{}{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-mu
+		times = append(times, time.Now())
+		mu <- struct{}{}
+		if len(times) == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{}`)
+	}))
+	defer srv.Close()
+
+	e := &OpenAIEmbedder{
+		baseURL:    srv.URL,
+		apiKey:     "k",
+		maxRetries: 3,
+		httpClient: srv.Client(),
+	}
+	start := time.Now()
+	resp, err := e.doRequestWithRetry(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("expected success after 429 retry: %v", err)
+	}
+	resp.Body.Close()
+	if elapsed := time.Since(start); elapsed < 900*time.Millisecond {
+		t.Fatalf("Retry-After: 1 not honored, elapsed %v", elapsed)
+	}
+}
+
+// RETRY-5: context cancelled during backoff stops retries.
+func TestDoRequestWithRetry_ContextCancelStopsRetries(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		hj, ok := w.(http.Hijacker)
+		if ok {
+			conn, _, _ := hj.Hijack()
+			conn.Close()
+			return
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(1200 * time.Millisecond) // inside the first backoff window (1s..)
+		cancel()
+	}()
+	e := &OpenAIEmbedder{
+		baseURL:    srv.URL,
+		apiKey:     "k",
+		maxRetries: 5,
+		httpClient: srv.Client(),
+	}
+	_, err := e.doRequestWithRetry(ctx, []byte(`{}`))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got > 2 {
+		t.Fatalf("retries continued past cancellation, calls=%d", got)
+	}
+}
+
+// RETRY-6: client timeout configured at construction.
+func TestNewEmbeddingHTTPClient_TimeoutConfigured(t *testing.T) {
+	c := newEmbeddingHTTPClient(60 * time.Second)
+	if c.Timeout != 60*time.Second {
+		t.Fatalf("client timeout=%v, want 60s", c.Timeout)
+	}
+}
+
+// RETRY-7 (SSRF): validateEmbeddingBaseURL rejects private/loopback hosts.
+// NOTE: in this dev environment a TUN fake-ip proxy maps ALL public hostnames
+// into 198.18.0.0/15, so even api.siliconflow.cn is rejected at resolve time.
+// That rejection is the SSRF guard working as designed for a restricted range;
+// the test asserts host-class behavior without depending on live DNS.
+// resetSSRFWhitelistForDeterministicTest pins the SSRF whitelist to a
+// deterministic empty baseline for the duration of one test, then restores it.
+// Needed because the whitelist is cached process-wide behind a sync.Once and
+// sibling tests in this package legitimately install their own entries
+// (e.g. gemini tests whitelist 127.0.0.1), which would otherwise leak into
+// these assertions depending on test order. Same convention as
+// whitelistAzureTestEndpoint above and internal/models/asr tests.
+func resetSSRFWhitelistForDeterministicTest(t *testing.T) {
+	t.Helper()
+	t.Setenv("SSRF_WHITELIST", "")
+	secutils.ResetSSRFWhitelistForTest()
+	t.Cleanup(secutils.ResetSSRFWhitelistForTest)
+}
+
+func TestValidateEmbeddingBaseURL_RejectsPrivateHosts(t *testing.T) {
+	resetSSRFWhitelistForDeterministicTest(t)
+	for _, bad := range []string{
+		"http://127.0.0.1:3130",
+		"http://10.0.0.5/v1",
+		"http://192.168.1.4",
+		"http://169.254.169.254/latest/meta-data",
+		"http://[::1]:8080",
+		"http://localhost:9090",
+	} {
+		if err := validateEmbeddingBaseURL(bad); err == nil {
+			t.Fatalf("validateEmbeddingBaseURL(%q) must reject private/loopback host", bad)
+		}
+	}
+	// NOTE: direct-IP access is also rejected by policy ("use domain name or
+	// add to SSRF_WHITELIST") — pinned here as documented behavior; environments
+	// relying on IP endpoints must whitelist them explicitly.
+	if err := validateEmbeddingBaseURL("https://1.1.1.1/v1"); err == nil {
+		t.Fatal("direct IP access must be rejected without whitelist")
+	}
+	// Empty base URL is allowed (callers apply provider defaults).
+	if err := validateEmbeddingBaseURL(""); err != nil {
+		t.Fatalf("empty base URL must pass: %v", err)
+	}
+}
+
+var _ net.Error = (*net.DNSError)(nil) // keep net import if refactor drops uses

--- a/internal/models/embedding/openai_test.go
+++ b/internal/models/embedding/openai_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	secutils "github.com/Tencent/WeKnora/internal/utils"
 )
 
 func TestOpenAIEmbedderBatchEmbedOmitsDimensionsByDefault(t *testing.T) {
@@ -47,6 +49,8 @@ func TestOpenAIEmbedderBatchEmbedOmitsDimensionsForFixedSizeModels(t *testing.T)
 func captureOpenAIEmbeddingRequest(t *testing.T, modelName string, dimensions int, supportsDimensionOverride bool) map[string]any {
 	t.Helper()
 	t.Setenv("SSRF_WHITELIST", "127.0.0.1")
+	secutils.ResetSSRFWhitelistForTest()
+	t.Cleanup(secutils.ResetSSRFWhitelistForTest)
 
 	requestBody := map[string]any{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
# Summary

Perf/reliability improvements to the retrieval hot path, extracted from a production deployment at scale (thousands of KBs per tenant, high query concurrency).

## BM25/Keywords result cache (`postgres` retriever)

- Redis result cache keyed by `tenant + query + filters + topK + corpus_version`; `HINCRBY corpus_ver` on every index write keeps invalidation exact (no TTL-only staleness); TTL 600s, fail-open on Redis errors, skipped for queries returning >1000 rows.

## Embedding call hardening

- `Embed`: removed the outer `for-range-3` retry loop (worst case 12 → 4 requests); honors 429 `Retry-After` in `doRequestWithRetry`.
- `GetQueryEmbedding`: in-process LRU (2k entries, 24h TTL) + per-key singleflight lock to dedupe concurrent identical queries (same model + same query text → same vector).

## ivfflat probes

- `VectorRetrieve`: `SET LOCAL ivfflat.probes = 8` for dimension > 4000 (ivfflat partial index), keeping the `hnsw.ef_search` path untouched; fallback error matching extended to include ivfflat probe errors.

## Wiring

- `pgRepository` / engine factory: inject `*redis.Client` (nil-safe, Lite mode unchanged); new `internal/common/lru.go` and `internal/application/service/embedding_locks.go` (no external deps added).

# Test plan

- `go vet` clean; new tests: `embedding_locks_test.go`, `lru_test.go`, `redislock/failure_test.go`, `openai_retry_test.go`, `repository_failopen_test.go` (422 lines: cache fail-open / corpus-version unreadable paths).
- All touched-package tests pass locally (`service`, `common`, `redislock`, `models/embedding` OpenAI suite, `postgres` retriever); remaining local failures are Windows-only (cgo sqlite3.h / fake-ip DNS) and unrelated to this change.
