### PR TITLE
refactor(ranking): unify the duplicated compositeScore/applyMMR core into searchutil

### DIFF
--- a/internal/agent/tools/knowledge_search.go
+++ b/internal/agent/tools/knowledge_search.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"sort"
 	"strings"
 	"sync"
@@ -1206,46 +1205,23 @@ func (t *KnowledgeSearchTool) getEnrichedPassage(ctx context.Context, result *ty
 	return combinedText
 }
 
-// compositeScore calculates a composite score considering multiple factors
+// compositeScore calculates a composite score considering multiple factors.
+// The weighted combination and the source weighting live in
+// searchutil.CompositeRawScore; this tool additionally applies the agent-only
+// position prior (see searchutil.PositionPrior) and clamps the product.
 func (t *KnowledgeSearchTool) compositeScore(
 	result *searchResultWithMeta,
 	modelScore, baseScore float64,
 ) float64 {
-	// Source weight: web_search results get slightly lower weight
-	sourceWeight := 1.0
-	if strings.ToLower(result.KnowledgeSource) == "web_search" {
-		sourceWeight = 0.95
-	}
-
-	// Position prior: slightly favor chunks earlier in the document
-	positionPrior := 1.0
-	if result.StartAt >= 0 && result.EndAt > result.StartAt {
-		// Calculate position ratio and apply small boost for earlier positions
-		positionRatio := 1.0 - float64(result.StartAt)/float64(result.EndAt+1)
-		positionPrior += t.clampFloat(positionRatio, -0.05, 0.05)
-	}
-
-	// Composite formula: weighted combination of model score, base score, and source weight
-	composite := 0.6*modelScore + 0.3*baseScore + 0.1*sourceWeight
-	composite *= positionPrior
-
-	// Clamp to [0, 1]
-	if composite < 0 {
-		composite = 0
-	}
-	if composite > 1 {
-		composite = 1
-	}
-
-	return composite
+	composite := searchutil.CompositeRawScore(result.KnowledgeSource, modelScore, baseScore)
+	composite *= searchutil.PositionPrior(result.StartAt, result.EndAt)
+	return searchutil.ClampFloat(composite, 0, 1)
 }
 
