### PR TITLE
fix(skills): accept UTF-8 BOM in skill manifests

### DIFF
--- a/internal/agent/skills/skill.go
+++ b/internal/agent/skills/skill.go
@@ -160,6 +160,8 @@ func (s *Skill) ToMetadata() *SkillMetadata {
 // It handles YAML frontmatter enclosed in --- delimiters
 func ParseSkillFile(content string) (*Skill, error) {
 	skill := &Skill{}
+	// Some editors emit a UTF-8 BOM, which strings.TrimSpace does not remove.
+	content = strings.TrimPrefix(content, "\ufeff")
 
 	// Check for YAML frontmatter
 	if !strings.HasPrefix(strings.TrimSpace(content), "---") {

--- a/internal/agent/skills/skills_test.go
+++ b/internal/agent/skills/skills_test.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,6 +49,30 @@ Use this skill when testing.
 
 	t.Logf("Parsed skill: name=%s, description=%s, instructions_len=%d",
 		skill.Name, skill.Description, len(skill.Instructions))
+}
+
+func TestParseSkillFileUTF8BOM(t *testing.T) {
+	for _, newline := range []string{"\n", "\r\n"} {
+		t.Run(fmt.Sprintf("newline=%q", newline), func(t *testing.T) {
+			content := "\ufeff---\nname: test-skill\ndescription: A test skill.\n---\nKeep this \ufeff character.\n"
+			content = strings.ReplaceAll(content, "\n", newline)
+			skill, err := ParseSkillFile(content)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if skill.Name != "test-skill" || skill.Description != "A test skill." ||
+				skill.Instructions != "Keep this \ufeff character." {
+				t.Fatalf("unexpected parsed skill: %+v", skill)
+			}
+			metadata, err := ParseSkillMetadata(content)
+			if err != nil || metadata.Name != "test-skill" {
+				t.Fatalf("unexpected metadata: %+v, error: %v", metadata, err)
+			}
+		})
+	}
+	if _, err := ParseSkillFile("\ufeff# Missing frontmatter"); err == nil {
+		t.Fatal("BOM must not bypass frontmatter validation")
+	}
 }
 
 func TestSkillValidation(t *testing.T) {

--- a/internal/application/service/tenant_skill_bundle.go
+++ b/internal/application/service/tenant_skill_bundle.go
@@ -391,6 +391,7 @@ func validateSkillEntryName(name string) error {
 }
 
 func parseSkillBundleVersion(manifest string) (string, error) {
+	manifest = strings.TrimPrefix(manifest, "\ufeff")
 	lines := strings.Split(manifest, "\n")
 	frontmatterStart := -1
 	for i, line := range lines {

--- a/internal/application/service/tenant_skill_bundle_test.go
+++ b/internal/application/service/tenant_skill_bundle_test.go
@@ -242,6 +242,18 @@ Use scripts/extract.py to pull text out of a PDF.
 		require.Equal(t, "1.2.3", bundle.Version)
 	})
 
+	t.Run("reads UTF-8 BOM frontmatter including version", func(t *testing.T) {
+		manifest := "\ufeff---\nname: pdf-tools\nversion: 1.2.3\n" +
+			"description: Extract text from PDF files\n---\nUse PDF tools.\n"
+		data := zipBundle(t, map[string]string{"SKILL.md": manifest})
+		bundle, err := ParseSkillBundle(data)
+		require.NoError(t, err)
+		require.Equal(t, "pdf-tools", bundle.Name)
+		require.Equal(t, "1.2.3", bundle.Version)
+		require.Equal(t, "Use PDF tools.", bundle.Instructions)
+		require.Equal(t, []byte(manifest), bundle.Files["SKILL.md"])
+	})
+
 	t.Run("uses slug when name is a display title", func(t *testing.T) {
 		data := zipBundle(t, map[string]string{
 			"SKILL.md": `---

--- a/internal/application/service/tenant_skill_source.go
+++ b/internal/application/service/tenant_skill_source.go
@@ -914,7 +914,7 @@ func looksLikeJSON(contentType string, body []byte) bool {
 }
 
 func looksLikeSkillMarkdown(body []byte) bool {
-	trimmed := bytes.TrimSpace(body)
+	trimmed := bytes.TrimSpace(bytes.TrimPrefix(body, []byte("\ufeff")))
 	if !bytes.HasPrefix(trimmed, []byte("---")) {
 		return false
 	}

--- a/internal/application/service/tenant_skill_source_test.go
+++ b/internal/application/service/tenant_skill_source_test.go
@@ -515,18 +515,23 @@ func TestFetchSkillArchiveFollowsGitHubHandoff(t *testing.T) {
 }
 
 func TestFetchSkillArchiveFromSkillMarkdown(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "text/markdown")
-		_, _ = w.Write([]byte(validSkillMD))
-	}))
-	t.Cleanup(server.Close)
-	allowLoopbackSkillFetch(t)
+	for _, prefix := range []string{"", "\ufeff"} {
+		t.Run(fmt.Sprintf("prefix=%q", prefix), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/markdown")
+				_, _ = w.Write([]byte(prefix + validSkillMD))
+			}))
+			t.Cleanup(server.Close)
+			allowLoopbackSkillFetch(t)
 
-	got, err := fetchSkillArchive(t.Context(), server.URL+"/SKILL.md", server.Client())
-	require.NoError(t, err)
-	bundle, err := ParseSkillBundle(got)
-	require.NoError(t, err)
-	require.Equal(t, "pdf-tools", bundle.Name)
+			got, err := fetchSkillArchive(t.Context(), server.URL+"/SKILL.md", server.Client())
+			require.NoError(t, err)
+			bundle, err := ParseSkillBundle(got)
+			require.NoError(t, err)
+			require.Equal(t, "pdf-tools", bundle.Name)
+			require.Equal(t, []byte(prefix+validSkillMD), bundle.Files["SKILL.md"])
+		})
+	}
 }
 
 func TestParseSkillBundleNestedRemoteArchive(t *testing.T) {


### PR DESCRIPTION
## Description

Importing a skill whose `SKILL.md` starts with a UTF-8 BOM fails with `SKILL.md must start with YAML frontmatter (---)`, even when its YAML header is valid. This affects the SkillHub `pdf-to-word-by-wp` bundle.

Ignore a leading BOM when parsing skill metadata and instructions, reading the bundle version, and recognizing remote Markdown downloads. Preserve the original file bytes and continue rejecting files without frontmatter.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🧪 Test

## Related Issue

Reported for https://skillhub.cn/skills/user_48bf225f/pdf-to-word-by-wp.

## Testing

The new regression cases reproduced the original parsing and remote-download failures before the fix. After the fix, these checks passed:

- `go test ./internal/agent/skills`
- `go test ./internal/application/service -run 'Test.*(SkillBundle|SkillSource|FetchSkill|NormalizeFetched|SkillMarkdown)' -count=1`
- `git diff --cached --check`
- `git diff --check github_public/main...HEAD`
- `golangci-lint run --new-from-rev=github_public/main ./internal/agent/skills/... ./internal/application/service/...` (0 issues)
- The pre-commit hook also passed repository-wide diff-scoped lint (`golangci-lint run --new-from-rev=HEAD ./...`, before creating the commit).
- The pre-push hook passed repository-wide diff-scoped lint against `origin/main`, vet for all app packages, full tests for both changed packages, and `go build ./cmd/server`.

Coverage includes LF and CRLF files, metadata discovery, bundle version extraction, remote Markdown import, preservation of original file bytes and embedded U+FEFF characters, and rejection of missing frontmatter. Full-repository tests were not run; both changed packages passed their full test suites. Lint reported an existing unknown `nolint` name warning, and the server linker reported a duplicate `-lc++` warning; both checks passed.

## Checklist

- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes for the affected Go packages
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change

No UI, documentation, or breaking API changes.
