### PR TITLE
fix(preview): improve keyboard scrolling and fullscreen controls

### DIFF
--- a/frontend/src/components/document-preview.focus.test.mjs
+++ b/frontend/src/components/document-preview.focus.test.mjs
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+import ts from 'typescript'
+import { effectScope, nextTick, reactive, shallowRef as ref, watch } from 'vue'
+import { parse, compileTemplate } from '@vue/compiler-sfc'
+
+const source = readFileSync(new URL('./document-preview.vue', import.meta.url), 'utf8')
+const start = source.indexOf('const previewRoot =')
+const end = source.indexOf('\nfunction toggleFullscreen()', start)
+assert.ok(start >= 0 && end > start)
+const focusSource = ts.transpile(source.slice(start, end))
+
+async function flush() {
+  await nextTick()
+  await nextTick()
+}
+
+function setup(t) {
+  const scope = effectScope()
+  t.after(() => scope.stop())
+  const document = { body: {}, activeElement: null }
+  document.activeElement = document.body
+  const calls = []
+  const element = name => ({
+    isConnected: true,
+    focus(options) {
+      assert.equal(options.preventScroll, true)
+      document.activeElement = this
+      calls.push(name)
+    },
+  })
+  const props = reactive({ active: true, sourceKey: 'artifact:one' })
+  const docxContainer = ref(null)
+  const htmlViewMode = ref('render')
+  const isFullscreen = ref(false)
+  const state = scope.run(() => vm.runInNewContext(`${focusSource}; ({
+    previewRoot, previewContent, focusPreviewContent, onPreviewFrameLoad,
+  })`, {
+    ref, watch, nextTick, props, document, docxContainer, htmlViewMode, isFullscreen,
+    getPreviewSourceKey: () => props.sourceKey,
+  }))
+  return { ...state, props, document, docxContainer, htmlViewMode, isFullscreen, calls, element }
+}
+
+test('opening a preview focuses its scroll container without scrolling ancestors', async t => {
+  const ctx = setup(t)
+  ctx.previewRoot.value = ctx.element('root')
+  ctx.previewContent.value = ctx.element('markdown')
+  await flush()
+  assert.deepEqual(ctx.calls, ['markdown'])
+})
+
+test('delayed content inherits focus from the loading preview', async t => {
+  const ctx = setup(t)
+  ctx.previewRoot.value = ctx.element('root')
+  await flush()
+  assert.deepEqual(ctx.calls, ['root'])
+  ctx.previewContent.value = ctx.element('code')
+  await flush()
+  assert.deepEqual(ctx.calls, ['root', 'code'])
+})
+
+test('loading does not steal focus from the composer or preview toolbar', async t => {
+  for (const target of ['composer', 'toolbar']) {
+    const ctx = setup(t)
+    ctx.previewRoot.value = ctx.element('root')
+    await flush()
+    const control = ctx.element(target)
+    ctx.document.activeElement = control
+    ctx.previewContent.value = ctx.element('excel')
+    await flush()
+    assert.equal(ctx.document.activeElement, control)
+    assert.deepEqual(ctx.calls, ['root'])
+  }
+})
+
+test('hidden previews never take focus and reactivation focuses cached content', async t => {
+  const ctx = setup(t)
+  ctx.props.active = false
+  ctx.previewRoot.value = ctx.element('root')
+  ctx.previewContent.value = ctx.element('cached')
+  await flush()
+  ctx.focusPreviewContent()
+  assert.deepEqual(ctx.calls, [])
+  ctx.props.active = true
+  await flush()
+  assert.deepEqual(ctx.calls, ['cached'])
+})
+
+test('switching files, source mode and fullscreen restores content focus', async t => {
+  const ctx = setup(t)
+  ctx.previewRoot.value = ctx.element('root')
+  ctx.previewContent.value = ctx.element('content')
+  await flush()
+  for (const update of [
+    () => { ctx.props.sourceKey = 'artifact:two' },
+    () => { ctx.htmlViewMode.value = 'source' },
+    () => { ctx.isFullscreen.value = true },
+    () => { ctx.isFullscreen.value = false },
+  ]) {
+    ctx.document.activeElement = ctx.element('button')
+    update()
+    await flush()
+    assert.equal(ctx.document.activeElement, ctx.previewContent.value)
+  }
+})
+
+test('DOCX focuses the renderer container and detached previews do not focus', async t => {
+  const ctx = setup(t)
+  ctx.previewRoot.value = ctx.element('root')
+  await flush()
+  ctx.docxContainer.value = ctx.element('docx')
+  await flush()
+  assert.deepEqual(ctx.calls, ['root', 'docx'])
+  ctx.previewRoot.value.isConnected = false
+  ctx.focusPreviewContent()
+  assert.deepEqual(ctx.calls, ['root', 'docx'])
+})
+
+test('iframe load retains preview focus without taking it from another input', async t => {
+  const ctx = setup(t)
+  ctx.previewRoot.value = ctx.element('root')
+  ctx.previewContent.value = ctx.element('iframe')
+  await flush()
+  ctx.onPreviewFrameLoad()
+  assert.deepEqual(ctx.calls, ['iframe', 'iframe'])
+  const input = ctx.element('input')
+  ctx.document.activeElement = input
+  ctx.onPreviewFrameLoad()
+  assert.equal(ctx.document.activeElement, input)
+})
+
+test('every document scroll target is tabbable and key events keep native behavior', () => {
+  const { descriptor } = parse(source)
+  const template = descriptor.template.content
+  for (const tag of template.matchAll(/<[^>]+ref="(?:previewContent|docxContainer)"[^>]*>/g)) {
+    assert.ok(/tabindex="0"|\bcontrols\b/.test(tag[0]), tag[0])
+  }
+  assert.doesNotMatch(template, /@key(?:down|up)/)
+  assert.match(template, /sandbox="allow-scripts"/)
+  assert.deepEqual(compileTemplate({ source: template, filename: 'document-preview.vue', id: 'preview' }).errors, [])
+})

