### PR TITLE
fix(preview): support storage in sandboxed HTML artifacts

### DIFF
--- a/frontend/src/components/document-preview.vue
+++ b/frontend/src/components/document-preview.vue
@@ -10,6 +10,7 @@ import 'katex/dist/katex.min.css';
 import { useI18n } from 'vue-i18n';
 import { sanitizeHTML, sanitizeMarkdownHTML } from '@/utils/security';
 import { renderDocumentPreviewMarkdown } from '@/utils/documentPreviewMarkdown';
+import { buildHtmlPreview } from '@/utils/htmlPreview';
 import { openMermaidFullscreen } from '@/utils/mermaidViewer';
 import { renderMermaidToSvg } from '@/utils/mermaidShared';
 import {
@@ -405,7 +406,8 @@ async function loadPreview() {
       }
       case 'html': {
         if (allowsHtmlScriptPreview()) {
-          blobUrl.value = URL.createObjectURL(blob);
+          const previewHtml = buildHtmlPreview(await blob.text());
+          blobUrl.value = URL.createObjectURL(new Blob([previewHtml], { type: 'text/html;charset=utf-8' }));
         }
         await renderText(blob, ft || 'html');
         break;

--- a/frontend/src/utils/htmlPreview.test.ts
+++ b/frontend/src/utils/htmlPreview.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+import { buildHtmlPreview } from './htmlPreview.ts'
+
+const bootstrap = buildHtmlPreview('').slice('<script>'.length, -'</script>'.length)
+
+function createFrame(overrides: Record<string, unknown> = {}) {
+  const window = Object.defineProperties({}, {
+    localStorage: { configurable: true, get() { throw new Error('SecurityError') } },
+    sessionStorage: { configurable: true, get() { throw new Error('SecurityError') } },
+  }) as Window
+  const context = vm.createContext({ window, ...overrides })
+  vm.runInContext(bootstrap, context)
+  return { window, context }
+}
+
+test('blocked storage no longer prevents generated page initialization and event handlers', () => {
+  const button = { onclick: null as null | (() => void) }
+  const { window, context } = createFrame({ button })
+  vm.runInContext(`
+    let best = Number(window.localStorage.getItem('best')) || 0;
+    button.onclick = () => window.localStorage.setItem('best', ++best);
+  `, context)
+  assert.equal(typeof button.onclick, 'function')
+  button.onclick!()
+  button.onclick!()
+  assert.equal(window.localStorage.getItem('best'), '2')
+})
+
+test('memory storage supports string conversion, keys, removal and clearing', () => {
+  const { localStorage: storage } = createFrame().window
+  assert.equal(storage.getItem('missing'), null)
+  assert.equal(storage.length, 0)
+  storage.setItem('best', 42 as unknown as string)
+  storage.setItem('empty', '')
+  storage.setItem('null', null as unknown as string)
+  assert.equal(storage.getItem('best'), '42')
+  assert.equal(storage.getItem('empty'), '')
+  assert.equal(storage.getItem('null'), 'null')
+  assert.equal(storage.length, 3)
+  assert.equal(storage.key(0), 'best')
+  assert.equal(storage.key(3), null)
+  assert.equal(storage.key(-1), null)
+  storage.removeItem('best')
+  assert.equal(storage.key(0), 'empty')
+  storage.clear()
+  assert.equal(storage.length, 0)
+})
+
+test('property access, deletion and enumeration share the same stored values', () => {
+  const { localStorage: storage } = createFrame().window
+  storage.score = 128
+  assert.equal(storage.getItem('score'), '128')
+  storage.setItem('board', '[2,4]')
+  assert.equal(storage.board, '[2,4]')
+  assert.deepEqual(Object.keys(storage), ['score', 'board'])
+  assert.equal(JSON.stringify(storage), '{"score":"128","board":"[2,4]"}')
+  assert.equal('score' in storage, true)
+  delete storage.score
+  assert.equal(storage.score, undefined)
+  assert.equal('score' in storage, false)
+  storage.setItem('__proto__', 'safe')
+  assert.equal(storage.getItem('__proto__'), 'safe')
+  assert.equal(Object.getPrototypeOf(storage), null)
+  storage.setItem('getItem', 'stored')
+  assert.equal(storage.getItem('getItem'), 'stored')
+})
+
+test('each frame and each storage area has independent, temporary state', () => {
+  const first = createFrame().window
+  const second = createFrame().window
+  first.localStorage.setItem('best', '100')
+  first.sessionStorage.setItem('best', '20')
+  assert.equal(first.localStorage.getItem('best'), '100')
+  assert.equal(first.sessionStorage.getItem('best'), '20')
+  assert.equal(second.localStorage.getItem('best'), null)
+  assert.equal(second.sessionStorage.getItem('best'), null)
+})
+
+test('available native storage is preserved independently for each area', () => {
+  const native = { length: 1, getItem: () => 'existing' }
+  const window = { localStorage: native }
+  vm.runInNewContext(bootstrap, { window })
+  assert.equal(window.localStorage, native)
+  assert.equal(window.localStorage.getItem(), 'existing')
+  assert.equal((window as unknown as Window).sessionStorage.length, 0)
+})
+
+test('bootstrap precedes application scripts while preserving doctype, head and all source bytes', () => {
+  const cases = [
+    ['', '<button>Play</button>'],
+    ['<!DOCTYPE html>', '<script>start()</script>'],
+    ['\uFEFF\n<!-- <head> decoy -->\n<!doctype html>\n<html lang="en">\n<head data-test=">">', '<script>start()</script></head><body></body></html>'],
+    ['<HTML><HEAD>', '<script>start()</script></HEAD></HTML>'],
+    ['', '<script>const text = "<head>";</script>'],
+  ]
+  for (const [prefix, rest] of cases) {
+    const source = prefix + rest
+    const rendered = buildHtmlPreview(source)
+    assert.equal(rendered, prefix + buildHtmlPreview('') + rest)
+    assert.equal(rendered.replace(buildHtmlPreview(''), ''), source)
+  }
+})
+
+test('only executable artifact previews use the compatibility copy; source and sandbox stay intact', () => {
+  const source = readFileSync(new URL('../components/document-preview.vue', import.meta.url), 'utf8')
+  const htmlCase = source.slice(source.indexOf("case 'html':"), source.indexOf("case 'docx':"))
+  assert.match(htmlCase, /if \(allowsHtmlScriptPreview\(\)\) \{\s*const previewHtml = buildHtmlPreview\(await blob\.text\(\)\)/)
+  assert.match(htmlCase, /new Blob\(\[previewHtml\], \{ type: 'text\/html;charset=utf-8' \}\)/)
+  assert.match(htmlCase, /await renderText\(blob, ft \|\| 'html'\)/)
+  assert.match(source, /sandbox="allow-scripts"/)
+  assert.doesNotMatch(source, /allow-same-origin/)
+})

--- a/frontend/src/utils/htmlPreview.ts
+++ b/frontend/src/utils/htmlPreview.ts
@@ -1,0 +1,68 @@
+// This is a standalone script: it runs inside the opaque-origin iframe, never
+// in the application window. Keep it independent of imports and bundler helpers.
+// Each frame owns two ephemeral stores, discarded when the frame is reloaded.
+const storageBootstrap = `<script>
+(() => {
+  function createStorage() {
+    const entries = new Map();
+    const api = Object.create(null);
+    Object.defineProperties(api, {
+      length: { configurable: true, get: () => entries.size },
+      key: { configurable: true, value: (index) => Array.from(entries.keys())[Number(index) >>> 0] ?? null },
+      getItem: { configurable: true, value: (key) => entries.get(String(key)) ?? null },
+      setItem: { configurable: true, value: (key, value) => { entries.set(String(key), String(value)); } },
+      removeItem: { configurable: true, value: (key) => { entries.delete(String(key)); } },
+      clear: { configurable: true, value: () => { entries.clear(); } },
+      [Symbol.toStringTag]: { configurable: true, value: 'Storage' },
+    });
+    return new Proxy(api, {
+      get(target, key) {
+        return Reflect.has(target, key) ? Reflect.get(target, key) : entries.get(key);
+      },
+      set(target, key, value) {
+        if (typeof key === 'string') entries.set(key, String(value));
+        return true;
+      },
+      deleteProperty(target, key) {
+        entries.delete(key);
+        return true;
+      },
+      has(target, key) {
+        return Reflect.has(target, key) || entries.has(key);
+      },
+      ownKeys() {
+        return Array.from(entries.keys());
+      },
+      getOwnPropertyDescriptor(target, key) {
+        return Reflect.getOwnPropertyDescriptor(target, key) || (entries.has(key)
+          ? { configurable: true, enumerable: true, writable: true, value: entries.get(key) }
+          : undefined);
+      },
+    });
+  }
+  for (const name of ['localStorage', 'sessionStorage']) {
+    try {
+      // Leave working browser storage alone. Sandboxed opaque origins throw
+      // here before a generated page can even register its event handlers.
+      void window[name].length;
+    } catch {
+      const storage = createStorage();
+      Object.defineProperty(window, name, { configurable: true, enumerable: true, get: () => storage });
+    }
+  }
+})();
+</script>`
+
+/** Add compatibility only to the rendered copy, preserving the original source. */
+export function buildHtmlPreview(html: string): string {
+  // Keep the doctype first (standards mode), and use an existing head when
+  // present. Only inspect the document prefix: text resembling tags inside
+  // comments, scripts or the body must never become an insertion point.
+  const trivia = String.raw`(?:\s|<!--[\s\S]*?-->)*`
+  const attributes = String.raw`(?:[^<>"']|"[^"]*"|'[^']*')*`
+  const prefix = new RegExp(
+    `^${trivia}(?:<!doctype\\b${attributes}>${trivia})?(?:<html\\b${attributes}>${trivia})?(?:<head\\b${attributes}>)?`,
+    'i',
+  ).exec(html)?.[0] ?? ''
+  return prefix + storageBootstrap + html.slice(prefix.length)
+}


### PR DESCRIPTION
Generated HTML artifacts that read `localStorage` during startup can fail before registering their controls because the preview iframe has an opaque origin. A generated 2048 page, for example, displayed its layout but could not initialize the board or respond to New Game.

Add a preview-only bootstrap that supplies independent in-memory `localStorage` and `sessionStorage` when browser storage is unavailable. It supports common storage methods and property access, runs before artifact scripts, and keeps the document doctype intact. Original files, source previews, downloads, and the existing `sandbox="allow-scripts"` boundary remain unchanged. Storage is temporary and resets when the frame reloads.

Validation:
- Frontend test suite, type check, and production build.
- Regression coverage for startup/event registration, storage operations, frame isolation, source preservation, and sandbox permissions.
- Chrome comparison using the original 2048 file in Blob-backed iframes with the same sandbox settings: the original fails with a storage SecurityError; the compatible preview initializes, responds to New Game and arrow keys, and updates its best score. Parent-document and cookie access remain blocked.
