### PR TITLE
fix(chunk): hard-delete chunks on whole-document teardown

### DIFF
--- a/internal/application/repository/chunk.go
+++ b/internal/application/repository/chunk.go
@@ -543,9 +543,27 @@ func (r *chunkRepository) DeleteChunks(ctx context.Context, tenantID uint64, ids
 	return nil
 }
 
-// DeleteChunksByKnowledgeID deletes all chunks for a knowledge ID
+// DeleteChunksByKnowledgeID deletes all chunks for a knowledge ID.
+//
+// Hard delete (Unscoped) on purpose. This is a whole-document teardown, used by
+// three paths that all destroy the document's retrievability in the same breath:
+// knowledge deletion, KB deletion, and the idempotent cleanup that runs at the
+// top of every (re)parse in processChunks. Every one of them also calls
+// retrieveEngine.DeleteByKnowledgeIDList, which hard-deletes the corresponding
+// vectors — so a soft-deleted chunk left behind is not recoverable in any
+// meaningful sense, it is just a dead row.
+//
+// Left as a soft delete, the rows accumulate forever: nothing purges them and
+// no read path ever passes Unscoped() to see them again. Re-parsing a single
+// document N times leaves N generations of its chunks behind.
+//
+// seq_id stays safe under a hard delete: Postgres/MySQL take it from a DB
+// sequence, which never reuses a value. Only SQLite derives it from
+// MAX(seq_id)+1 (see types.AssignChunkSeqIDs), so there the external ids of
+// deleted chunks can be handed out again — harmless for uniqueness, since the
+// rows holding them are gone.
 func (r *chunkRepository) DeleteChunksByKnowledgeID(ctx context.Context, tenantID uint64, knowledgeID string) error {
-	return r.db.WithContext(ctx).Where(
+	return r.db.WithContext(ctx).Unscoped().Where(
 		"tenant_id = ? AND knowledge_id = ?", tenantID, knowledgeID,
 	).Delete(&types.Chunk{}).Error
 }
@@ -564,9 +582,11 @@ func (r *chunkRepository) ListImageInfoByKnowledgeIDs(
 	return results, err
 }
 
-// DeleteByKnowledgeList deletes all chunks for a knowledge list
+// DeleteByKnowledgeList deletes all chunks for a knowledge list.
+// Hard delete for the same reason as DeleteChunksByKnowledgeID — this is the
+// batch variant of the same whole-document teardown.
 func (r *chunkRepository) DeleteByKnowledgeList(ctx context.Context, tenantID uint64, knowledgeIDs []string) error {
-	return r.db.WithContext(ctx).Where(
+	return r.db.WithContext(ctx).Unscoped().Where(
 		"tenant_id = ? AND knowledge_id in ?", tenantID, knowledgeIDs,
 	).Delete(&types.Chunk{}).Error
 }

--- a/internal/application/repository/chunk_sqlite_test.go
+++ b/internal/application/repository/chunk_sqlite_test.go
@@ -361,3 +361,63 @@ func TestListRecentDocumentChunksWithQuestions_UnionsExplicitKBAndKnowledge(t *t
 	require.Len(t, got, 2)
 	assert.ElementsMatch(t, []string{fromExplicitKB.ID, fromExplicitDocument.ID}, []string{got[0].ID, got[1].ID})
 }
+// TestDeleteChunksByKnowledgeID_HardDeletes guards the whole-document teardown
+// paths against regressing to GORM's soft delete. A soft delete leaves the rows
+// in place forever — nothing purges them and no read path passes Unscoped() —
+// so re-parsing a document repeatedly grows the table without bound.
+func TestDeleteChunksByKnowledgeID_HardDeletes(t *testing.T) {
+	db := setupChunkTestDB(t)
+	repo := NewChunkRepository(db)
+	ctx := context.Background()
+
+	kbID := uuid.New().String()
+	knowledgeID := uuid.New().String()
+	other := uuid.New().String()
+
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{
+		makeChunk(kbID, knowledgeID, "text"),
+		makeChunk(kbID, knowledgeID, "text"),
+		makeChunk(kbID, other, "text"),
+	}))
+
+	require.NoError(t, repo.DeleteChunksByKnowledgeID(ctx, 1, knowledgeID))
+
+	// Unscoped: the rows must be gone from the table, not just filtered out.
+	var remaining int64
+	require.NoError(t, db.Unscoped().Model(&types.Chunk{}).
+		Where("knowledge_id = ?", knowledgeID).Count(&remaining).Error)
+	assert.Zero(t, remaining, "chunks should be hard-deleted, not soft-deleted")
+
+	// Sibling knowledge in the same KB is untouched.
+	var untouched int64
+	require.NoError(t, db.Unscoped().Model(&types.Chunk{}).
+		Where("knowledge_id = ?", other).Count(&untouched).Error)
+	assert.EqualValues(t, 1, untouched)
+}
+
+// TestDeleteByKnowledgeList_HardDeletes is the batch variant of the guard above.
+func TestDeleteByKnowledgeList_HardDeletes(t *testing.T) {
+	db := setupChunkTestDB(t)
+	repo := NewChunkRepository(db)
+	ctx := context.Background()
+
+	kbID := uuid.New().String()
+	k1, k2, keep := uuid.New().String(), uuid.New().String(), uuid.New().String()
+
+	require.NoError(t, repo.CreateChunks(ctx, []*types.Chunk{
+		makeChunk(kbID, k1, "text"),
+		makeChunk(kbID, k2, "text"),
+		makeChunk(kbID, keep, "text"),
+	}))
+
+	require.NoError(t, repo.DeleteByKnowledgeList(ctx, 1, []string{k1, k2}))
+
+	var remaining int64
+	require.NoError(t, db.Unscoped().Model(&types.Chunk{}).
+		Where("knowledge_id IN ?", []string{k1, k2}).Count(&remaining).Error)
+	assert.Zero(t, remaining, "chunks should be hard-deleted, not soft-deleted")
+
+	var total int64
+	require.NoError(t, db.Unscoped().Model(&types.Chunk{}).Count(&total).Error)
+	assert.EqualValues(t, 1, total)
+}