-// clampFloat clamps a float value to the specified range
-func (t *KnowledgeSearchTool) clampFloat(v, minV, maxV float64) float64 {
-	return searchutil.ClampFloat(v, minV, maxV)
-}
-
-// applyMMR applies Maximal Marginal Relevance algorithm to reduce redundancy
+// applyMMR applies Maximal Marginal Relevance algorithm to reduce redundancy.
+// Scoring and selection live in searchutil.ApplyMMR; this wrapper keeps the
+// tool-specific concerns: sequential tokenization of enriched passages and the
+// tool's logger output.
 func (t *KnowledgeSearchTool) applyMMR(
 	ctx context.Context,
 	results []*searchResultWithMeta,
@@ -1259,76 +1235,24 @@ func (t *KnowledgeSearchTool) applyMMR(
 	logger.Infof(ctx, "[Tool][KnowledgeSearch] Applying MMR: lambda=%.2f, k=%d, candidates=%d",
 		lambda, k, len(results))
 
-	selected := make([]*searchResultWithMeta, 0, k)
-	candidates := make([]*searchResultWithMeta, len(results))
-	copy(candidates, results)
-
 	// Pre-compute token sets for all candidates
-	tokenSets := make([]map[string]struct{}, len(candidates))
-	for i, r := range candidates {
-		tokenSets[i] = t.tokenizeSimple(t.getEnrichedPassage(ctx, r.SearchResult))
+	tokenSets := make([]map[string]struct{}, len(results))
+	for i, r := range results {
+		tokenSets[i] = searchutil.TokenizeSimple(t.getEnrichedPassage(ctx, r.SearchResult))
 	}
 
-	// MMR selection loop, incremental form: maxRedundancy[i] caches candidate i's
-	// maximum jaccard against everything selected so far, so each round only needs
-	// one comparison per remaining candidate instead of one per (candidate, selected)
-	// pair. Selection output is identical to the naive form, including tie-breaking,
-	// because the candidate iteration order is unchanged.
-	selectedTokenSets := make([]map[string]struct{}, 0, k)
-	maxRedundancy := make([]float64, len(candidates))
-	for len(selected) < k && len(candidates) > 0 {
-		bestIdx := 0
-		bestScore := -1.0
-
-		for i, r := range candidates {
-			// MMR score: balance relevance and diversity
-			mmr := lambda*r.Score - (1.0-lambda)*maxRedundancy[i]
-			if mmr > bestScore {
-				bestScore = mmr
-				bestIdx = i
-			}
-		}
-
-		// Add best candidate to selected and remove from candidates
-		selected = append(selected, candidates[bestIdx])
-		chosenTokens := tokenSets[bestIdx]
-		selectedTokenSets = append(selectedTokenSets, chosenTokens)
-		candidates = append(candidates[:bestIdx], candidates[bestIdx+1:]...)
-		// Remove corresponding token set and cached redundancy
-		tokenSets = append(tokenSets[:bestIdx], tokenSets[bestIdx+1:]...)
-		maxRedundancy = append(maxRedundancy[:bestIdx], maxRedundancy[bestIdx+1:]...)
-
-		// Fold the freshly selected result into every remaining candidate's cache
-		for i := range candidates {
-			maxRedundancy[i] = math.Max(maxRedundancy[i], t.jaccard(tokenSets[i], chosenTokens))
-		}
-	}
-
-	// Compute average redundancy among selected results, reusing the cached token
-	// sets instead of re-tokenizing every pair
-	avgRed := 0.0
-	if len(selectedTokenSets) > 1 {
-		pairs := 0
-		for i := 0; i < len(selectedTokenSets); i++ {
-			for j := i + 1; j < len(selectedTokenSets); j++ {
-				avgRed += t.jaccard(selectedTokenSets[i], selectedTokenSets[j])
-				pairs++
-			}
-		}
-		if pairs > 0 {
-			avgRed /= float64(pairs)
-		}
-	}
+	selected, avgRed := searchutil.ApplyMMR(
+		results,
+		func(r *searchResultWithMeta) float64 { return r.Score },
+		tokenSets,
+		k,
+		lambda,
+	)
 
 	logger.Infof(ctx, "[Tool][KnowledgeSearch] MMR completed: selected=%d, avg_redundancy=%.4f",
 		len(selected), avgRed)
 
 	return selected
-}
-
-// tokenizeSimple tokenizes text into a set of words (simple whitespace-based)
-func (t *KnowledgeSearchTool) tokenizeSimple(text string) map[string]struct{} {
-	return searchutil.TokenizeSimple(text)
 }
 
 // extractSnippetForQueries tries to produce a short contextual snippet around
@@ -1387,9 +1311,4 @@ func extractSnippetForQueries(content string, queries []string) string {
 		snippet = strings.ReplaceAll(snippet, "  ", " ")
 	}
 	return "... " + strings.TrimSpace(snippet) + " ..."
-}
-
-// jaccard calculates Jaccard similarity between two token sets
-func (t *KnowledgeSearchTool) jaccard(a, b map[string]struct{}) float64 {
-	return searchutil.Jaccard(a, b)
 }

--- a/internal/agent/tools/knowledge_search_mmr_test.go
+++ b/internal/agent/tools/knowledge_search_mmr_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/Tencent/WeKnora/internal/searchutil"
 	"github.com/Tencent/WeKnora/internal/types"
 )
 
