### PR TITLE
fix (chat): render mermaid syntax errors in UI instead of console log only

### DIFF
--- a/frontend/src/components/css/chat-markdown.less
+++ b/frontend/src/components/css/chat-markdown.less
@@ -325,6 +325,59 @@
     border-radius: 0;
   }
 
+  :deep(.chat-mermaid-block__canvas[data-mermaid="error"]),
+  :deep(pre.mermaid[data-mermaid="error"]) {
+    cursor: default;
+    text-align: left;
+    white-space: normal;
+  }
+
+  :deep(.chat-mermaid-block__error) {
+    font-family: var(--app-font-family);
+  }
+
+  // Mermaid parse errors are multi-line ("Parse error on line N:" + the
+  // offending source line + a caret marker); keep those breaks readable.
+  :deep(.chat-mermaid-block__error-message) {
+    margin: 0 0 8px;
+    color: var(--td-error-color);
+    font-size: 13px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+
+  :deep(.chat-mermaid-block__error-source) {
+    font-size: 12px;
+
+    summary {
+      cursor: pointer;
+      color: var(--td-text-color-secondary);
+
+      &:hover {
+        color: var(--td-text-color-primary);
+      }
+    }
+  }
+
+  // Specificity must match the generic `pre:not(...):not(...)` rule above so
+  // this later rule wins for the error source block.
+  :deep(.chat-mermaid-block__error-source pre.chat-mermaid-block__error-code) {
+    margin: 8px 0 0;
+    padding: 10px 12px;
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--td-bg-color-secondarycontainer) 88%, var(--td-bg-color-container));
+    overflow-x: auto;
+    white-space: pre;
+    font-size: 12px;
+    line-height: 1.5;
+
+    code {
+      background: transparent;
+      padding: 0;
+    }
+  }
+
   :deep(pre.mermaid:not(.chat-mermaid-block__canvas)) {
     margin: 0.75em 0;
     padding: 20px 16px;

--- a/frontend/src/directives/stableHtml.ts
+++ b/frontend/src/directives/stableHtml.ts
@@ -62,11 +62,35 @@ function mermaidCanvasHasSvg(el: Element): boolean {
   return !!el.querySelector('svg');
 }
 
+// Source a failed canvas was rendered from (kept in its collapsible block), or
+// null when the canvas is not in the error state.
+function mermaidCanvasErrorSource(el: Element): string | null {
+  if (el.getAttribute('data-mermaid') !== 'error') return null;
+  return (el.querySelector('.chat-mermaid-block__error-code code')?.textContent ?? '').trim();
+}
+
+function mermaidCanvasSource(el: Element): string {
+  return (el.querySelector('code')?.textContent ?? el.textContent ?? '').trim();
+}
+
 function morphMermaidCanvas(current: Element, next: Element): void {
   // Incoming HTML from marked still has mermaid source. Keep a diagram that
   // was already painted so typewriter / stream ticks cannot flash it back
   // into a fenced code block.
   if (mermaidCanvasHasSvg(current) && !mermaidCanvasHasSvg(next)) {
+    syncAttributes(current, next, new Set(['data-mermaid']));
+    return;
+  }
+  // Likewise keep a rendered error while the incoming source is unchanged;
+  // otherwise every update would reset it to source and re-run the parser.
+  // A changed source falls through so the new text gets a fresh attempt.
+  const erroredSource = mermaidCanvasErrorSource(current);
+  if (
+    erroredSource !== null
+    && !mermaidCanvasHasSvg(next)
+    && next.getAttribute('data-mermaid') === 'false'
+    && mermaidCanvasSource(next) === erroredSource
+  ) {
     syncAttributes(current, next, new Set(['data-mermaid']));
     return;
   }

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -6143,7 +6143,9 @@ export default {
     reset: 'Reset',
     download: 'Download Image',
     close: 'Close',
-    downloading: 'Downloading...'
+    downloading: 'Downloading...',
+    renderError: 'Diagram failed to render',
+    showSource: 'Show diagram source'
   },
   ollama: {
     unknown: 'Unknown',

--- a/frontend/src/i18n/locales/ja-JP.ts
+++ b/frontend/src/i18n/locales/ja-JP.ts
@@ -6143,7 +6143,9 @@ export default {
     reset: 'リセット',
     download: '画像をダウンロード',
     close: '閉じる',
-    downloading: 'ダウンロード中...'
+    downloading: 'ダウンロード中...',
+    renderError: '図のレンダリングに失敗しました',
+    showSource: '図のソースを表示'
   },
   ollama: {
     unknown: '不明',

--- a/frontend/src/i18n/locales/ko-KR.ts
+++ b/frontend/src/i18n/locales/ko-KR.ts
@@ -824,7 +824,9 @@ export default {
     reset: '초기화',
     download: '이미지 다운로드',
     close: '닫기',
-    downloading: '다운로드 중...'
+    downloading: '다운로드 중...',
+    renderError: '다이어그램을 렌더링하지 못했습니다',
+    showSource: '다이어그램 소스 보기'
   },
   faqManager: {
     import: {

--- a/frontend/src/i18n/locales/ru-RU.ts
+++ b/frontend/src/i18n/locales/ru-RU.ts
@@ -824,7 +824,9 @@ export default {
     reset: 'Сброс',
     download: 'Скачать изображение',
     close: 'Закрыть',
-    downloading: 'Загрузка...'
+    downloading: 'Загрузка...',
+    renderError: 'Не удалось отобразить диаграмму',
+    showSource: 'Показать исходный код диаграммы'
   },
   faqManager: {
     import: {

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -826,7 +826,9 @@ export default {
     reset: '重置',
     download: '下载图片',
     close: '关闭',
-    downloading: '下载中...'
+    downloading: '下载中...',
+    renderError: '图表渲染失败',
+    showSource: '查看图表源码'
   },
   faqManager: {
     import: {

--- a/frontend/src/utils/chatMessageShared.ts
+++ b/frontend/src/utils/chatMessageShared.ts
@@ -1,5 +1,9 @@
 import i18n from '@/i18n';
-import { buildMermaidBlockHtml, buildMermaidLoadingHtml } from '@/utils/markdownEnhancements';
+import {
+  buildMermaidBlockHtml,
+  buildMermaidLoadingHtml,
+  buildMermaidErrorFragment,
+} from '@/utils/markdownEnhancements';
 import {
   injectCachedMermaidSvg as injectCachedMermaidSvgHtml,
   maskMermaidBlocksForStreaming as maskMermaidBlocks,
@@ -63,7 +67,7 @@ export const injectCachedMermaidSvg = (
   html: string,
   cachedSvgHtml: CachedMermaidSvgHtml,
 ): string => {
-  return injectCachedMermaidSvgHtml(html, cachedSvgHtml, buildMermaidBlockHtml);
+  return injectCachedMermaidSvgHtml(html, cachedSvgHtml, buildMermaidBlockHtml, buildMermaidErrorFragment);
 };
 
 export const formatManualTitle = (question?: string): string => {

--- a/frontend/src/utils/markdownEnhancements.ts
+++ b/frontend/src/utils/markdownEnhancements.ts
@@ -127,6 +127,24 @@ export function buildMermaidLoadingHtml(): string {
   </div>`;
 }
 
+/**
+ * Inner-content replacement for a diagram that failed to render. Used both
+ * standalone (swapped directly into an existing `.chat-mermaid-block__canvas`
+ * element, keeping its header/badge/expand-button chrome) and wrapped via
+ * buildMermaidBlockHtml (for the streaming loading-skeleton-to-error swap).
+ */
+export function buildMermaidErrorFragment(rawCode: string, message: string): string {
+  const errorLabel = escapeHtml(i18n.global.t('mermaid.renderError'));
+  const showSourceLabel = escapeHtml(i18n.global.t('mermaid.showSource'));
+  return `<div class="chat-mermaid-block__error">
+    <p class="chat-mermaid-block__error-message">${errorLabel}: ${escapeHtml(message)}</p>
+    <details class="chat-mermaid-block__error-source">
+      <summary>${showSourceLabel}</summary>
+      <pre class="chat-mermaid-block__error-code"><code>${escapeHtml(rawCode)}</code></pre>
+    </details>
+  </div>`;
+}
+
 async function handleCodeCopy(btn: HTMLButtonElement): Promise<void> {
   const code = btn.closest('.chat-code-block')?.querySelector('code')?.textContent ?? '';
   if (!code) return;

--- a/frontend/src/utils/mermaidShared.ts
+++ b/frontend/src/utils/mermaidShared.ts
@@ -5,10 +5,12 @@ import { openMermaidFullscreen } from '@/utils/mermaidViewer.ts'
 import {
   buildCodeBlockHtml,
   buildMermaidBlockHtml,
+  buildMermaidErrorFragment,
   attachMarkdownEnhancementListeners,
   highlightCodeBlocksInContainer,
   syncMermaidExpandButtons,
 } from '@/utils/markdownEnhancements'
+import { encodeMermaidRenderError } from '@/utils/mermaidStreaming'
 
 hljs.registerAliases('mermaid', { languageName: 'plaintext' })
 
@@ -211,22 +213,57 @@ export const createMermaidCodeRenderer = (idPrefix: string) => {
   }
 }
 
-export const renderMermaidToSvg = async (code: string, id?: string): Promise<string | null> => {
-  if (!code.trim()) return null
+const MERMAID_ERROR_MESSAGE_MAX_LINES = 4
+const MERMAID_ERROR_MESSAGE_MAX_CHARS = 300
+
+function mermaidErrorMessage(e: unknown): string {
+  const raw = e instanceof Error ? e.message : String(e)
+  // UnknownDiagramError repeats the entire diagram after "for text:"; the
+  // source is already available in the collapsible block under the message.
+  const withoutSource = raw.replace(/\s*for text:[\s\S]*$/, '').trim()
+  const lines = withoutSource.split('\n').slice(0, MERMAID_ERROR_MESSAGE_MAX_LINES).join('\n')
+  return lines.length > MERMAID_ERROR_MESSAGE_MAX_CHARS
+    ? `${lines.slice(0, MERMAID_ERROR_MESSAGE_MAX_CHARS)}…`
+    : lines
+}
+
+type MermaidRenderResult = { svg: string } | { error: string }
+
+// Shared by renderMermaidToSvg (existing string|null contract, kept for
+// document-preview.vue and any other simple caller) and the chat render
+// paths, which also need the caught message to show the user something
+// more useful than a silently-dropped diagram.
+//
+// Returns null only when mermaid itself could not be loaded/initialised —
+// that is not a diagram problem, so callers leave the slot unresolved and a
+// later pass retries. An {error} is always a genuine parse/render failure.
+async function renderMermaidDiagnostic(code: string, id?: string): Promise<MermaidRenderResult | null> {
+  let mermaid: Awaited<ReturnType<typeof getMermaid>>
   try {
-    const mermaid = await getMermaid()
+    mermaid = await getMermaid()
     ensureMermaidInitialized()
     await initPromise
+  } catch (e) {
+    console.error('Mermaid load error:', e)
+    return null
+  }
+  try {
     await mermaid.parse(code)
     // Mermaid reuses the render id as the SVG root id. Always mint a fresh
     // one so a later render cannot collide with an SVG already in the DOM.
     const renderId = `${id || 'mermaid'}-${++mermaidCount}`
     const { svg } = await mermaid.render(renderId, code)
-    return svg
+    return { svg }
   } catch (e) {
     console.error('Mermaid rendering error:', e)
-    return null
+    return { error: mermaidErrorMessage(e) }
   }
+}
+
+export const renderMermaidToSvg = async (code: string, id?: string): Promise<string | null> => {
+  if (!code.trim()) return null
+  const result = await renderMermaidDiagnostic(code, id)
+  return result && 'svg' in result ? result.svg : null
 }
 
 function mermaidSourceFromElement(el: HTMLElement): string {
@@ -242,8 +279,15 @@ export async function appendMermaidSvgCache(
   const next = cache.slice()
   while (next.length < codes.length) {
     const i = next.length
-    const svg = await renderMermaidToSvg(codes[i], `${idPrefix}-${i}`)
-    next.push(svg || '')
+    const result = await renderMermaidDiagnostic(codes[i], `${idPrefix}-${i}`)
+    if (!result) {
+      // Mermaid unavailable: leave the slot unresolved so it is retried.
+      next.push('')
+    } else if ('svg' in result) {
+      next.push(result.svg)
+    } else {
+      next.push(encodeMermaidRenderError(codes[i], result.error))
+    }
   }
   return next
 }
@@ -261,12 +305,13 @@ export const renderMermaidInContainer = async (
     'pre[data-mermaid="false"], .chat-mermaid-block__canvas[data-mermaid="false"]',
   )
   for (const el of mermaidElements) {
+    let code = ''
     try {
       if (el.querySelector('svg')) {
         el.setAttribute('data-mermaid', 'true')
         continue
       }
-      const code = mermaidSourceFromElement(el)
+      code = mermaidSourceFromElement(el)
       if (!code) continue
       await mermaid.parse(code)
       const renderId = `mermaid-render-${++mermaidCount}`
@@ -276,6 +321,8 @@ export const renderMermaidInContainer = async (
       el.setAttribute('data-mermaid', 'true')
     } catch (e) {
       console.error('Mermaid rendering error:', e)
+      el.innerHTML = buildMermaidErrorFragment(code, mermaidErrorMessage(e))
+      el.setAttribute('data-mermaid', 'error')
       continue
     }
   }

--- a/frontend/src/utils/mermaidStreaming.test.ts
+++ b/frontend/src/utils/mermaidStreaming.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  encodeMermaidRenderError,
   extractMermaidCodes,
   injectCachedMermaidSvg,
   maskMermaidBlocksForStreaming,
@@ -18,6 +19,10 @@ function buildBlock(innerHtml: string, preAttrs = ''): string {
   return `<div class="chat-mermaid-block">
     <pre class="chat-mermaid-block__canvas mermaid"${attrs}>${innerHtml}</pre>
   </div>`
+}
+
+function buildErrorFragment(code: string, message: string): string {
+  return `<div class="chat-mermaid-block__error">${message}::${code}</div>`
 }
 
 const TWO_DIAGRAMS = `Intro
@@ -65,6 +70,7 @@ test('injectCachedMermaidSvg maps cached SVGs onto loading placeholders 1:1', ()
     html,
     ['<svg id="first"></svg>', '<svg id="second"></svg>'],
     buildBlock,
+    buildErrorFragment,
   )
   assert.match(injected, /data-mermaid="cached"[^>]*>\s*<svg id="first">/)
   assert.match(injected, /data-mermaid="cached"[^>]*>\s*<svg id="second">/)
@@ -87,6 +93,7 @@ test('injectCachedMermaidSvg does not swallow a cached diagram when a later skel
     html,
     ['<svg id="first"></svg>', '<svg id="second"></svg>'],
     buildBlock,
+    buildErrorFragment,
   )
   assert.match(injected, /<svg id="kept">/)
   assert.match(injected, /between/)
@@ -103,10 +110,59 @@ test('injectCachedMermaidSvg fills unrendered mermaid canvases after the stream 
     html,
     ['<svg id="first"></svg>', '<svg id="second"></svg>'],
     buildBlock,
+    buildErrorFragment,
   )
   assert.match(injected, /id="m-1" data-mermaid="cached"><svg id="first">/)
   assert.match(injected, /id="m-2" data-mermaid="cached"><svg id="second">/)
   assert.equal(injected.includes('graph TD'), false)
+})
+
+test('extractMermaidCodes keeps blank fences so slots stay aligned with placeholders', () => {
+  const content = 'A\n\n```mermaid\n```\n\nB\n\n```mermaid\ngraph TD\n    A --> B\n```\n'
+  assert.deepEqual(extractMermaidCodes(content), ['', 'graph TD\n    A --> B'])
+  assert.equal([...maskMermaidBlocksForStreaming(content, LOADING).matchAll(/chat-mermaid-block--loading/g)].length, 2)
+})
+
+test('injectCachedMermaidSvg replaces a stuck loading skeleton with a visible error once a diagram permanently fails', () => {
+  const html = `
+    <p>Intro</p>
+    ${LOADING}
+    <p>Done.</p>
+  `
+  const injected = injectCachedMermaidSvg(
+    html,
+    [encodeMermaidRenderError('graph TD\n  A(broken', 'Lexical error on line 2.')],
+    buildBlock,
+    buildErrorFragment,
+  )
+  assert.equal(injected.includes('streaming-mermaid-loading'), false)
+  assert.match(injected, /data-mermaid="error"/)
+  assert.match(injected, /Lexical error on line 2\./)
+  assert.match(injected, /graph TD/)
+  assert.match(injected, /Intro/)
+  assert.match(injected, /Done\./)
+})
+
+test('injectCachedMermaidSvg leaves an unresolved (empty) slot as the loading skeleton', () => {
+  const html = `${LOADING}\n${LOADING}`
+  const injected = injectCachedMermaidSvg(html, ['<svg id="first"></svg>', ''], buildBlock, buildErrorFragment)
+  assert.match(injected, /<svg id="first">/)
+  assert.equal([...injected.matchAll(/chat-mermaid-block--loading/g)].length, 1)
+})
+
+test('injectCachedMermaidSvg marks an unrendered canvas as an error after the stream completes', () => {
+  const html = `
+    <pre class="chat-mermaid-block__canvas mermaid" id="m-1" data-mermaid="false"><code>graph TD</code></pre>
+  `
+  const injected = injectCachedMermaidSvg(
+    html,
+    [encodeMermaidRenderError('graph TD', 'Lexical error on line 1.')],
+    buildBlock,
+    buildErrorFragment,
+  )
+  assert.match(injected, /id="m-1" data-mermaid="error"/)
+  assert.match(injected, /Lexical error on line 1\./)
+  assert.equal(injected.includes('<code>graph TD</code>'), false)
 })
 
 test('prepareStreamingMermaidMarkdown masks a trailing incomplete mermaid fence', () => {

--- a/frontend/src/utils/mermaidStreaming.ts
+++ b/frontend/src/utils/mermaidStreaming.ts
@@ -1,5 +1,31 @@
 export type CachedMermaidSvgHtml = string | readonly (string | null | undefined)[] | null | undefined;
 
+// A cache slot holds a rendered SVG string, '' while unresolved (mermaid not
+// loaded yet), or — encoded via this marker — a permanent render failure. A
+// fence is only cached once it is complete and mermaid itself has loaded, so
+// an encoded failure is a genuine parse/render error, not "still streaming".
+// The marker is a control character that never appears in real SVG markup,
+// so a slot's meaning is recoverable without widening CachedMermaidSvgHtml
+// (still a plain string) through every caller of appendMermaidSvgCache.
+const MERMAID_ERROR_MARKER = '\u0000mermaid-error\u0000';
+
+export function encodeMermaidRenderError(code: string, message: string): string {
+  return MERMAID_ERROR_MARKER + JSON.stringify({ code, message });
+}
+
+function decodeMermaidRenderError(value: string | null | undefined): { code: string; message: string } | null {
+  if (typeof value !== 'string' || !value.startsWith(MERMAID_ERROR_MARKER)) return null;
+  try {
+    const parsed = JSON.parse(value.slice(MERMAID_ERROR_MARKER.length));
+    if (parsed && typeof parsed.code === 'string' && typeof parsed.message === 'string') {
+      return parsed;
+    }
+  } catch {
+    // Malformed marker payload — treat as no diagnostic available.
+  }
+  return null;
+}
+
 const MERMAID_FENCE_START = '```mermaid';
 const COMPLETE_MERMAID_FENCE_RE = /```mermaid[\s\S]*?```/;
 
@@ -48,8 +74,10 @@ export const extractMermaidCodes = (content: string): string[] => {
   const re = /```mermaid([\s\S]*?)```/g;
   let match: RegExpExecArray | null;
   while ((match = re.exec(content)) !== null) {
-    const code = match[1].trim();
-    if (code) codes.push(code);
+    // Keep blank fences: maskMermaidBlocksForStreaming emits one placeholder
+    // per fence, and injectCachedMermaidSvg pairs them by position, so
+    // dropping a fence here would shift every later diagram by one slot.
+    codes.push(match[1].trim());
   }
   return codes;
 };
@@ -75,19 +103,31 @@ const MERMAID_UNRENDERED_CANVAS_RE =
 
 function replaceUnrenderedCanvas(
   match: string,
-  svg: string,
+  innerHtml: string,
+  dataMermaidValue: string = 'cached',
 ): string {
   const openEnd = match.indexOf('>');
   if (openEnd < 0) return match;
-  const openTag = match.slice(0, openEnd + 1).replace(/data-mermaid="false"/, 'data-mermaid="cached"');
-  return `${openTag}${svg}</pre>`;
+  const openTag = match
+    .slice(0, openEnd + 1)
+    .replace(/data-mermaid="false"/, `data-mermaid="${dataMermaidValue}"`);
+  return `${openTag}${innerHtml}</pre>`;
 }
 
-/** Inject trusted Mermaid SVG after DOMPurify, 1:1 with complete mermaid fences. */
+/**
+ * Inject trusted Mermaid SVG after DOMPurify, 1:1 with complete mermaid fences.
+ *
+ * A cache slot may also hold an encoded render failure (see
+ * encodeMermaidRenderError) — a mermaid fence is only ever cached once it is
+ * complete, so a failure here is a genuine syntax error, not "still
+ * streaming"; that slot renders as a visible error (via buildErrorFragment)
+ * instead of leaving the loading skeleton stuck forever.
+ */
 export const injectCachedMermaidSvg = (
   html: string,
   cachedSvgHtml: CachedMermaidSvgHtml,
   buildBlock: (innerHtml: string, preAttrs?: string) => string,
+  buildErrorFragment: (code: string, message: string) => string,
 ): string => {
   if (!html) return html;
   const svgs = normalizeCachedMermaidSvgs(cachedSvgHtml);
@@ -96,11 +136,15 @@ export const injectCachedMermaidSvg = (
   const index = { i: 0 };
   const withLoading = html.replace(STREAMING_MERMAID_LOADING_RE, (match) => {
     const svg = svgs[index.i++];
+    const err = decodeMermaidRenderError(svg);
+    if (err) return buildBlock(buildErrorFragment(err.code, err.message), 'data-mermaid="error"');
     return svg ? buildBlock(svg, 'data-mermaid="cached"') : match;
   });
   if (index.i >= svgs.length) return withLoading;
   return withLoading.replace(MERMAID_UNRENDERED_CANVAS_RE, (match) => {
     const svg = svgs[index.i++];
+    const err = decodeMermaidRenderError(svg);
+    if (err) return replaceUnrenderedCanvas(match, buildErrorFragment(err.code, err.message), 'error');
     return svg ? replaceUnrenderedCanvas(match, svg) : match;
   });
 };

--- a/frontend/src/views/chat/components/botmsg.vue
+++ b/frontend/src/views/chat/components/botmsg.vue
@@ -418,7 +418,9 @@ onUpdated(() => {
         await hydrateProtectedFileImages(parentMd.value);
         await hydrateArtifactImages(parentMd.value, artifactRefContext.value);
         refreshMarkdownEnhancements(parentMd.value);
-        if (props.session?.is_completed) {
+        // Wait for the typewriter to catch up, not just the backend completion
+        // event: a fence that is still being typed out is not yet a diagram.
+        if (answerFullyRendered.value) {
             await renderMermaidInContainer(parentMd.value);
         }
     });

--- a/frontend/src/views/embed/EmbedBotMessage.vue
+++ b/frontend/src/views/embed/EmbedBotMessage.vue
@@ -155,6 +155,12 @@ const { displayed: typedAnswer } = useTypewriter(
   () => Boolean(props.session?.is_completed),
 )
 
+// The backend completion event can arrive while the typewriter still has
+// buffered text; a fence that is still being typed out is not yet a diagram.
+const answerFullyRendered = computed(() =>
+  Boolean(props.session?.is_completed) && typedAnswer.value.length >= answerText.value.length,
+)
+
 const renderedHTML = computed(() => {
   const text = typedAnswer.value
   if (!text.trim()) return ''
@@ -187,7 +193,7 @@ watch(renderedHTML, () => {
   nextTick(async () => {
     rebindCitations()
     await hydrateImages()
-    if (props.session?.is_completed) {
+    if (answerFullyRendered.value) {
       await renderMermaidDiagrams()
     }
   })
@@ -196,7 +202,7 @@ watch(renderedHTML, () => {
 onUpdated(() => {
   nextTick(async () => {
     await hydrateImages()
-    if (props.session?.is_completed) {
+    if (answerFullyRendered.value) {
       await renderMermaidDiagrams()
     }
   })


### PR DESCRIPTION
<!-- Title should follow Conventional Commits, e.g. `feat: ...`, `fix: ...`, `docs: ...` -->

## Description
Previously, when a Mermaid diagram failed to parse or render (e.g. syntax errors, malformed graph definitions, unknown diagram types), the error was logged only to the browser console (`console.error`). In the UI, this left the diagram as raw unrendered code, an empty container, or an indefinitely spinning loading skeleton during streaming, with no feedback to the user explaining why the diagram failed.
This PR introduces visible inline error handling for failed Mermaid diagrams:
- **UI Error Presentation**: Added `buildMermaidErrorFragment()` to render a clean, localized error message (`Diagram failed to render: <reason>`) with an expandable `<details>` section displaying the diagram's source code.
- **Diagnostic Error Handling**: Updated `mermaidShared.ts` to capture parse/render diagnostics, truncating verbose multi-line error traces and stripping redundant diagram source repeats.
- **Streaming Pipeline Support**: Added `encodeMermaidRenderError()` / `decodeMermaidRenderError()` to `mermaidStreaming.ts` so cached SVG injection swaps permanently failed diagrams out of the loading skeleton into the error UI.
- **DOM Stability**: Updated `v-stable-html` (`stableHtml.ts`) to retain the rendered error canvas across typewriter/streaming DOM morphs unless the source code itself changes.
- **Typewriter Synchronization**: Adjusted `botmsg.vue` and `EmbedBotMessage.vue` to wait until `answerFullyRendered` before invoking container-level rendering, preventing incomplete/streaming fences from triggering premature parse errors.
- **i18n Support**: Added localized strings (`mermaid.renderError`, `mermaid.showSource`) across all supported locales (`en-US`, `zh-CN`, `ko-KR`, `ru-RU`).
- **Test Coverage**: Added unit tests in `mermaidStreaming.test.ts` covering blank fences, error encoding, placeholder error swaps, and unrendered canvas conversions.
## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI
## Related Issue
Fixes #


## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [ ] Breaking changes are clearly called out in the description above

## Screenshots / Recordings
<!-- Required for user-visible UI changes -->
<img width="978" height="279" alt="Screenshot 2026-09-09 at 16 46 00" src="https://github.com/user-attachments/assets/99732a2d-6d06-49fa-8b9d-27e0b5adbf7a" />
<img width="989" height="243" alt="Screenshot 2026-09-09 at 16 45 36" src="https://github.com/user-attachments/assets/2febe3c6-1184-4447-abf0-c4a35f6eb3ab" />
