### PR TITLE
fix(chat): prevent pending steer messages from jittering during streaming

### DIFF
--- a/frontend/src/composables/useEmbedChatSession.ts
+++ b/frontend/src/composables/useEmbedChatSession.ts
@@ -95,7 +95,7 @@ export function useEmbedChatSession(options: {
     scrollToBottom(true)
   }
 
-  useStickyBottomOnResize(scrollContainer, userHasScrolledUp, scrollToBottom)
+  useStickyBottomOnResize(scrollContainer, userHasScrolledUp)
 
   const debounce = <T extends (...args: never[]) => void>(fn: T, delay: number) => {
     let timer: ReturnType<typeof setTimeout>

--- a/frontend/src/composables/useStickyBottomOnResize.test.ts
+++ b/frontend/src/composables/useStickyBottomOnResize.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createRenderer, ref, shallowRef } from 'vue'
+import { useStickyBottomOnResize } from './useStickyBottomOnResize.ts'
+
+function mountChat() {
+  const renderer = createRenderer<any, any>({
+    patchProp() {}, insert() {}, remove() {}, setText() {}, setElementText() {},
+    createElement: () => ({}), createText: () => ({}), createComment: () => ({}),
+    parentNode: () => null, nextSibling: () => null,
+  })
+  const messageList = {} as HTMLElement
+  let top = 400
+  const element = {
+    firstElementChild: messageList,
+    scrollHeight: 1000,
+    clientHeight: 600,
+    get scrollTop() { return top },
+    set scrollTop(value: number) {
+      top = Math.max(0, Math.min(value, this.scrollHeight - this.clientHeight))
+    },
+  }
+  const container = shallowRef(element as unknown as HTMLElement | null)
+  const detached = ref(false)
+  const app = renderer.createApp({
+    setup() {
+      useStickyBottomOnResize(container, detached)
+      return () => null
+    },
+  })
+  app.mount({})
+  return { app, element, container, detached, messageList }
+}
+
+test('keeps a trailing steer bubble at the live edge before each streaming frame paints', () => {
+  const originalObserver = globalThis.ResizeObserver
+  const originalRequest = globalThis.requestAnimationFrame
+  const originalCancel = globalThis.cancelAnimationFrame
+  let onResize!: ResizeObserverCallback
+  let observed: Element | undefined
+  let disconnected = false
+  let deferredFrames = 0
+  globalThis.ResizeObserver = class {
+    constructor(callback: ResizeObserverCallback) { onResize = callback }
+    observe(target: Element) { observed = target }
+    unobserve() {}
+    disconnect() { disconnected = true }
+  } as typeof ResizeObserver
+  globalThis.requestAnimationFrame = () => ++deferredFrames
+  globalThis.cancelAnimationFrame = () => {}
+  const chat = mountChat()
+  const resize = () => onResize([], {} as ResizeObserver)
+  try {
+    assert.equal(observed, chat.messageList)
+    // ResizeObserver runs after layout and before paint. An rAF requested here
+    // runs in the NEXT frame, exposing the pushed-down bubble in this frame.
+    for (let frame = 0; frame < 120; frame++) {
+      chat.element.scrollHeight += frame % 5 === 4 ? -12 : 24
+      resize()
+      const bubbleBottom = chat.element.scrollHeight - chat.element.scrollTop
+      assert.equal(bubbleBottom, chat.element.clientHeight,
+        `steer bubble must stay at the viewport bottom in frame ${frame}`)
+    }
+    assert.equal(deferredFrames, 0, 'resize follow must finish before the current paint')
+
+    chat.detached.value = true
+    chat.element.scrollTop -= 200
+    const readingPosition = chat.element.scrollTop
+    chat.element.scrollHeight += 100
+    resize()
+    assert.equal(chat.element.scrollTop, readingPosition, 'preserve intentional upward scrolling')
+
+    chat.detached.value = false
+    resize()
+    assert.equal(chat.element.scrollHeight - chat.element.scrollTop, chat.element.clientHeight)
+    chat.container.value = null
+    assert.doesNotThrow(resize)
+  } finally {
+    chat.app.unmount()
+    globalThis.ResizeObserver = originalObserver
+    globalThis.requestAnimationFrame = originalRequest
+    globalThis.cancelAnimationFrame = originalCancel
+  }
+  assert.equal(disconnected, true)
+})

--- a/frontend/src/composables/useStickyBottomOnResize.ts
+++ b/frontend/src/composables/useStickyBottomOnResize.ts
@@ -11,34 +11,31 @@ import { onMounted, onUnmounted, type Ref } from 'vue'
 export function useStickyBottomOnResize(
   scrollContainer: Ref<HTMLElement | null>,
   userHasScrolledUp: Ref<boolean>,
-  scrollToBottom: () => void,
 ): void {
   let resizeObserver: ResizeObserver | null = null
-  let scrollFrame: number | null = null
 
-  const scheduleFollow = () => {
-    if (userHasScrolledUp.value || scrollFrame !== null) return
+  const followResize = () => {
+    if (userHasScrolledUp.value) return
+    const container = scrollContainer.value
+    if (!container) return
 
-    scrollFrame = requestAnimationFrame(() => {
-      scrollFrame = null
-      if (!userHasScrolledUp.value) scrollToBottom()
-    })
+    // ResizeObserver runs after layout, before paint. Deferring to rAF here
+    // paints one frame with a trailing steer bubble displaced by the growing
+    // answer, then snaps it back on the next frame. Correct the scroll offset
+    // now; changing scrollTop does not resize the observed message list.
+    container.scrollTop = container.scrollHeight
   }
 
   onMounted(() => {
     const messageList = scrollContainer.value?.firstElementChild
     if (!messageList || typeof ResizeObserver === 'undefined') return
 
-    resizeObserver = new ResizeObserver(scheduleFollow)
+    resizeObserver = new ResizeObserver(followResize)
     resizeObserver.observe(messageList)
   })
 
   onUnmounted(() => {
     resizeObserver?.disconnect()
     resizeObserver = null
-    if (scrollFrame !== null) {
-      cancelAnimationFrame(scrollFrame)
-      scrollFrame = null
-    }
   })
 }

--- a/frontend/src/views/chat/index.vue
+++ b/frontend/src/views/chat/index.vue
@@ -586,7 +586,7 @@ const onClickScrollToBottom = () => {
 // Images and other rich Markdown content can grow after the SSE chunk that
 // introduced them. Follow those delayed height changes while the user remains
 // at the live edge; preserve position when they intentionally scroll upward.
-useStickyBottomOnResize(scrollContainer, userHasScrolledUp, scrollToBottom);
+useStickyBottomOnResize(scrollContainer, userHasScrolledUp);
 
 const debounce = (fn, delay) => {
     let timer


### PR DESCRIPTION
Pending injected steer messages could visibly jump while the preceding answer streamed. The message-list ResizeObserver deferred bottom following to the next animation frame, allowing the displaced bubble to paint before the scroll correction.

Update the scroll offset directly in the resize callback, before the current frame paints. Both the main chat and embedded chat use the updated composable, and intentional upward scrolling still pauses automatic following.

Validation:
- Added a regression test covering 120 frames of height changes, upward-scroll preservation, resuming bottom following, and observer cleanup. The previous implementation failed the position assertion.
- All 51 focused streaming, steering, typewriter, and resize-follow tests passed.
- The pre-push frontend test suite passed all 277 tests.
- `npm run type-check` passed.
- `npm run build` passed with a chunk-size warning.
- `git diff --check` passed.

Browser visual verification has not been performed.
