### PR TITLE
fix(agent-share): resolve own-workspace selector as a local agent

### DIFF
--- a/internal/application/service/agent_share.go
+++ b/internal/application/service/agent_share.go
@@ -464,7 +464,26 @@ func (s *agentShareService) GetSharedAgentForTenant(
 	}
 	if len(sourceTenantID) > 0 && sourceTenantID[0] != 0 {
 		if sourceTenantID[0] == tenantID {
-			return nil, ErrAgentShareNotFound
+			// The selector names the caller's own workspace. Such an agent is
+			// reachable directly and never has a share record for its own
+			// workspace (GetShareByAgentIDForTenant deliberately excludes
+			// source_tenant_id == tenantID), so resolve it locally instead of
+			// reporting a missing share. Clients legitimately echo the owning
+			// workspace back for their own agents, and older links / persisted
+			// session state keep sending it.
+			agent, err := s.agentRepo.GetAgentByID(ctx, agentID, tenantID)
+			if err != nil {
+				if errors.Is(err, repository.ErrCustomAgentNotFound) {
+					return nil, ErrAgentNotFoundForShare
+				}
+				return nil, err
+			}
+			if agent == nil {
+				return nil, ErrAgentNotFoundForShare
+			}
+			types.ApplyBuiltinAgentLocalization(ctx, agent)
+			_ = callerTenantRole
+			return agent, nil
 		}
 		share, err := s.shareRepo.GetShareByAgentIDAndSourceForTenant(ctx, tenantID, agentID, sourceTenantID[0])
 		if err != nil {

--- a/internal/handler/session/qa.go
+++ b/internal/handler/session/qa.go
@@ -562,11 +562,20 @@ func (h *Handler) resolveAgent(
 		var err error
 		agent, err = h.agentShareService.GetSharedAgentForTenant(ctx, currentTenantID, callerTenantRole, agentID, sourceTenantID)
 		if err == nil && agent != nil {
-			effectiveTenantID = agent.TenantID
 			customAgent = agent
-			sharedAgentReadOnly = true
-			logger.Infof(ctx, "Using shared agent: ID=%s, Name=%s, effectiveTenantID=%d (retrieval scope)",
-				customAgent.ID, customAgent.Name, effectiveTenantID)
+			if agent.TenantID == currentTenantID {
+				// The selector named the caller's own workspace, so the share
+				// resolver handed back an own agent. Keep local semantics: run
+				// in the caller's tenant (effective 0 = context tenant) and stay
+				// writable, because an own agent is not a read-only share.
+				logger.Infof(ctx, "Using own agent selected by own-workspace id: ID=%s, Name=%s, AgentMode=%s",
+					customAgent.ID, customAgent.Name, customAgent.Config.AgentMode)
+			} else {
+				effectiveTenantID = agent.TenantID
+				sharedAgentReadOnly = true
+				logger.Infof(ctx, "Using shared agent: ID=%s, Name=%s, effectiveTenantID=%d (retrieval scope)",
+					customAgent.ID, customAgent.Name, effectiveTenantID)
+			}
 		}
 	}
 

--- a/internal/handler/session/resolve_agent_test.go
+++ b/internal/handler/session/resolve_agent_test.go
@@ -189,3 +189,24 @@ func TestTerminalProvisionConfigID_UsesSharedAgentSandboxConfig(t *testing.T) {
 		"lookup-only connects must not resolve an agent config")
 	require.Equal(t, "shared-cfg", h.terminalProvisionConfigID(ctx, c, true))
 }
+
+// A selector naming the caller's own workspace is not a share. The share
+// resolver hands back the caller's own agent for that input (see
+// agentShareService.GetSharedAgentForTenant), and the handler must keep local,
+// writable semantics: effective tenant 0 (= context tenant) and read-only off.
+// Regression guard for chats that deep-link / restore agent_source_tenant_id
+// equal to their own workspace, which used to 404 with "Shared agent not found".
+func TestResolveAgent_TreatsOwnWorkspaceSelectorAsLocalAgent(t *testing.T) {
+	c, ctx := newResolveAgentTestContext(7)
+	ownAgent := &types.CustomAgent{ID: "builtin-smart-reasoning", TenantID: 7, Name: "Own"}
+	h := &Handler{
+		agentShareService:  &resolveAgentShareStub{agent: ownAgent},
+		customAgentService: &resolveOwnAgentStub{agent: ownAgent},
+	}
+
+	agent, effectiveTenantID, sharedReadOnly := h.resolveAgent(ctx, c, "builtin-smart-reasoning", 7)
+
+	require.Equal(t, ownAgent, agent)
+	require.Equal(t, uint64(0), effectiveTenantID)
+	require.False(t, sharedReadOnly)
+}


### PR DESCRIPTION
<!-- Title: fix(agent-share): resolve own-workspace selector as a local agent -->

## Description

A request carrying `agent_source_tenant_id` equal to the caller's own tenant is not a share request, but the backend treated it as one and rejected it. `GetSharedAgentForTenant` returned `ErrAgentShareNotFound` because an own-workspace agent never has a share row for its own workspace — `GetShareByAgentIDForTenant` deliberately excludes `source_tenant_id == tenantID`.

Since clients persist the selector together with the conversation (deep-link query / restored `last_request_state`) and resend it on every message, such conversations failed permanently:

- `POST /api/v1/agent-chat/:session` → `404 Shared agent not found`
- agent-scoped KB listing → `403 no permission for this shared agent`
- `POST /api/v1/sessions/:id/temporary-documents` → same `resolveAgent` guard

This change treats a self-referential selector as "no selector":

1. `agentShareService.GetSharedAgentForTenant` resolves the caller's own agent via `agentRepo.GetAgentByID(ctx, agentID, tenantID)` and applies builtin localization, mirroring the genuine cross-workspace branch right below it. A genuinely missing agent still maps to `ErrAgentNotFoundForShare`.
2. `session.Handler.resolveAgent` recognizes the returned own agent (`agent.TenantID == caller tenant`) and keeps local semantics: `effectiveTenantID = 0` (context tenant) and read-only off, instead of flagging an own agent as a read-only share.

Fix lives in `GetSharedAgentForTenant`, so every caller benefits without duplicated normalization: `resolveSharedAgentForRequest` (KB listing/search), `access.ResolveKB` and `access.ResolveFile`.

**Security review — no shared-agent path is widened:**

- Cross-workspace selectors still take the strict share lookup, so a revoked or unshared agent is never silently upgraded to a same-ID local agent.
- The KB list gate in `resolveSharedAgentForRequest` still requires the resolved agent to match the requested source (`internal/handler/shared_agent_access.go:45`), which now means "the agent really is owned by the requested workspace".
- KB scope stays tenant-bound: `types.SharedAgentKBScope.Allows` requires `scope.tenantID == kb.TenantID` (`internal/types/shared_agent_access.go:49-55`), so for a self-referential selector the KBs of another tenant remain denied. `internal/application/access/knowledgebase.go` only reaches its shared-agent branch for another tenant's KB (own-tenant KBs are granted earlier, lines 117-119).
- `internal/application/access/files.go:196` passes the resource owner as the selector and only runs when `owner != caller.TenantID`, so it cannot hit the self-referential case.
- Callers that previously got an error now get the agent the caller already owns; no new agent (and no new tenant) becomes reachable.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #3161

## Testing

Scoped checks (from the repository root, on top of `origin/main`):

```bash
git diff --check origin/main...HEAD
gofmt -l internal/application/service/agent_share.go internal/handler/session/qa.go internal/handler/session/resolve_agent_test.go
go build ./...
golangci-lint run --new-from-rev=origin/main ./...
go test ./internal/handler/session/ -run 'TestResolveAgent|TestTerminalProvisionConfigID' -count=1
go test ./internal/application/service/ ./internal/middleware/ -run 'SharedAgent|Share|KBAccess' -count=1
```

Results:

- `git diff --check` — clean.
- `gofmt -l` — no output (changed files formatted).
- `go build ./...` — exit 0.
- `golangci-lint run --new-from-rev=origin/main ./...` (v2.12.2, the version pinned in `go-lint.yml`) — `0 issues`.
- `go test ./internal/handler/session/ ...` — ok.
- `go test ./internal/application/service/ ./internal/middleware/ -run 'SharedAgent|Share|KBAccess'` — ok.

New regression test `TestResolveAgent_TreatsOwnWorkspaceSelectorAsLocalAgent` asserts that a self-referential selector yields the local agent with `effectiveTenantID == 0` and `sharedReadOnly == false`. The existing `TestResolveAgent_RejectsInvalidSharedSelectorWithoutLocalFallback` still covers the cross-workspace rejection, so the strict path is pinned from both sides.

Reproduction check on `main` before the change (no source modification): the same requests return 404/403 as described in the linked issue.

Unrelated failures observed while validating (present on `origin/main` without this change, verified in a clean worktree):

- `TestSkillPythonVerifier` and `TestCleanImageScratchCommandShape` in `internal/application/service` fail because they need sandbox/venv infrastructure that is unavailable in my environment. `TestSkillPythonVerifier` fails identically on a pristine `origin/main` checkout (`5db13a1`).

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (not applicable — no public API, config or doc surface change)
- [x] Breaking changes are clearly called out in the description above (none)

## Screenshots / Recordings

Not applicable — backend-only change with no UI surface change.