--- a/frontend/src/components/document-preview.fullscreen.test.mjs
+++ b/frontend/src/components/document-preview.fullscreen.test.mjs
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+import ts from 'typescript'
+import { effectScope, nextTick, reactive, shallowRef as ref, watch } from 'vue'
+import { parse, compileStyleAsync } from '@vue/compiler-sfc'
+
+const source = readFileSync(new URL('./document-preview.vue', import.meta.url), 'utf8')
+const start = source.indexOf('function toggleFullscreen()')
+const end = source.indexOf('function ensureBlobType(', start)
+assert.ok(start >= 0 && end > start)
+const fullscreenSource = ts.transpile(source.slice(start, end))
+
+function setup(t, native = true) {
+  const scope = effectScope()
+  const mounted = [], unmounted = [], listeners = new Map()
+  const events = {
+    addEventListener(name, fn, capture) { listeners.set(name, { fn, capture }) },
+    removeEventListener(name, fn) {
+      if (listeners.get(name)?.fn === fn) listeners.delete(name)
+    },
+  }
+  const document = { ...events, body: { style: { overflow: 'clip' } }, fullscreenElement: null }
+  const isFullscreen = ref(false)
+  const props = reactive({ active: true })
+  const root = { isConnected: true }
+  if (native) {
+    root.requestFullscreen = async () => {
+      document.fullscreenElement = root
+      listeners.get('fullscreenchange').fn()
+    }
+  }
+  document.exitFullscreen = async () => {
+    document.fullscreenElement = null
+    listeners.get('fullscreenchange')?.fn()
+  }
+  const state = scope.run(() => vm.runInNewContext(`${fullscreenSource}; ({
+    enterPreviewFullscreen, exitPreviewFullscreen, toggleFullscreen, onFullscreenEscape,
+  })`, {
+    props, isFullscreen, previewRoot: ref(root), document, window: events, watch,
+    onMounted: fn => mounted.push(fn), onUnmounted: fn => unmounted.push(fn),
+  }))
+  mounted.forEach(fn => fn())
+  const dispose = () => { unmounted.splice(0).forEach(fn => fn()); scope.stop() }
+  t.after(dispose)
+  return { ...state, props, root, document, isFullscreen, listeners, dispose }
+}
+
+test('native fullscreen synchronizes browser Escape and button exit without changing body scroll', async t => {
+  const ctx = setup(t)
+  await ctx.enterPreviewFullscreen()
+  assert.equal(ctx.document.fullscreenElement, ctx.root)
+  assert.equal(ctx.isFullscreen.value, true)
+  assert.equal(ctx.document.body.style.overflow, 'clip')
+  // Browser Escape works even when the iframe consumes all keyboard events.
+  ctx.document.fullscreenElement = null
+  ctx.listeners.get('fullscreenchange').fn()
+  assert.equal(ctx.isFullscreen.value, false)
+  await ctx.enterPreviewFullscreen()
+  await ctx.exitPreviewFullscreen()
+  assert.equal(ctx.isFullscreen.value, false)
+  assert.equal(ctx.document.fullscreenElement, null)
+})
+
+test('fallback Escape exits only fullscreen and restores the existing scroll lock', async t => {
+  const ctx = setup(t, false)
+  await ctx.enterPreviewFullscreen()
+  assert.equal(ctx.isFullscreen.value, true)
+  assert.equal(ctx.document.body.style.overflow, 'hidden')
+  assert.equal(ctx.listeners.get('keydown').capture, true)
+  const calls = []
+  ctx.onFullscreenEscape({ key: 'Escape', preventDefault: () => calls.push('prevent'), stopImmediatePropagation: () => calls.push('stop') })
+  assert.deepEqual(calls, ['prevent', 'stop'])
+  assert.equal(ctx.isFullscreen.value, false)
+  assert.equal(ctx.document.body.style.overflow, 'clip')
+  ctx.onFullscreenEscape({ key: 'Escape', preventDefault: () => assert.fail('regular Escape belongs to the drawer') })
+})
+
+test('ordinary keys and IME Escape are left alone', async t => {
+  const ctx = setup(t, false)
+  await ctx.enterPreviewFullscreen()
+  for (const event of [{ key: 'PageDown' }, { key: 'Escape', isComposing: true }]) {
+    ctx.onFullscreenEscape({ ...event, preventDefault: () => assert.fail('key must remain native') })
+  }
+  assert.equal(ctx.isFullscreen.value, true)
+})
+
+test('a denied native request falls back and deactivation exits fullscreen', async t => {
+  const ctx = setup(t)
+  ctx.root.requestFullscreen = async () => { throw new Error('Permissions policy') }
+  await ctx.enterPreviewFullscreen()
+  assert.equal(ctx.isFullscreen.value, true)
+  ctx.props.active = false
+  await nextTick()
+  assert.equal(ctx.isFullscreen.value, false)
+  assert.equal(ctx.document.body.style.overflow, 'clip')
+})
+
+test('native fullscreen is exited when the preview is hidden', async t => {
+  const ctx = setup(t)
+  await ctx.enterPreviewFullscreen()
+  ctx.props.active = false
+  await nextTick()
+  assert.equal(ctx.document.fullscreenElement, null)
+  assert.equal(ctx.isFullscreen.value, false)
+})
+
+test('teardown restores fallback styles and unregisters both listeners', async t => {
+  const ctx = setup(t, false)
+  await ctx.enterPreviewFullscreen()
+  ctx.dispose()
+  assert.equal(ctx.document.body.style.overflow, 'clip')
+  assert.equal(ctx.listeners.size, 0)
+  await ctx.enterPreviewFullscreen()
+  assert.equal(ctx.isFullscreen.value, false)
+})
+
+test('a late native request cannot leave a disposed preview fullscreen', async t => {
+  const ctx = setup(t)
+  let complete
+  ctx.root.requestFullscreen = () => new Promise(resolve => {
+    complete = () => { ctx.document.fullscreenElement = ctx.root; resolve() }
+  })
+  const pending = ctx.enterPreviewFullscreen()
+  ctx.dispose()
+  complete()
+  await pending
+  assert.equal(ctx.document.fullscreenElement, null)
+  assert.equal(ctx.isFullscreen.value, false)
+})
+
+test('diagram zoom exits native fullscreen before opening its body-mounted viewer', async () => {
+  const code = source.slice(source.indexOf('async function openMermaid()'), source.indexOf('async function loadPreview()'))
+  const calls = []
+  let finishExit
+  const open = vm.runInNewContext(`${code}; openMermaid`, {
+    mermaidSvg: { value: '<svg />' }, props: { active: true }, previewRoot: { value: { isConnected: true } },
+    exitPreviewFullscreen: () => new Promise(resolve => { finishExit = resolve }),
+    openMermaidFullscreen: svg => calls.push(svg),
+  })
+  const pending = open()
+  assert.deepEqual(calls, [])
+  finishExit()
+  await pending
+  assert.deepEqual(calls, ['<svg />'])
+})
+
+test('toolbar reserves layout space in normal and fullscreen modes and keeps exit visible on errors', async () => {
+  const { descriptor } = parse(source)
+  assert.match(descriptor.template.content, /v-if="isFullscreen \|\|/)
+  assert.match(descriptor.template.content, /\{\{ isFullscreen \? \$t\('preview.exitFullscreen'\)/)
+  const result = await compileStyleAsync({
+    source: descriptor.styles[0].content, filename: 'document-preview.vue', id: 'preview', preprocessLang: 'less',
+  })
+  assert.deepEqual(result.errors, [])
+  const toolbars = [...result.code.matchAll(/[^{}]*\.preview-toolbar\s*\{([^}]+)\}/g)]
+  assert.ok(toolbars.length >= 2)
+  for (const [, css] of toolbars) assert.doesNotMatch(css, /position:\s*(absolute|fixed)|opacity:/)
+  assert.ok(toolbars.some(([, css]) => /flex-shrink:\s*0/.test(css)))
+})

--- a/frontend/src/components/document-preview.vue
+++ b/frontend/src/components/document-preview.vue
@@ -1,6 +1,6 @@
 // @ts-nocheck
 <script setup lang="ts">
-import { ref, shallowRef, watch, onUnmounted, nextTick, defineAsyncComponent } from 'vue';
+import { ref, shallowRef, watch, onMounted, onUnmounted, nextTick, defineAsyncComponent } from 'vue';
 import { previewKnowledgeFile } from '@/api/knowledge-base/index';
 import { previewTemporaryAttachment } from '@/api/chat/temporary-attachments';
 import { downloadArtifact } from '@/api/chat';
@@ -60,15 +60,134 @@ const imageNaturalHeight = ref(0);
 let loadedForId = '';
 
 const isFullscreen = ref(false);
+const previewRoot = ref<HTMLElement | null>(null);
+const previewContent = ref<HTMLElement | null>(null);
 
-function toggleFullscreen() {
-  isFullscreen.value = !isFullscreen.value;
-  if (isFullscreen.value) {
-    document.body.style.overflow = 'hidden';
-  } else {
-    document.body.style.overflow = '';
+function focusPreviewContent() {
+  const root = previewRoot.value;
+  if (!props.active || !root?.isConnected) return;
+  // Focus the actual scrolling element so the browser handles arrows, Space,
+  // PageUp/Down and Home/End, including native iframe and media controls.
+  const target = previewContent.value || docxContainer.value || root;
+  target.focus({ preventScroll: true });
+}
+
+watch(
+  () => [props.active, previewRoot.value, getPreviewSourceKey(), props.sourceBlob, htmlViewMode.value, isFullscreen.value],
+  async () => {
+    if (!props.active) return;
+    const previousFocus = document.activeElement;
+    await nextTick();
+    // Do not override a user who moved to another control while rendering.
+    if (document.activeElement !== previousFocus && document.activeElement !== document.body) return;
+    focusPreviewContent();
+  },
+  { flush: 'post' },
+);
+
+watch(
+  () => [previewContent.value, docxContainer.value],
+  () => {
+    // While downloading, focus rests on the preview root. Transfer it only
+    // if it is still there when the content arrives (never steal input focus).
+    if (document.activeElement === previewRoot.value) focusPreviewContent();
+  },
+  { flush: 'post' },
+);
+
+function onPreviewFrameLoad() {
+  if (document.activeElement === previewContent.value || document.activeElement === previewRoot.value) {
+    focusPreviewContent();
   }
 }
+
+function toggleFullscreen() {
+  if (isFullscreen.value) {
+    void exitPreviewFullscreen();
+  } else {
+    void enterPreviewFullscreen();
+  }
+}
+
+let fallbackOverflow: string | null = null;
+let fullscreenDisposed = false;
+
+async function enterPreviewFullscreen() {
+  const root = previewRoot.value;
+  if (!props.active || !root?.isConnected) return;
+  // Native fullscreen also handles Escape when focus is inside a PDF viewer
+  // or a sandboxed HTML iframe, whose keyboard events cannot bubble here.
+  if (root.requestFullscreen) {
+    try {
+      await root.requestFullscreen();
+      if (fullscreenDisposed || !props.active) {
+        if (document.fullscreenElement === root) await document.exitFullscreen();
+      } else {
+        syncFullscreen();
+      }
+      return;
+    } catch {
+      // Embedded hosts may disallow the Fullscreen API. Keep page fullscreen
+      // available there, with Escape handled in the parent document.
+    }
+  }
+  if (fullscreenDisposed || !props.active || !root.isConnected) return;
+  if (fallbackOverflow === null) fallbackOverflow = document.body.style.overflow;
+  document.body.style.overflow = 'hidden';
+  isFullscreen.value = true;
+}
+
+function clearFallbackFullscreen() {
+  if (fallbackOverflow !== null) {
+    document.body.style.overflow = fallbackOverflow;
+    fallbackOverflow = null;
+  }
+  isFullscreen.value = false;
+}
+
+async function exitPreviewFullscreen() {
+  if (previewRoot.value && document.fullscreenElement === previewRoot.value) {
+    try {
+      await document.exitFullscreen();
+    } catch {
+      // The browser may already have exited in response to Escape.
+    }
+    syncFullscreen();
+    return;
+  }
+  clearFallbackFullscreen();
+}
+
+function syncFullscreen() {
+  if (fallbackOverflow === null) {
+    isFullscreen.value = !!previewRoot.value && document.fullscreenElement === previewRoot.value;
+  }
+}
+
+function onFullscreenEscape(event: KeyboardEvent) {
+  if (event.key !== 'Escape' || event.isComposing || !isFullscreen.value || !props.active) return;
+  // Consume this Escape before a containing drawer can also close.
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  void exitPreviewFullscreen();
+}
+
+watch(() => props.active, (active) => {
+  if (!active) void exitPreviewFullscreen();
+});
+
+onMounted(() => {
+  document.addEventListener('fullscreenchange', syncFullscreen);
+  window.addEventListener('keydown', onFullscreenEscape, true);
+});
+
+onUnmounted(() => {
+  fullscreenDisposed = true;
+  document.removeEventListener('fullscreenchange', syncFullscreen);
+  window.removeEventListener('keydown', onFullscreenEscape, true);
+  void exitPreviewFullscreen();
+  clearFallbackFullscreen();
+});
 
 
 function ensureBlobType(blob: Blob, ft: string): Blob {
@@ -231,8 +350,12 @@ async function renderMermaid(blob: Blob) {
   await renderText(new Blob([text], { type: 'text/plain' }), 'mmd');
 }
 
-function openMermaid() {
-  if (mermaidSvg.value) openMermaidFullscreen(mermaidSvg.value);
+async function openMermaid() {
+  const svg = mermaidSvg.value;
+  if (!svg) return;
+  // The diagram viewer mounts on body, outside the native fullscreen element.
+  await exitPreviewFullscreen();
+  if (props.active && previewRoot.value?.isConnected) openMermaidFullscreen(svg);
 }
 
 async function loadPreview() {
@@ -349,31 +472,29 @@ watch(
 );
 
 onUnmounted(() => {
-  document.body.style.overflow = '';
   cleanup();
 });
 </script>
 
 <template>
-  <div class="document-preview" :class="{ 'is-fullscreen': isFullscreen, 'fill-height': fillHeight }">
+  <div ref="previewRoot" tabindex="-1" :aria-label="fileName" class="document-preview" :class="{ 'is-fullscreen': isFullscreen, 'fill-height': fillHeight }">
     <!-- Toolbar -->
-    <div class="preview-toolbar" v-if="!loading && !error && previewType !== 'unsupported'">
-      <t-space size="small">
-        <t-tooltip
+    <div class="preview-toolbar" v-if="isFullscreen || (!loading && !error && previewType !== 'unsupported')">
+      <span v-if="isFullscreen" class="preview-toolbar-title" :title="fileName">{{ fileName }}</span>
+      <div class="preview-toolbar-actions">
+        <t-button
           v-if="previewType === 'html' && allowsHtmlScriptPreview()"
-          :content="htmlViewMode === 'render' ? $t('preview.htmlSource') : $t('preview.htmlRendered')"
-          placement="bottom"
+          theme="default" variant="text" size="small"
+          @click="htmlViewMode = htmlViewMode === 'render' ? 'source' : 'render'"
         >
-          <t-button theme="default" variant="text" shape="square" @click="htmlViewMode = htmlViewMode === 'render' ? 'source' : 'render'">
-            <template #icon><t-icon :name="htmlViewMode === 'render' ? 'code' : 'browse'" /></template>
-          </t-button>
-        </t-tooltip>
-        <t-tooltip :content="isFullscreen ? $t('preview.exitFullscreen') : $t('preview.fullscreen')" placement="bottom">
-          <t-button theme="default" variant="text" shape="square" @click="toggleFullscreen">
-            <template #icon><t-icon :name="isFullscreen ? 'fullscreen-exit' : 'fullscreen'" /></template>
-          </t-button>
-        </t-tooltip>
-      </t-space>
+          <template #icon><t-icon :name="htmlViewMode === 'render' ? 'code' : 'browse'" /></template>
+          {{ htmlViewMode === 'render' ? $t('preview.htmlSource') : $t('preview.htmlRendered') }}
+        </t-button>
+        <t-button theme="default" variant="outline" size="small" :aria-pressed="isFullscreen" @click="toggleFullscreen">
+          <template #icon><t-icon :name="isFullscreen ? 'fullscreen-exit' : 'fullscreen'" /></template>
+          {{ isFullscreen ? $t('preview.exitFullscreen') : $t('preview.fullscreen') }}
+        </t-button>
+      </div>
     </div>
 
     <!-- Loading -->
@@ -400,23 +521,27 @@ onUnmounted(() => {
 
     <!-- PDF -->
     <div v-else-if="previewType === 'pdf' && blobUrl" class="preview-pdf">
-      <iframe :src="blobUrl" class="pdf-iframe" />
+      <iframe ref="previewContent" tabindex="0" :title="fileName" :src="blobUrl" class="pdf-iframe" @load="onPreviewFrameLoad" />
     </div>
 
     <!-- HTML: artifacts render in a unique-origin iframe; other sources stay as source. -->
     <div v-else-if="previewType === 'html'" class="preview-html">
       <iframe
         v-if="allowsHtmlScriptPreview() && htmlViewMode === 'render' && blobUrl"
+        ref="previewContent"
+        tabindex="0"
+        :title="fileName"
         :src="blobUrl"
         class="html-iframe"
         sandbox="allow-scripts"
         referrerpolicy="no-referrer"
+        @load="onPreviewFrameLoad"
       />
-      <pre v-show="!allowsHtmlScriptPreview() || htmlViewMode === 'source'" class="code-preview"><code class="hljs" v-html="highlightedCode"></code></pre>
+      <pre v-else-if="!allowsHtmlScriptPreview() || htmlViewMode === 'source'" ref="previewContent" tabindex="0" :aria-label="fileName" class="code-preview"><code class="hljs" v-html="highlightedCode"></code></pre>
     </div>
 
     <!-- Image -->
-    <div v-else-if="previewType === 'image' && blobUrl" class="preview-image">
+    <div v-else-if="previewType === 'image' && blobUrl" ref="previewContent" tabindex="0" :aria-label="fileName" class="preview-image">
       <div class="image-wrapper">
         <img :src="blobUrl" :alt="fileName" @load="onImageLoad" />
         <div v-if="imageNaturalWidth" class="image-info">
@@ -427,31 +552,31 @@ onUnmounted(() => {
 
     <!-- DOCX -->
     <div v-else-if="previewType === 'docx'" class="preview-docx">
-      <div ref="docxContainer" class="docx-container" />
+      <div ref="docxContainer" tabindex="0" :aria-label="fileName" class="docx-container" />
     </div>
 
     <!-- PPTX -->
-    <div v-else-if="previewType === 'pptx' && pptxData" class="preview-pptx">
+    <div v-else-if="previewType === 'pptx' && pptxData" ref="previewContent" tabindex="0" :aria-label="fileName" class="preview-pptx">
       <vue-office-pptx :src="pptxData" @rendered="() => {}" @error="(e: any) => { error = e?.message || $t('preview.loadFailed'); }" />
     </div>
 
     <!-- Excel -->
     <div v-else-if="previewType === 'excel' && excelHtml" class="preview-excel">
-      <div class="excel-container" v-html="excelHtml" />
+      <div ref="previewContent" tabindex="0" :aria-label="fileName" class="excel-container" v-html="excelHtml" />
     </div>
 
     <!-- Markdown -->
-    <div v-else-if="previewType === 'markdown' && markdownHtml" class="preview-markdown">
+    <div v-else-if="previewType === 'markdown' && markdownHtml" ref="previewContent" tabindex="0" :aria-label="fileName" class="preview-markdown">
       <div class="markdown-body" v-html="markdownHtml" />
     </div>
 
     <!-- Text / Code -->
     <div v-else-if="previewType === 'text' && highlightedCode" class="preview-text">
-      <pre class="code-preview"><code class="hljs" v-html="highlightedCode"></code></pre>
+      <pre ref="previewContent" tabindex="0" :aria-label="fileName" class="code-preview"><code class="hljs" v-html="highlightedCode"></code></pre>
     </div>
 
     <!-- Mermaid -->
-    <div v-else-if="previewType === 'mermaid' && mermaidSvg" class="preview-mermaid" @click="openMermaid">
+    <div v-else-if="previewType === 'mermaid' && mermaidSvg" ref="previewContent" tabindex="0" :aria-label="fileName" class="preview-mermaid" @click="openMermaid">
       <div class="mermaid-body" v-html="mermaidSvg" />
     </div>
 
@@ -460,7 +585,7 @@ onUnmounted(() => {
       <div class="audio-wrapper">
         <t-icon name="sound" size="48px" />
         <p class="audio-filename">{{ fileName }}</p>
-        <audio controls :src="blobUrl" class="audio-element">
+        <audio ref="previewContent" controls :src="blobUrl" class="audio-element">
           {{ $t('preview.audioNotSupported') }}
         </audio>
       </div>
@@ -468,7 +593,7 @@ onUnmounted(() => {
 
     <!-- Video -->
     <div v-else-if="previewType === 'video' && blobUrl" class="preview-video">
-      <video controls playsinline :src="blobUrl" class="video-element">
+      <video ref="previewContent" controls playsinline :src="blobUrl" class="video-element">
         {{ $t('preview.videoNotSupported') }}
       </video>
     </div>
@@ -514,7 +639,8 @@ onUnmounted(() => {
   min-height: 200px;
   position: relative;
 
-  &.fill-height {
+  &.fill-height,
+  &.is-fullscreen {
     height: 100%;
     min-height: 0;
     display: flex;
@@ -548,11 +674,15 @@ onUnmounted(() => {
       overflow: auto;
     }
 
-    .preview-docx {
+    .preview-docx,
+    .preview-excel,
+    .preview-text {
       display: flex;
       flex-direction: column;
 
-      .docx-container {
+      .docx-container,
+      .excel-container,
+      .code-preview {
         flex: 1;
         min-height: 0;
         max-height: none;
@@ -591,28 +721,17 @@ onUnmounted(() => {
   z-index: 2001;
   background: var(--td-bg-color-container);
   padding: 0;
-  overflow-y: auto;
+  overflow: hidden;
 
   .preview-toolbar {
-    position: fixed;
-    top: 12px;
-    right: 32px;
-    z-index: 2002;
-  }
-
-  /* Children use height: 100% rather than 100vh because <html> carries a
-     `zoom` multiplier for font-size control; 100vh resolves against the
-     unscaled viewport and then gets scaled, overshooting the screen. The
-     fullscreen container is already inset 0 on all sides, so 100% resolves
-     to the true viewport height. */
-  .preview-pdf {
-    height: 100%;
+    padding: 12px 16px;
+    margin-bottom: 0;
   }
 
   .preview-pptx {
     height: auto;
-    min-height: 100%;
-    overflow: visible;
+    min-height: 0;
+    overflow: auto;
     border: none;
 
     :deep(.pptx-preview-wrapper) {
@@ -621,57 +740,43 @@ onUnmounted(() => {
     }
   }
 
-  .preview-docx {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    .docx-container {
-      max-height: 100%;
-      height: 100%;
-      flex: 1;
-    }
-  }
-
   .preview-image {
-    min-height: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
-    .image-wrapper img {
-      max-height: calc(100% - 80px);
-    }
-  }
-
-  .preview-excel .excel-container,
-  .preview-markdown,
-  .preview-text .code-preview,
-  .preview-html .code-preview {
-    max-height: 100%;
-  }
-
-  .preview-html,
-  .preview-video,
-  .preview-mermaid {
-    height: 100%;
   }
 }
 
 .preview-toolbar {
-  position: absolute;
-  top: 8px;
-  right: 24px;
-  z-index: 10;
-  background: var(--td-bg-color-container);
-  border: 1px solid var(--td-component-border);
-  border-radius: var(--td-radius-default);
-  box-shadow: var(--td-shadow-1);
-  padding: 4px;
-  opacity: 0.6;
-  transition: opacity 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+  min-width: 0;
+  padding: 8px 0;
+  margin-bottom: 8px;
+  border-bottom: 1px solid @border-color;
+  background: @bg-white;
+}
 
-  &:hover {
-    opacity: 1;
-  }
+.preview-toolbar-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: @text-primary;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.preview-toolbar-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-left: auto;
 }
 
 // ── States ──
@@ -772,6 +877,7 @@ onUnmounted(() => {
 
 // ── Image ──
 .preview-image {
+  overflow: auto;
   display: flex;
   justify-content: center;
   padding: 20px 0;


### PR DESCRIPTION
Opening a document preview leaves keyboard focus outside its scroll container, so arrow keys, Space and PageUp/PageDown can act on the surrounding page. The floating fullscreen button also covers document content, and the CSS-only fullscreen mode does not handle Escape.

Focus the actual preview scroll container on open and file/view changes, while preserving focus if the user moves elsewhere during loading. Constrain text and spreadsheet scrolling in panels and fullscreen mode. These changes apply to the shared preview used by artifacts, attachments, knowledge-base files and protected resources.

Move labeled preview controls into a separate toolbar. Prefer native fullscreen so Escape also works from PDF and sandboxed HTML frames, and prevent a handled Escape from also closing the containing drawer. Clean up fullscreen state and restore existing body scroll styles on close. Restricted embedded hosts retain a page-fullscreen fallback; Escape inside an iframe remains limited in that fallback.

Validation:
- All 299 frontend tests passed, including 39 focused tests across preview focus/fullscreen behavior, artifact panels, Markdown rendering and file preview utilities.
- Frontend type checking passed.
- Frontend production build passed (bundle size warning).
- Git whitespace checks passed.
- Browser interaction and visual QA were not performed.