### PR DESCRIPTION
## Problem

`DeleteChunksByKnowledgeID` and `DeleteByKnowledgeList` use GORM's soft delete, so the rows stay in the `chunks` table with `deleted_at` set. Nothing ever purges them, and no read path passes `Unscoped()` to see them again — they are pure dead weight.

The soft delete also buys no recoverability. All three callers destroy the document's retrievability in the same breath:

- knowledge deletion (`knowledge_delete.go`)
- KB deletion (`ProcessKBDelete`)
- the idempotent cleanup at the top of every (re)parse (`processChunks`)

and each of them also calls `retrieveEngine.DeleteByKnowledgeIDList`, which **hard**-deletes the corresponding vectors. A chunk left behind without its embedding cannot be restored into anything useful.

## Impact

This is not theoretical. On one instance the `chunks` table held:

| | rows |
|---|---|
| owning knowledge already deleted | **2,387,890** |
| live | 52,428 |

98% dead, 4.3 GB of table. Re-parsing is the bigger contributor of the two paths — every reparse leaves another full generation of the document's chunks behind, so a document parsed N times accumulates N generations.

## Prior art in this repo

The repository already draws exactly this distinction one level up. From `knowledge.go`:

```go
// HardDeleteKnowledge physically removes a knowledge row. Call it AFTER
// DeleteKnowledge's soft-delete cascade so sync-internal deletions never
// become tombstones that block a later re-sync of the same external item.
```

That reasoning was simply never carried down to the chunks the knowledge owns.

## Change

Add `Unscoped()` to the two whole-document teardown paths. Deliberately scoped to those two — the single-chunk and tag-scoped deletes (`DeleteChunk`, `DeleteChunks`, `DeleteChunksByTagID`) are user-facing, low-volume, and left as soft deletes.

## Is `seq_id` safe?

Yes. `seq_id` carries a `UNIQUE` index and is user-visible for FAQ entries, so it is worth spelling out:

- **Postgres / MySQL** take it from a DB sequence, which never reuses a value → no change in behaviour.
- **SQLite** derives it from `MAX(seq_id)+1` (`types.AssignChunkSeqIDs`, only invoked when `Dialector.Name() == "sqlite"`). There the external ids of deleted chunks can be handed out again — harmless for uniqueness, since the rows holding them are gone.

## Tests

Two regression tests in the existing SQLite harness. They assert through `db.Unscoped().Count()`, so a return to soft delete **fails** the test rather than passing silently, and they check that sibling knowledge in the same KB is untouched.

```
--- PASS: TestDeleteChunksByKnowledgeID_HardDeletes
--- PASS: TestDeleteByKnowledgeList_HardDeletes
```

`go build ./...` and the full `internal/application/repository/...` suite pass.
