### PR TITLE
fix(preview): align header controls and artifact cards

### DIFF
--- a/frontend/src/components/css/artifact-file-icon.less
+++ b/frontend/src/components/css/artifact-file-icon.less
@@ -1,0 +1,40 @@
+.artifact-file-icon-style() {
+  display: block;
+  flex-shrink: 0;
+  width: 32px;
+  height: 38px;
+  color: var(--td-text-color-secondary);
+
+  &.kind-file-word { color: #5381c4; }
+  &.kind-file-excel { color: #419781; }
+  &.kind-file-powerpoint { color: #c18a4e; }
+  &.kind-file-pdf { color: #c56868; }
+  &.kind-image,
+  &.kind-video { color: #9273bd; }
+  &.kind-code,
+  &.kind-sound { color: #5d95ad; }
+
+  .file-sheet {
+    fill: var(--td-bg-color-container);
+    stroke: currentColor;
+    stroke-opacity: 0.35;
+    stroke-width: 1.2;
+  }
+
+  .file-fold,
+  .file-lines {
+    stroke: currentColor;
+    stroke-opacity: 0.35;
+    stroke-width: 1.2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  text {
+    fill: #fff;
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 7px;
+    font-weight: 650;
+    letter-spacing: 0.2px;
+  }
+}

--- a/frontend/src/components/css/chat-markdown.less
+++ b/frontend/src/components/css/chat-markdown.less
@@ -1,4 +1,5 @@
 @import './chat-hljs.less';
+@import './artifact-file-icon.less';
 
 // Single source of truth for chat answer Markdown typography and block styles.
 // Used by botmsg, AgentStreamDisplay, embed chat, and the dev Markdown test page.
@@ -644,25 +645,25 @@
   :deep(.artifact-ref-card) {
     display: inline-flex;
     align-items: center;
-    gap: 10px;
+    gap: 12px;
+    width: 420px;
     max-width: min(420px, 100%);
     margin: 0.75em 0;
-    padding: 8px 14px 8px 10px;
-    border: 1px solid var(--td-component-stroke);
-    border-radius: 10px;
-    background: var(--td-bg-color-container);
+    box-sizing: border-box;
+    padding: 12px 8px;
+    border-radius: 8px;
+    background: transparent;
     cursor: pointer;
     vertical-align: middle;
     text-align: left;
-    transition: border-color 0.15s ease, background 0.15s ease;
+    transition: background 0.15s ease;
 
     &:hover {
-      border-color: var(--td-brand-color);
       background: var(--td-bg-color-container-hover);
     }
 
     &:focus-visible {
-      outline: 2px solid var(--td-brand-color);
+      outline: 2px solid var(--td-text-color-secondary);
       outline-offset: 2px;
     }
   }
@@ -672,37 +673,34 @@
     opacity: 0.7;
 
     &:hover {
-      border-color: var(--td-component-stroke);
-      background: var(--td-bg-color-container);
+      background: transparent;
     }
   }
 
   :deep(.artifact-ref-card__icon) {
     flex-shrink: 0;
-    width: 30px;
-    height: 30px;
-    border-radius: 8px;
+    width: 32px;
+    height: 38px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    background: var(--td-bg-color-secondarycontainer);
-    color: var(--td-text-color-secondary);
   }
 
-  :deep(.artifact-ref-card__glyph) {
-    width: 17px;
-    height: 17px;
+  :deep(.artifact-file-icon-svg) {
+    .artifact-file-icon-style();
   }
 
   :deep(.artifact-ref-card__text) {
     display: inline-flex;
     flex-direction: column;
     min-width: 0;
+    flex: 1;
   }
 
   :deep(.artifact-ref-card__name) {
     font-size: 13px;
-    font-weight: 600;
+    font-weight: 500;
+    letter-spacing: 0.01em;
     line-height: 1.35;
     color: var(--td-text-color-primary);
     overflow: hidden;
@@ -711,6 +709,7 @@
   }
 
   :deep(.artifact-ref-card__hint) {
+    margin-top: 2px;
     font-size: 12px;
     line-height: 1.3;
     color: var(--td-text-color-placeholder);

--- a/frontend/src/components/document-preview.fullscreen.test.mjs
+++ b/frontend/src/components/document-preview.fullscreen.test.mjs
@@ -149,7 +149,9 @@ test('diagram zoom exits native fullscreen before opening its body-mounted viewe
 test('toolbar reserves layout space in normal and fullscreen modes and keeps exit visible on errors', async () => {
   const { descriptor } = parse(source)
   assert.match(descriptor.template.content, /v-if="isFullscreen \|\|/)
-  assert.match(descriptor.template.content, /\{\{ isFullscreen \? \$t\('preview.exitFullscreen'\)/)
+  assert.match(descriptor.template.content, /:aria-label="isFullscreen \? \$t\('preview.exitFullscreen'\)/)
+  assert.match(descriptor.template.content, /<Teleport :to="toolbarTarget \|\| 'body'" :disabled="isFullscreen \|\| !toolbarTarget">/)
+  assert.doesNotMatch(descriptor.template.content, /\{\{ isFullscreen \? \$t\('preview.exitFullscreen'\)/)
   const result = await compileStyleAsync({
     source: descriptor.styles[0].content, filename: 'document-preview.vue', id: 'preview', preprocessLang: 'less',
   })

--- a/frontend/src/components/document-preview.vue
+++ b/frontend/src/components/document-preview.vue
@@ -41,6 +41,8 @@ const props = defineProps<{
   fileName: string;
   active: boolean;
   fillHeight?: boolean;
+  /** Place preview actions beside the host header's download button. */
+  toolbarTarget?: HTMLElement | null;
 }>();
 
 const loading = ref(false);
@@ -479,23 +481,28 @@ onUnmounted(() => {
 <template>
   <div ref="previewRoot" tabindex="-1" :aria-label="fileName" class="document-preview" :class="{ 'is-fullscreen': isFullscreen, 'fill-height': fillHeight }">
     <!-- Toolbar -->
-    <div class="preview-toolbar" v-if="isFullscreen || (!loading && !error && previewType !== 'unsupported')">
-      <span v-if="isFullscreen" class="preview-toolbar-title" :title="fileName">{{ fileName }}</span>
-      <div class="preview-toolbar-actions">
-        <t-button
-          v-if="previewType === 'html' && allowsHtmlScriptPreview()"
-          theme="default" variant="text" size="small"
-          @click="htmlViewMode = htmlViewMode === 'render' ? 'source' : 'render'"
-        >
-          <template #icon><t-icon :name="htmlViewMode === 'render' ? 'code' : 'browse'" /></template>
-          {{ htmlViewMode === 'render' ? $t('preview.htmlSource') : $t('preview.htmlRendered') }}
-        </t-button>
-        <t-button theme="default" variant="outline" size="small" :aria-pressed="isFullscreen" @click="toggleFullscreen">
-          <template #icon><t-icon :name="isFullscreen ? 'fullscreen-exit' : 'fullscreen'" /></template>
-          {{ isFullscreen ? $t('preview.exitFullscreen') : $t('preview.fullscreen') }}
-        </t-button>
+    <Teleport :to="toolbarTarget || 'body'" :disabled="isFullscreen || !toolbarTarget">
+      <div class="preview-toolbar" :class="{ 'is-inline': toolbarTarget && !isFullscreen }" v-if="isFullscreen || (!loading && !error && previewType !== 'unsupported')">
+        <span v-if="isFullscreen" class="preview-toolbar-title" :title="fileName">{{ fileName }}</span>
+        <div class="preview-toolbar-actions">
+          <t-button
+            v-if="previewType === 'html' && allowsHtmlScriptPreview()"
+            theme="default" variant="text" size="small" shape="square"
+            :title="htmlViewMode === 'render' ? $t('preview.htmlSource') : $t('preview.htmlRendered')"
+            :aria-label="htmlViewMode === 'render' ? $t('preview.htmlSource') : $t('preview.htmlRendered')"
+            @click="htmlViewMode = htmlViewMode === 'render' ? 'source' : 'render'"
+          >
+            <template #icon><t-icon :name="htmlViewMode === 'render' ? 'code' : 'browse'" /></template>
+          </t-button>
+          <t-button theme="default" variant="text" size="small" shape="square" :aria-pressed="isFullscreen"
+            :title="isFullscreen ? $t('preview.exitFullscreen') : $t('preview.fullscreen')"
+            :aria-label="isFullscreen ? $t('preview.exitFullscreen') : $t('preview.fullscreen')"
+            @click="toggleFullscreen">
+            <template #icon><t-icon :name="isFullscreen ? 'fullscreen-exit' : 'fullscreen'" /></template>
+          </t-button>
+        </div>
       </div>
-    </div>
+    </Teleport>
 
     <!-- Loading -->
     <div v-if="loading" class="preview-loading">
@@ -770,6 +777,13 @@ onUnmounted(() => {
   font-weight: 500;
 }
 
+.preview-toolbar.is-inline {
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background: transparent;
+}
+
 .preview-toolbar-actions {
   display: flex;
   align-items: center;
@@ -777,6 +791,19 @@ onUnmounted(() => {
   justify-content: flex-end;
   gap: 8px;
   margin-left: auto;
+
+  :deep(.t-button) {
+    flex-shrink: 0;
+    width: 30px;
+    height: 30px;
+    border-radius: 7px;
+    color: @text-secondary;
+  }
+
+  :deep(.t-button__icon) {
+    margin: 0;
+    font-size: 16px;
+  }
 }
 
 // ── States ──

--- a/frontend/src/utils/artifactFileIcon.ts
+++ b/frontend/src/utils/artifactFileIcon.ts
@@ -1,0 +1,16 @@
+import { getFileIcon } from './files'
+import { resolveFilePreviewExt } from './filePreview'
+
+/** Shared trusted SVG for Vue file rows and inline Markdown artifact cards. */
+export function renderArtifactFileIcon(fileName: string): string {
+  const kind = getFileIcon(fileName)
+  const ext = resolveFilePreviewExt(fileName)
+  // Only this restricted extension label is interpolated, never the filename.
+  const label = /^[a-z0-9]{1,4}$/i.test(ext) ? ext.toUpperCase() : 'FILE'
+  return `<svg class="artifact-file-icon-svg kind-${kind}" viewBox="0 0 32 38" fill="none" aria-hidden="true">`
+    + '<path class="file-sheet" d="M6 1.5h13L28.5 11v22A3.5 3.5 0 0 1 25 36.5H6A3.5 3.5 0 0 1 2.5 33V5A3.5 3.5 0 0 1 6 1.5Z" />'
+    + '<path class="file-fold" d="M19 1.5V8a3 3 0 0 0 3 3h6.5" />'
+    + '<path class="file-lines" d="M8 14h9M8 18h14" />'
+    + '<rect x="5" y="23" width="24" height="11" rx="3" fill="currentColor" />'
+    + `<text x="17" y="30.8" text-anchor="middle">${label}</text></svg>`
+}

--- a/frontend/src/utils/sandboxArtifactRefs.test.ts
+++ b/frontend/src/utils/sandboxArtifactRefs.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { renderArtifactFileIcon } from './artifactFileIcon'
 
 import {
   isArtifactRefHref,
@@ -10,6 +11,19 @@ import {
 } from './sandboxArtifactRefs.ts'
 
 const labels = { previewHint: '点击预览', missingHint: '文件不可用' }
+
+test('inline file cards reuse the drawer icon and keep filenames escaped', () => {
+  for (const name of ['report.pdf', 'table.xlsx', 'notes.docx', 'slides.pptx', 'chart.html', 'bad.<img src=x onerror=alert(1)>']) {
+    const icon = renderArtifactFileIcon(name)
+    const html = renderArtifactReference({ href: 'sandbox:' + name, artifacts: [{ index: 3, file_name: name }], labels })
+    assert.ok(html?.includes(icon))
+    assert.ok(html?.includes('data-artifact-index="3"'))
+    assert.doesNotMatch(icon, /<img|onerror/)
+    assert.doesNotMatch(html!, /<img src=x/)
+  }
+  assert.match(renderArtifactFileIcon('report.pdf'), /kind-file-pdf/)
+  assert.match(renderArtifactFileIcon('report.pdf'), />PDF<\/text>/)
+})
 
 // 22 位句柄，与后端 types.ResourceHandleLength 一致。
 const handleFor = (i: number) => `art${i}`.padEnd(22, 'x')

--- a/frontend/src/utils/sandboxArtifactRefs.ts
+++ b/frontend/src/utils/sandboxArtifactRefs.ts
@@ -19,6 +19,7 @@
  */
 
 import { escapeHTML } from './security.ts';
+import { renderArtifactFileIcon } from './artifactFileIcon';
 
 /** 与后端 artifactListItem / SSE publicArtifactViews 对齐的最小字段集。 */
 export interface ArtifactRefMeta {
@@ -234,16 +235,6 @@ function blobCacheKey(ctx: ArtifactRefContext, index: number): string {
   return `${ctx.sessionId}\u0000${ctx.messageId}\u0000${index}`;
 }
 
-function fileIconSvg(): string {
-  return (
-    '<svg class="artifact-ref-card__glyph" viewBox="0 0 24 24" aria-hidden="true">'
-    + '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6z" '
-    + 'fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>'
-    + '<path d="M14 2v6h6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>'
-    + '</svg>'
-  );
-}
-
 // 与 chatMarkdownRenderer 的流式图片骨架同一个类名，样式复用。
 const STREAMING_PLACEHOLDER =
   '<span class="streaming-image-loading"><span class="streaming-image-loading__skeleton"></span></span>';
@@ -259,7 +250,7 @@ function renderCard(fileName: string, hint: string, index: number | null): strin
   const state = index === null ? ' artifact-ref-card--pending' : '';
   return (
     `<span class="artifact-ref-card${state}"${interactive} title="${safeName}">`
-    + `<span class="artifact-ref-card__icon" aria-hidden="true">${fileIconSvg()}</span>`
+    + `<span class="artifact-ref-card__icon" aria-hidden="true">${renderArtifactFileIcon(fileName)}</span>`
     + '<span class="artifact-ref-card__text">'
     + `<span class="artifact-ref-card__name">${safeName}</span>`
     + `<span class="artifact-ref-card__hint">${safeHint}</span>`

--- a/frontend/src/views/chat/components/ArtifactFileIcon.vue
+++ b/frontend/src/views/chat/components/ArtifactFileIcon.vue
@@ -1,64 +1,28 @@
 <template>
-  <svg class="artifact-file-icon" :class="`kind-${kind}`" viewBox="0 0 32 38" fill="none" aria-hidden="true">
-    <path class="file-sheet" d="M6 1.5h13L28.5 11v22A3.5 3.5 0 0 1 25 36.5H6A3.5 3.5 0 0 1 2.5 33V5A3.5 3.5 0 0 1 6 1.5Z" />
-    <path class="file-fold" d="M19 1.5V8a3 3 0 0 0 3 3h6.5" />
-    <path class="file-lines" d="M8 14h9M8 18h14" />
-    <rect x="5" y="23" width="24" height="11" rx="3" fill="currentColor" />
-    <text x="17" y="30.8" text-anchor="middle">{{ label }}</text>
-  </svg>
+  <span class="artifact-file-icon" aria-hidden="true" v-html="iconSvg" />
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { getFileIcon } from '@/utils/files'
-import { resolveFilePreviewExt } from '@/utils/filePreview'
+import { renderArtifactFileIcon } from '@/utils/artifactFileIcon'
 
 const props = defineProps<{ fileName: string }>()
-const kind = computed(() => getFileIcon(props.fileName))
-const label = computed(() => {
-  const ext = resolveFilePreviewExt(props.fileName)
-  return /^[a-z0-9]{1,4}$/i.test(ext) ? ext.toUpperCase() : 'FILE'
-})
+const iconSvg = computed(() => renderArtifactFileIcon(props.fileName))
 </script>
 
 <style scoped lang="less">
+@import '@/components/css/artifact-file-icon.less';
+
 .artifact-file-icon {
+  display: inline-flex;
   flex-shrink: 0;
   width: 32px;
   height: 38px;
-  color: var(--td-text-color-secondary);
 
-  &.kind-file-word { color: #5381c4; }
-  &.kind-file-excel { color: #419781; }
-  &.kind-file-powerpoint { color: #c18a4e; }
-  &.kind-file-pdf { color: #c56868; }
-  &.kind-image,
-  &.kind-video { color: #9273bd; }
-  &.kind-code,
-  &.kind-sound { color: #5d95ad; }
-
-  .file-sheet {
-    fill: var(--td-bg-color-container);
-    stroke: currentColor;
-    stroke-opacity: 0.35;
-    stroke-width: 1.2;
-  }
-
-  .file-fold,
-  .file-lines {
-    stroke: currentColor;
-    stroke-opacity: 0.35;
-    stroke-width: 1.2;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-  }
-
-  text {
-    fill: #fff;
-    font-family: ui-sans-serif, system-ui, sans-serif;
-    font-size: 7px;
-    font-weight: 650;
-    letter-spacing: 0.2px;
+  :deep(.artifact-file-icon-svg) {
+    .artifact-file-icon-style();
+    width: 100%;
+    height: 100%;
   }
 }
 </style>

--- a/frontend/src/views/chat/components/ChatArtifactsDrawer.vue
+++ b/frontend/src/views/chat/components/ChatArtifactsDrawer.vue
@@ -78,6 +78,7 @@
                         <t-icon name="download" size="16px" />
                     </template>
                 </t-button>
+                <div ref="previewActions" class="artifact-preview-actions" />
             </div>
             <div v-else class="artifact-drawer-header">
                 <div class="artifact-drawer-header-icon">
@@ -88,6 +89,7 @@
         </template>
         <div v-if="previewItem" class="artifact-preview-body">
             <DocumentPreview
+                :toolbar-target="previewActions"
                 :session-id="sessionId"
                 :message-id="messageId"
                 :artifact-index="previewItem.index"
@@ -204,6 +206,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const previewActions = ref<HTMLElement | null>(null)
 
 /** TDesign always follows @close with update:visible=false; swallow that when popping preview. */
 let suppressDrawerClose = false
@@ -451,6 +454,10 @@ onUnmounted(() => {
     :deep(.t-button__icon) {
         margin: 0;
     }
+}
+
+.artifact-preview-actions {
+    flex-shrink: 0;
 }
 
 .artifact-drawer-header-icon {

--- a/frontend/src/views/chat/components/ChatArtifactsPanel.vue
+++ b/frontend/src/views/chat/components/ChatArtifactsPanel.vue
@@ -30,10 +30,12 @@
           <t-icon name="download" size="16px" />
         </template>
       </t-button>
+      <div ref="previewActions" class="artifact-preview-actions" />
     </div>
 
     <div v-if="previewItem" class="artifact-preview-body">
       <DocumentPreview
+        :toolbar-target="previewActions"
         :session-id="sessionId"
         :message-id="previewItem.messageId"
         :artifact-index="previewItem.index"
@@ -157,6 +159,7 @@ const props = withDefaults(
 
 const { t } = useI18n()
 const panel = useChatSandboxPanel()
+const previewActions = ref<HTMLElement | null>(null)
 const listRef = ref<HTMLElement | null>(null)
 const previewItem = ref<SessionArtifactItem | null>(null)
 const downloading = reactive<Record<string, boolean>>({})
@@ -325,6 +328,10 @@ async function handleDownload(item: SessionArtifactItem) {
   :deep(.t-button__icon) {
     margin: 0;
   }
+}
+
+.artifact-preview-actions {
+  flex-shrink: 0;
 }
 
 .artifact-panel-header-icon {


### PR DESCRIPTION
The fullscreen control occupies a separate row below the artifact header, and document cards in streamed answers use a different icon and visual treatment from the artifact list.

Place icon-only preview controls beside the download button in both the artifact panel and drawer. Keep accessible labels and hover titles, and move the controls back inside the preview during fullscreen so the exit button remains available.

Reuse the artifact list's file icon SVG and styles for streamed document cards, including extension badges and file-type colors. Align card padding, spacing, typography and hover treatment with the list while preserving preview activation and filename escaping.

Validation:
- Full frontend tests, type checking and production build passed through the pre-push checks.
- Added a regression check for shared card icons and escaped filenames; updated fullscreen toolbar coverage.
- Browser interaction and visual QA were not performed.