@@ -29,7 +30,7 @@ func (t *KnowledgeSearchTool) applyMMRNaive(
 
 	tokenSets := make([]map[string]struct{}, len(candidates))
 	for i, r := range candidates {
-		tokenSets[i] = t.tokenizeSimple(t.getEnrichedPassage(ctx, r.SearchResult))
+		tokenSets[i] = searchutil.TokenizeSimple(t.getEnrichedPassage(ctx, r.SearchResult))
 	}
 
 	for len(selected) < k && len(candidates) > 0 {
@@ -40,8 +41,8 @@ func (t *KnowledgeSearchTool) applyMMRNaive(
 			relevance := r.Score
 			redundancy := 0.0
 			for _, s := range selected {
-				selectedTokens := t.tokenizeSimple(t.getEnrichedPassage(ctx, s.SearchResult))
-				redundancy = math.Max(redundancy, t.jaccard(tokenSets[i], selectedTokens))
+				selectedTokens := searchutil.TokenizeSimple(t.getEnrichedPassage(ctx, s.SearchResult))
+				redundancy = math.Max(redundancy, searchutil.Jaccard(tokenSets[i], selectedTokens))
 			}
 			mmr := lambda*relevance - (1.0-lambda)*redundancy
 			if mmr > bestScore {

--- a/internal/application/service/chat_pipeline/rerank.go
+++ b/internal/application/service/chat_pipeline/rerank.go
@@ -200,7 +200,7 @@ func (p *PluginRerank) OnEvent(ctx context.Context,
 		sr.Metadata["base_score"] = fmt.Sprintf("%.4f", base)
 		modelScore := rr.RelevanceScore
 		sr.Metadata["model_score"] = fmt.Sprintf("%.4f", modelScore)
-		sr.Score = compositeScore(sr, modelScore, base)
+		sr.Score = searchutil.CompositeScore(sr.KnowledgeSource, modelScore, base)
 
 		// Apply FAQ score boost if enabled
 		if chatManage.FAQPriorityEnabled && chatManage.FAQScoreBoost > 1.0 &&
@@ -220,7 +220,7 @@ func (p *PluginRerank) OnEvent(ctx context.Context,
 		reranked = append(reranked, sr)
 	}
 
-	final := applyMMR(ctx, reranked, chatManage, min(len(reranked), max(1, chatManage.RerankTopK)), 0.7)
+	final := applyMMR(ctx, reranked, min(len(reranked), max(1, chatManage.RerankTopK)), 0.7)
 	chatManage.RerankResult = final
 
 	// Log composite top scores and MMR selection summary
@@ -454,11 +454,13 @@ func compositeScore(sr *types.SearchResult, modelScore, baseScore float64) float
 	return composite
 }
 
-// applyMMR applies the MMR algorithm to the search results with pre-computed token sets
+// applyMMR applies the MMR algorithm to the search results with pre-computed
+// token sets. Scoring and selection live in searchutil.ApplyMMR; this wrapper
+// keeps the pipeline-specific concerns: parallel tokenization of enriched
+// passages and the mmr_start/mmr_done pipeline events.
 func applyMMR(
 	ctx context.Context,
 	results []*types.SearchResult,
-	chatManage *types.ChatManage,
 	k int,
 	lambda float64,
 ) []*types.SearchResult {
@@ -476,60 +478,13 @@ func applyMMR(
 		return searchutil.TokenizeSimple(getEnrichedPassage(ctx, r))
 	})
 
-	selected := make([]*types.SearchResult, 0, k)
-	selectedTokenSets := make([]map[string]struct{}, 0, k)
-	selectedIndices := make(map[int]struct{})
-
-	for len(selected) < k && len(selectedIndices) < len(results) {
-		bestIdx := -1
-		bestScore := -1.0
-
-		for i, r := range results {
-			if _, isSelected := selectedIndices[i]; isSelected {
-				continue
-			}
-
-			relevance := r.Score
-			redundancy := 0.0
-
-			// Use pre-computed token sets for redundancy calculation
-			for _, selTokens := range selectedTokenSets {
-				sim := searchutil.Jaccard(allTokenSets[i], selTokens)
-				if sim > redundancy {
-					redundancy = sim
-				}
-			}
-
-			mmr := lambda*relevance - (1.0-lambda)*redundancy
-			if mmr > bestScore {
-				bestScore = mmr
-				bestIdx = i
-			}
-		}
-
-		if bestIdx < 0 {
-			break
-		}
-
-		selected = append(selected, results[bestIdx])
-		selectedTokenSets = append(selectedTokenSets, allTokenSets[bestIdx])
-		selectedIndices[bestIdx] = struct{}{}
-	}
-
-	// Compute average redundancy among selected using pre-computed token sets
-	avgRed := 0.0
-	if len(selected) > 1 {
-		pairs := 0
-		for i := 0; i < len(selectedTokenSets); i++ {
-			for j := i + 1; j < len(selectedTokenSets); j++ {
-				avgRed += searchutil.Jaccard(selectedTokenSets[i], selectedTokenSets[j])
-				pairs++
-			}
-		}
-		if pairs > 0 {
-			avgRed /= float64(pairs)
-		}
-	}
+	selected, avgRed := searchutil.ApplyMMR(
+		results,
+		func(r *types.SearchResult) float64 { return r.Score },
+		allTokenSets,
+		k,
+		lambda,
+	)
 	pipelineInfo(ctx, "Rerank", "mmr_done", map[string]interface{}{
 		"selected":       len(selected),
 		"avg_redundancy": fmt.Sprintf("%.4f", avgRed),

--- a/internal/searchutil/ranking.go
+++ b/internal/searchutil/ranking.go
@@ -1,0 +1,118 @@
+package searchutil
+
+import (
+	"math"
+	"strings"
+)
+
+// Composite ranking weights shared by every retrieval surface that combines a
+// rerank model score with the retrieval base score (chat pipeline and agent
+// knowledge_search today).
+const (
+	CompositeModelWeight  = 0.6
+	CompositeBaseWeight   = 0.3
+	CompositeSourceWeight = 0.1
+	// webSearchSourceWeight slightly down-weights web_search passages so
+	// knowledge-base content wins ties against fetched web content.
+	webSearchSourceWeight = 0.95
+)
+
+// CompositeRawScore returns the unclamped weighted combination
+// CompositeModelWeight*modelScore + CompositeBaseWeight*baseScore +
+// CompositeSourceWeight*sourceWeight, where web_search sources use
+// webSearchSourceWeight and everything else weighs 1.0.
+// Callers that multiply in an additional prior (the agent position prior)
+// should clamp the product themselves so the clamp stays the final step.
+func CompositeRawScore(knowledgeSource string, modelScore, baseScore float64) float64 {
+	sourceWeight := 1.0
+	if strings.ToLower(knowledgeSource) == "web_search" {
+		sourceWeight = webSearchSourceWeight
+	}
+	return CompositeModelWeight*modelScore + CompositeBaseWeight*baseScore + CompositeSourceWeight*sourceWeight
+}
+
+// CompositeScore is CompositeRawScore clamped to [0, 1].
+func CompositeScore(knowledgeSource string, modelScore, baseScore float64) float64 {
+	return ClampFloat(CompositeRawScore(knowledgeSource, modelScore, baseScore), 0, 1)
+}
+
+// PositionPrior returns the multiplier that slightly favors chunks earlier in
+// their document: 1 + clamp(1 - startAt/(endAt+1), -0.05, 0.05) for a valid
+// span, and 1.0 otherwise. Applied by the agent knowledge_search tool only;
+// whether it should spread to the chat pipeline is a maintainer decision.
+func PositionPrior(startAt, endAt int) float64 {
+	prior := 1.0
+	if startAt >= 0 && endAt > startAt {
+		positionRatio := 1.0 - float64(startAt)/float64(endAt+1)
+		prior += ClampFloat(positionRatio, -0.05, 0.05)
+	}
+	return prior
+}
+
+// ApplyMMR selects up to k items by maximal marginal relevance:
+//
+//	mmr = lambda*score(item) - (1-lambda)*max Jaccard(item tokens, selected tokens)
+//
+// over pre-computed token sets, preserving candidate order on ties (the first
+// candidate with the best MMR score wins each round). It returns the selected
+// items in selection order plus the average pairwise Jaccard redundancy among
+// them, so callers can log the same diversity summary they produced before
+// this helper existed. tokenSets must be the same length as items.
+//
+// The selection uses the incremental maxRedundancy cache: each round folds the
+// freshly selected item into every remaining candidate's cached maximum, which
+// yields the same picks as rescanning all selected pairs each round.
+func ApplyMMR[T any](items []T, score func(T) float64, tokenSets []map[string]struct{}, k int, lambda float64) (selected []T, avgRedundancy float64) {
+	if k <= 0 || len(items) == 0 {
+		return nil, 0
+	}
+
+	candidates := make([]T, len(items))
+	copy(candidates, items)
+	candidateTokens := make([]map[string]struct{}, len(items))
+	copy(candidateTokens, tokenSets)
+	maxRedundancy := make([]float64, len(items))
+
+	selected = make([]T, 0, k)
+	selectedTokens := make([]map[string]struct{}, 0, k)
+
+	for len(selected) < k && len(candidates) > 0 {
+		bestIdx := 0
+		bestScore := -1.0
+
+		for i, item := range candidates {
+			mmr := lambda*score(item) - (1.0-lambda)*maxRedundancy[i]
+			if mmr > bestScore {
+				bestScore = mmr
+				bestIdx = i
+			}
+		}
+
+		selected = append(selected, candidates[bestIdx])
+		chosenTokens := candidateTokens[bestIdx]
+		selectedTokens = append(selectedTokens, chosenTokens)
+		candidates = append(candidates[:bestIdx], candidates[bestIdx+1:]...)
+		candidateTokens = append(candidateTokens[:bestIdx], candidateTokens[bestIdx+1:]...)
+		maxRedundancy = append(maxRedundancy[:bestIdx], maxRedundancy[bestIdx+1:]...)
+
+		// Fold the freshly selected item into every remaining candidate's cache.
+		for i := range candidates {
+			maxRedundancy[i] = math.Max(maxRedundancy[i], Jaccard(candidateTokens[i], chosenTokens))
+		}
+	}
+
+	avgRedundancy = 0.0
+	if len(selectedTokens) > 1 {
+		pairs := 0
+		for i := 0; i < len(selectedTokens); i++ {
+			for j := i + 1; j < len(selectedTokens); j++ {
+				avgRedundancy += Jaccard(selectedTokens[i], selectedTokens[j])
+				pairs++
+			}
+		}
+		if pairs > 0 {
+			avgRedundancy /= float64(pairs)
+		}
+	}
+	return selected, avgRedundancy
+}

--- a/internal/searchutil/ranking_test.go
+++ b/internal/searchutil/ranking_test.go
@@ -1,0 +1,231 @@
+package searchutil
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestCompositeScore(t *testing.T) {
+	// Expectations use the same runtime float64 arithmetic as the
+	// implementation (weights times float64 variables), so the test pins the
+	// exact values both call sites produced before the extraction.
+	var m, b float64 = 0.5, 0.5
+	tests := []struct {
+		name            string
+		knowledgeSource string
+		modelScore      float64
+		baseScore       float64
+		want            float64
+	}{
+		{"even scores default source", "knowledge_base", m, b, CompositeModelWeight*m + CompositeBaseWeight*b + CompositeSourceWeight*1.0},
+		{"web_search down-weighted", "web_search", m, b, CompositeModelWeight*m + CompositeBaseWeight*b + CompositeSourceWeight*webSearchSourceWeight},
+		{"source match is case-insensitive", "WEB_SEARCH", m, b, CompositeModelWeight*m + CompositeBaseWeight*b + CompositeSourceWeight*webSearchSourceWeight},
+		{"clamped low", "knowledge_base", -2, -2, 0},
+		{"clamped high", "knowledge_base", 2, 1, 1},
+		{"zero scores keep source floor", "", 0, 0, 0.1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CompositeScore(tt.knowledgeSource, tt.modelScore, tt.baseScore); got != tt.want {
+				t.Fatalf("CompositeScore(%q, %v, %v) = %v, want %v", tt.knowledgeSource, tt.modelScore, tt.baseScore, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompositeRawScoreNotClamped(t *testing.T) {
+	// The agent path multiplies in the position prior before clamping, so the
+	// raw variant must preserve out-of-range magnitudes instead of clamping.
+	// Operands stay variables so the expectation uses runtime float64
+	// arithmetic, exactly like the implementation.
+	var modelScore, baseScore float64 = 2, 2
+	got := CompositeRawScore("web_search", modelScore, baseScore)
+	want := CompositeModelWeight*modelScore + CompositeBaseWeight*baseScore + CompositeSourceWeight*webSearchSourceWeight
+	if got != want {
+		t.Fatalf("CompositeRawScore = %v, want %v", got, want)
+	}
+}
+
+func TestPositionPrior(t *testing.T) {
+	tests := []struct {
+		name           string
+		startAt, endAt int
+		want           float64
+	}{
+		{"negative start is neutral", -1, 10, 1.0},
+		{"empty span is neutral", 5, 5, 1.0},
+		{"inverted span is neutral", 10, 5, 1.0},
+		{"document head gets the full boost", 0, 9, 1.05},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PositionPrior(tt.startAt, tt.endAt); got != tt.want {
+				t.Fatalf("PositionPrior(%d, %d) = %v, want %v", tt.startAt, tt.endAt, got, tt.want)
+			}
+		})
+	}
+	t.Run("mid-document ratio", func(t *testing.T) {
+		want := 1.0 + ClampFloat(1.0-9.0/11.0, -0.05, 0.05)
+		if got := PositionPrior(9, 10); got != want {
+			t.Fatalf("PositionPrior(9, 10) = %v, want %v", got, want)
+		}
+	})
+}
+
+type mmrItem struct {
+	id    int
+	score float64
+}
+
+func tokens(words ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(words))
+	for _, w := range words {
+		set[w] = struct{}{}
+	}
+	return set
+}
+
+func TestApplyMMRGoldenSelection(t *testing.T) {
+	items := []mmrItem{
+		{1, 0.9}, {2, 0.8}, {3, 0.7},
+	}
+	tokenSets := []map[string]struct{}{
+		tokens("a", "b"), tokens("a", "b"), tokens("c", "d"),
+	}
+	selected, avgRed := ApplyMMR(items, func(i mmrItem) float64 { return i.score }, tokenSets, 3, 0.7)
+
+	var order []int
+	for _, s := range selected {
+		order = append(order, s.id)
+	}
+	// Item 2 is near-duplicate of item 1 (Jaccard 1.0), so it must fall behind
+	// the less relevant but diverse item 3.
+	wantOrder := []int{1, 3, 2}
+	if len(order) != len(wantOrder) {
+		t.Fatalf("selected %d items, want %d", len(order), len(wantOrder))
+	}
+	for i := range wantOrder {
+		if order[i] != wantOrder[i] {
+			t.Fatalf("selection order = %v, want %v", order, wantOrder)
+		}
+	}
+	wantAvg := (Jaccard(tokenSets[0], tokenSets[2]) + Jaccard(tokenSets[0], tokenSets[1]) + Jaccard(tokenSets[2], tokenSets[1])) / 3
+	if avgRed != wantAvg {
+		t.Fatalf("avgRedundancy = %v, want %v", avgRed, wantAvg)
+	}
+}
+
+func TestApplyMMREdgeCases(t *testing.T) {
+	items := []mmrItem{{1, 0.9}}
+	sets := []map[string]struct{}{tokens("a")}
+
+	if selected, avg := ApplyMMR(items, func(i mmrItem) float64 { return i.score }, sets, 0, 0.7); selected != nil || avg != 0 {
+		t.Fatalf("k<=0: got (%v, %v), want (nil, 0)", selected, avg)
+	}
+	if selected, avg := ApplyMMR(nil, func(i mmrItem) float64 { return i.score }, nil, 3, 0.7); selected != nil || avg != 0 {
+		t.Fatalf("empty items: got (%v, %v), want (nil, 0)", selected, avg)
+	}
+	// k larger than the candidate pool selects everything.
+	selected, avg := ApplyMMR(items, func(i mmrItem) float64 { return i.score }, sets, 10, 0.7)
+	if len(selected) != 1 || selected[0].id != 1 || avg != 0 {
+		t.Fatalf("k>len: got (%v, %v)", selected, avg)
+	}
+}
+
+// naiveApplyMMR is the rescan-every-round form the chat pipeline used before
+// the shared helper: for each remaining candidate it recomputes the maximum
+// Jaccard against every selected item. It is the behavioral reference the
+// incremental cache in ApplyMMR must match, including tie-breaking.
+func naiveApplyMMR(items []mmrItem, tokenSets []map[string]struct{}, k int, lambda float64) ([]mmrItem, float64) {
+	if k <= 0 || len(items) == 0 {
+		return nil, 0
+	}
+	selected := make([]mmrItem, 0, k)
+	selectedTokenSets := make([]map[string]struct{}, 0, k)
+	selectedIndices := make(map[int]struct{})
+
+	for len(selected) < k && len(selectedIndices) < len(items) {
+		bestIdx := -1
+		bestScore := -1.0
+		for i, item := range items {
+			if _, isSelected := selectedIndices[i]; isSelected {
+				continue
+			}
+			redundancy := 0.0
+			for _, selTokens := range selectedTokenSets {
+				if sim := Jaccard(tokenSets[i], selTokens); sim > redundancy {
+					redundancy = sim
+				}
+			}
+			mmr := lambda*item.score - (1.0-lambda)*redundancy
+			if mmr > bestScore {
+				bestScore = mmr
+				bestIdx = i
+			}
+		}
+		if bestIdx < 0 {
+			break
+		}
+		selected = append(selected, items[bestIdx])
+		selectedTokenSets = append(selectedTokenSets, tokenSets[bestIdx])
+		selectedIndices[bestIdx] = struct{}{}
+	}
+
+	avgRed := 0.0
+	if len(selectedTokenSets) > 1 {
+		pairs := 0
+		for i := 0; i < len(selectedTokenSets); i++ {
+			for j := i + 1; j < len(selectedTokenSets); j++ {
+				avgRed += Jaccard(selectedTokenSets[i], selectedTokenSets[j])
+				pairs++
+			}
+		}
+		if pairs > 0 {
+			avgRed /= float64(pairs)
+		}
+	}
+	return selected, avgRed
+}
+
+// TestApplyMMRMatchesNaiveSelection pins the consolidation's core claim: the
+// incremental maxRedundancy cache picks exactly what the naive rescan picked,
+// so moving the chat pipeline onto the shared implementation changes nothing.
+func TestApplyMMRMatchesNaiveSelection(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260909))
+	vocab := []string{"go", "rust", "kb", "rag", "chunk", "score", "mmr", "rank", "query", "doc", "span", "token"}
+
+	for iter := 0; iter < 300; iter++ {
+		n := 1 + rng.Intn(12)
+		items := make([]mmrItem, n)
+		tokenSets := make([]map[string]struct{}, n)
+		for i := 0; i < n; i++ {
+			items[i] = mmrItem{id: i, score: float64(rng.Intn(101)) / 100.0}
+			set := map[string]struct{}{}
+			for len(set) == 0 {
+				for _, w := range vocab {
+					if rng.Intn(3) == 0 {
+						set[w] = struct{}{}
+					}
+				}
+			}
+			tokenSets[i] = set
+		}
+		k := 1 + rng.Intn(n)
+		lambda := []float64{0.3, 0.7, 0.9}[rng.Intn(3)]
+
+		got, gotAvg := ApplyMMR(items, func(i mmrItem) float64 { return i.score }, tokenSets, k, lambda)
+		want, wantAvg := naiveApplyMMR(items, tokenSets, k, lambda)
+
+		if len(got) != len(want) {
+			t.Fatalf("iter %d n=%d k=%d lambda=%v: selected %d items, naive selected %d", iter, n, k, lambda, len(got), len(want))
+		}
+		for i := range got {
+			if got[i].id != want[i].id {
+				t.Fatalf("iter %d n=%d k=%d lambda=%v: order[%d] = item %d, naive picked item %d", iter, n, k, lambda, i, got[i].id, want[i].id)
+			}
+		}
+		if gotAvg != wantAvg {
+			t.Fatalf("iter %d n=%d k=%d lambda=%v: avgRedundancy = %v, naive = %v", iter, n, k, lambda, gotAvg, wantAvg)
+		}
+	}
+}


### PR DESCRIPTION
Implements #3093.

## What changes

The ranking core that had drifted between the chat pipeline and the agent
`knowledge_search` tool now lives once in `internal/searchutil/ranking.go`:

- **`CompositeScore` / `CompositeRawScore`** — the `0.6*modelScore +
  0.3*baseScore + 0.1*sourceWeight` blend with the `web_search` source
  weight. The raw variant lets the agent multiply in its position prior
  before the final clamp, exactly as it did before.
- **`PositionPrior`** — the agent-only `StartAt/EndAt` prior. It stays
  agent-side in this PR; whether it should also apply to the chat pipeline
  is the open decision from the issue, now changeable in one place.
- **`ApplyMMR`** — generic MMR over precomputed token sets using the
  incremental `maxRedundancy` form. It returns the selection plus the
  average pairwise redundancy so each caller keeps its own logging and
  tokenization strategy (the chat pipeline tokenizes enriched passages in
  parallel and emits `mmr_start`/`mmr_done` events; the agent tool
  tokenizes sequentially and logs via its logger).

Path-specific wrappers shrink to their concerns:

- `chat_pipeline/rerank.go`: `compositeScore` is gone (one-line call at the
  rerank loop), `applyMMR` keeps events + `ParallelMap` tokenization, and
  its unused `chatManage` parameter is dropped.
- `agent/tools/knowledge_search.go`: `compositeScore`/`applyMMR` delegate to
  the shared core; the `tokenizeSimple`/`clampFloat`/`jaccard` one-line
  delegates are removed.

## No behavior change

- The agent multiplies the prior into the **raw** score and clamps once at
  the end — the same single clamp as before, including for out-of-range
  inputs.
- The incremental MMR form is pinned against the naive rescan form by:
  - a randomized differential test (300 seeded cases, exact selection
    order and average redundancy) in `searchutil/ranking_test.go`,
  - the existing corpus-based `TestApplyMMR_matchesNaiveSelection` in the
    agent tools, which now exercises the wrapper on top of the shared core.

## Left out on purpose

`grep_chunks.go` carries a third `applyMMR` variant whose swap-based
candidate removal changes tie-breaking relative to the order-preserving
forms consolidated here. Unifying it would be a (tiny) behavior change, so
it is deferred to a follow-up.

## Test plan

- [x] `go build ./...`
- [x] `go vet` on the three touched packages
- [x] `go test ./internal/searchutil/ ./internal/application/service/chat_pipeline/ ./internal/agent/tools/`
      — all green except the pre-existing, environment-dependent
      `TestSkillPythonPackageRecoveryInstallsWithoutPip/ensurepip`, which
      fails identically on pristine upstream/main on this host (missing
      python3-venv) and is unrelated to this change.