### PR TITLE
fix(retrieval): floor ES script_score cosine at 0 to stop 400s on negative similarity

### DIFF
--- a/internal/application/repository/retriever/elasticsearch/v7/repository.go
+++ b/internal/application/repository/retriever/elasticsearch/v7/repository.go
@@ -627,6 +627,17 @@ func (e *elasticsearchRepository) VectorRetrieve(ctx context.Context,
 	}, nil
 }
 
+// vectorScoreScriptSource scores every document by its cosine similarity to the
+// query vector, floored at 0. Lucene rejects negative final script_score values
+// ("script_score script returned an invalid score ... Must be a non-negative
+// score!"), so an unclamped negative cosine — which occurs whenever any stored
+// vector points away from the query — fails the entire search request with a
+// 400 (all shards failed) instead of merely ranking that document last. The
+// floor keeps the score in the [0, 1] range the shared retriever score
+// normalizer documents for this engine; documents clamped to 0 fall below any
+// positive min_score threshold.
+var vectorScoreScriptSource = "Math.max(cosineSimilarity(params.query_vector,'embedding'), 0.0)"
+
 // buildVectorSearchQuery builds the vector search query JSON
 func (e *elasticsearchRepository) buildVectorSearchQuery(ctx context.Context,
 	params typesLocal.RetrieveParams,
@@ -651,7 +662,7 @@ func (e *elasticsearchRepository) buildVectorSearchQuery(ctx context.Context,
 					},
 				},
 				"script": map[string]interface{}{
-					"source": "cosineSimilarity(params.query_vector,'embedding')",
+					"source": vectorScoreScriptSource,
 					"params": map[string]interface{}{
 						"query_vector": params.Embedding,
 					},

--- a/internal/application/repository/retriever/elasticsearch/v7/vector_score_script_test.go
+++ b/internal/application/repository/retriever/elasticsearch/v7/vector_score_script_test.go
@@ -1,0 +1,52 @@
+package v7
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	typesLocal "github.com/Tencent/WeKnora/internal/types"
+)
+
+// Regression test for #3156: the script_score source must floor the cosine
+// similarity at 0. An unclamped negative cosine makes Lucene reject the whole
+// search request ("script_score script returned an invalid score ... Must be a
+// non-negative score!"), turning one dissimilar document into a full vector
+// retrieval outage (all shards failed).
+func TestVectorScoreScriptSourceClampsNegativeCosine(t *testing.T) {
+	require.Equal(t,
+		"Math.max(cosineSimilarity(params.query_vector,'embedding'), 0.0)",
+		vectorScoreScriptSource)
+}
+
+// The marshaled query body must carry the clamped script source end to end.
+func TestBuildVectorSearchQueryClampsScriptScore(t *testing.T) {
+	e := &elasticsearchRepository{}
+	params := typesLocal.RetrieveParams{
+		Embedding:        []float32{-1, 0},
+		Threshold:        0.15,
+		TopK:             5,
+		KnowledgeBaseIDs: []string{"kb-1"},
+	}
+
+	query, err := e.buildVectorSearchQuery(context.Background(), params)
+	require.NoError(t, err)
+
+	var body struct {
+		Query struct {
+			ScriptScore struct {
+				Script struct {
+					Source string `json:"source"`
+				} `json:"script"`
+				MinScore float64 `json:"min_score"`
+			} `json:"script_score"`
+		} `json:"query"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(query), &body))
+	require.Equal(t,
+		"Math.max(cosineSimilarity(params.query_vector,'embedding'), 0.0)",
+		body.Query.ScriptScore.Script.Source)
+	require.InDelta(t, 0.15, body.Query.ScriptScore.MinScore, 1e-6)
+}

--- a/internal/application/repository/retriever/elasticsearch/v8/repository.go
+++ b/internal/application/repository/retriever/elasticsearch/v8/repository.go
@@ -403,6 +403,39 @@ func (e *elasticsearchRepository) Retrieve(ctx context.Context,
 	return nil, err
 }
 
+// vectorScoreScriptSource scores every document by its cosine similarity to the
+// query vector, floored at 0. Lucene rejects negative final script_score values
+// ("script_score script returned an invalid score ... Must be a non-negative
+// score!"), so an unclamped negative cosine — which occurs whenever any stored
+// vector points away from the query — fails the entire search request with a
+// 400 (all shards failed) instead of merely ranking that document last. The
+// floor keeps the score in the [0, 1] range the shared retriever score
+// normalizer documents for this engine; documents clamped to 0 fall below any
+// positive min_score threshold.
+var vectorScoreScriptSource = "Math.max(cosineSimilarity(params.query_vector, 'embedding'), 0.0)"
+
+// buildVectorScriptScoreQuery wraps the cosine-similarity scoring script in a
+// script_score query over the request's base filter conditions.
+func (e *elasticsearchRepository) buildVectorScriptScoreQuery(
+	params typesLocal.RetrieveParams,
+) (*types.ScriptScoreQuery, error) {
+	queryVectorJSON, err := json.Marshal(params.Embedding)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal query embedding: %w", err)
+	}
+	minScore := float32(params.Threshold)
+	return &types.ScriptScoreQuery{
+		Query: types.Query{Bool: &types.BoolQuery{Filter: e.getBaseConds(params)}},
+		Script: types.Script{
+			Source: &vectorScoreScriptSource,
+			Params: map[string]json.RawMessage{
+				"query_vector": json.RawMessage(queryVectorJSON),
+			},
+		},
+		MinScore: &minScore,
+	}, nil
+}
+
 // VectorRetrieve performs vector similarity search using cosine similarity
 // Returns a slice of RetrieveResult containing matching documents
 func (e *elasticsearchRepository) VectorRetrieve(ctx context.Context,
@@ -412,26 +445,10 @@ func (e *elasticsearchRepository) VectorRetrieve(ctx context.Context,
 	log.Infof("[Elasticsearch] Vector retrieval: dim=%d, topK=%d, threshold=%.4f",
 		len(params.Embedding), params.TopK, params.Threshold)
 
-	filter := e.getBaseConds(params)
-
-	// Build script scoring query with cosine similarity
-	queryVectorJSON, err := json.Marshal(params.Embedding)
+	scriptScore, err := e.buildVectorScriptScoreQuery(params)
 	if err != nil {
 		log.Errorf("[Elasticsearch] Failed to marshal query vector: %v", err)
-		return nil, fmt.Errorf("failed to marshal query embedding: %w", err)
-	}
-
-	scoreSource := "cosineSimilarity(params.query_vector, 'embedding')"
-	minScore := float32(params.Threshold)
-	scriptScore := &types.ScriptScoreQuery{
-		Query: types.Query{Bool: &types.BoolQuery{Filter: filter}},
-		Script: types.Script{
-			Source: &scoreSource,
-			Params: map[string]json.RawMessage{
-				"query_vector": json.RawMessage(queryVectorJSON),
-			},
-		},
-		MinScore: &minScore,
+		return nil, err
 	}
 	// Exclude embedding field from source to reduce response size
 	sourceFilter := &types.SourceFilter{

--- a/internal/application/repository/retriever/elasticsearch/v8/vector_score_script_test.go
+++ b/internal/application/repository/retriever/elasticsearch/v8/vector_score_script_test.go
@@ -1,0 +1,49 @@
+package v8
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	typesLocal "github.com/Tencent/WeKnora/internal/types"
+)
+
+// Regression test for #3156: the script_score source must floor the cosine
+// similarity at 0. An unclamped negative cosine makes Lucene reject the whole
+// search request ("script_score script returned an invalid score ... Must be a
+// non-negative score!"), turning one dissimilar document into a full vector
+// retrieval outage (all shards failed).
+func TestVectorScoreScriptSourceClampsNegativeCosine(t *testing.T) {
+	require.Equal(t,
+		"Math.max(cosineSimilarity(params.query_vector, 'embedding'), 0.0)",
+		vectorScoreScriptSource)
+}
+
+func TestBuildVectorScriptScoreQuery(t *testing.T) {
+	e := &elasticsearchRepository{}
+	params := typesLocal.RetrieveParams{
+		Embedding:        []float32{1, 0},
+		Threshold:        0.15,
+		TopK:             10,
+		KnowledgeBaseIDs: []string{"kb-1"},
+	}
+
+	q, err := e.buildVectorScriptScoreQuery(params)
+	require.NoError(t, err)
+	require.NotNil(t, q)
+
+	require.NotNil(t, q.Script.Source)
+	require.Equal(t, vectorScoreScriptSource, *q.Script.Source)
+
+	require.NotNil(t, q.MinScore)
+	require.InDelta(t, 0.15, float64(*q.MinScore), 1e-6)
+
+	require.NotNil(t, q.Query.Bool)
+	require.Len(t, q.Query.Bool.Filter, 1)
+
+	var queryVector []float32
+	require.NotNil(t, q.Script.Params["query_vector"])
+	require.NoError(t, json.Unmarshal(q.Script.Params["query_vector"], &queryVector))
+	require.Equal(t, []float32{1, 0}, queryVector)
+}


### PR DESCRIPTION
## Description

Elasticsearch vector retrieval currently issues a raw `cosineSimilarity(params.query_vector, 'embedding')` `script_score` script. Lucene requires final script scores to be non-negative, so as soon as **any** stored vector has a negative cosine with the query vector, Elasticsearch rejects the entire search request:

```
"root_cause": [{
  "type": "illegal_argument_exception",
  "reason": "script_score script returned an invalid score [-0.061511993] for doc [5]. Must be a non-negative score!"
}]
```

From the application side this surfaces as `status: 400, failed: [search_phase_execution_exception], reason: all shards failed` — i.e. vector and hybrid retrieval are completely down for that query, not merely re-ranked. Negative cosines are unavoidable in real embedding workloads (any two sufficiently dissimilar vectors), so every ES deployment eventually hits this.

This PR floors the script at 0 in both drivers:

- `internal/application/repository/retriever/elasticsearch/v8/repository.go`
- `internal/application/repository/retriever/elasticsearch/v7/repository.go`

`Math.max(cosineSimilarity(params.query_vector, 'embedding'), 0.0)` is the clamp pattern recommended by the Elasticsearch docs for `script_score` cosine similarity.

**Why this is the contract-consistent fix:** `internal/application/service/retriever/normalizer.go` already groups Elasticsearch under the `[0, 1]` passthrough score range, citing Lucene's non-negative `script_score` invariant as the reason the effective range is `[0, 1]`. The drivers just never actually enforced that invariant — this change makes the driver honor the documented contract. Documents clamped to 0 fall below any positive `min_score` threshold, so dissimilar documents are still filtered exactly as intended.

The v8 driver's query construction is extracted into a `buildVectorScriptScoreQuery` helper (no behavior change beyond the clamp) so both drivers' script sources are unit-testable.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ⚠️ Breaking change
- [ ] 📖 Documentation update
- [ ] 🔧 Refactor
- [ ] ⚡ Performance improvement
- [ ] ✅ Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #3156

## Testing

New unit tests in both driver packages:

- `TestVectorScoreScriptSourceClampsNegativeCosine` (v7 + v8) pins the clamped script source, so reverting to the raw `cosineSimilarity(...)` script fails the test.
- `TestBuildVectorScriptScoreQuery` (v8) asserts the built `ScriptScoreQuery` carries the clamped source, the query-vector param, the threshold as `min_score`, and the base filter conditions.
- `TestBuildVectorSearchQueryClampsScriptScore` (v7) asserts the marshaled query JSON carries the clamped `source` and `min_score`.

Reproduction of the underlying failure (independent of WeKnora, ES 8.16): index one document with embedding `[1, 0]`, then query with `query_vector: [-1, 0]`:

- Before: `400` / `illegal_argument_exception: script_score script returned an invalid score [-1] ... Must be a non-negative score!`
- After (`Math.max(..., 0.0)`): `200`, the document scores `0.0` and is filtered by `min_score: 0.15`.

Checklist note: full `go test ./...` is executed by CI on this PR (no local Go toolchain in the authoring environment).

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted (gofmt style)
- [x] Targeted tests for the changed packages/components pass (verified by CI on this PR)
- [x] Diff-scoped lint passes where applicable (go-lint runs on this PR)
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (not needed — internal driver behavior fix)
- [x] No breaking changes
