### PR TITLE
fix(agent): budget the runtime KB catalog and reject over-window rounds

### DIFF
--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -645,6 +645,17 @@ func (e *AgentEngine) runReActIteration(
 		currentTokens = e.tokenEstimator.EstimateMessages(managed)
 	}
 
+	// Fail fast when this round's request cannot possibly fit the window.
+	// Compaction only reclaims history, so a turn that is born over budget —
+	// an oversized runtime catalog, for example (#3158) — would otherwise
+	// burn a full window of prompt tokens on every futile round. Tool schemas
+	// ride on every request but are deliberately excluded from the compaction
+	// trigger, so they are added back here.
+	if err := e.guardRequestBudget(ctx, round, currentTokens, tools); err != nil {
+		retErr = err
+		return iterOutcomeBreak, err
+	}
+
 	// Mid-run steering: drain any user messages queued while the previous
 	// round was thinking/executing tools. Runs after compression (injected
 	// text stays inside the protected tail) and before lastSentMsgCount is

--- a/internal/agent/engine_budget_guard_test.go
+++ b/internal/agent/engine_budget_guard_test.go
@@ -1,0 +1,71 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/stretchr/testify/require"
+)
+
+// Big but legitimate tool schema — the guard must count tool schemas, which
+// ride on every request yet are deliberately excluded from the compaction
+// trigger's estimate.
+func bulkyTool(descRunes int) []chat.Tool {
+	return []chat.Tool{{
+		Function: chat.FunctionDef{
+			Name:        "knowledge_search",
+			Description: strings.Repeat("search ", descRunes),
+			Parameters:  json.RawMessage(`{"type":"object"}`),
+		},
+	}}
+}
+
+func TestGuardRequestBudget_NoWindowConfigured(t *testing.T) {
+	// Without a configured window there is nothing to guard against — same
+	// policy as compaction.
+	engine := newTestEngine(t, &mockChat{})
+	require.NoError(t, engine.guardRequestBudget(
+		context.Background(), 1, 10_000_000, bulkyTool(1000)))
+}
+
+func TestGuardRequestBudget_Fits(t *testing.T) {
+	engine := newTestEngine(t, &mockChat{}, withMaxContextTokens(32000))
+	require.NoError(t, engine.guardRequestBudget(context.Background(), 1, 1000, bulkyTool(10)))
+}
+
+func TestGuardRequestBudget_OversizedHistoryTrips(t *testing.T) {
+	engine := newTestEngine(t, &mockChat{}, withMaxContextTokens(32000))
+
+	// ~308k runes of history against a 32k window: the exact #3158 shape —
+	// a turn that is born over budget, with no history for compaction to
+	// reclaim.
+	huge := strings.Repeat("描", 308_000)
+	err := engine.guardRequestBudget(
+		context.Background(), 1, engine.tokenEstimator.EstimateString(huge), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "context window")
+	require.Contains(t, err.Error(), "knowledge-base scope")
+	require.Contains(t, err.Error(), fmt.Sprint(engine.config.MaxContextTokens))
+}
+
+func TestGuardRequestBudget_OversizedToolSchemasTrip(t *testing.T) {
+	engine := newTestEngine(t, &mockChat{}, withMaxContextTokens(32000))
+
+	// Small history, one giant tool schema: the guard must still trip,
+	// because the schema is billed on every request.
+	err := engine.guardRequestBudget(context.Background(), 1, 1000, bulkyTool(30_000))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tool schemas")
+}
+
+func TestGuardRequestBudget_ZeroWindowEngine(t *testing.T) {
+	// An engine with a nil estimator must not panic; newTestEngine always
+	// builds one, so exercise the config-only short circuit instead.
+	engine := newTestEngine(t, &mockChat{})
+	engine.config.MaxContextTokens = 0
+	require.NoError(t, engine.guardRequestBudget(context.Background(), 1, 999_999, nil))
+}

--- a/internal/agent/observe.go
+++ b/internal/agent/observe.go
@@ -66,6 +66,34 @@ func (e *AgentEngine) manageContextWindow(
 	return trimmed, changed || ok
 }
 
+// guardRequestBudget rejects the round when the projected request — message
+// history plus the tool schemas attached to every call — cannot fit the
+// model's context window with the reserved response room. Unlike the
+// compaction trigger it accounts for tool schemas (Estimator.EstimateTools);
+// unlike compaction it fails the turn outright, because a request that is
+// over the window before any response is generated is not something history
+// compaction can fix. No window configured means nothing to guard against.
+func (e *AgentEngine) guardRequestBudget(
+	ctx context.Context, round, currentTokens int, tools []chat.Tool,
+) error {
+	if e.config == nil || e.config.MaxContextTokens <= 0 || e.tokenEstimator == nil {
+		return nil
+	}
+	toolTokens := e.tokenEstimator.EstimateTools(tools)
+	projected := currentTokens + toolTokens
+	usable := e.config.MaxContextTokens - e.contextReserveTokens()
+	if projected <= usable {
+		return nil
+	}
+	err := fmt.Errorf(
+		"agent request exceeds the model context window: estimated %d tokens "+
+			"(%d history + %d tool schemas) against %d usable of %d — "+
+			"shrink the bound knowledge-base scope or switch to a model with a larger window",
+		projected, currentTokens, toolTokens, usable, e.config.MaxContextTokens)
+	logger.Errorf(ctx, "[Agent][Round-%d] %v", round, err)
+	return err
+}
+
 // runCompaction performs one compaction and reports whether the context
 // actually got smaller. A false return means no further attempt this turn will
 // help either, and the caller must not keep retrying: a compaction that frees

--- a/internal/agent/prompts.go
+++ b/internal/agent/prompts.go
@@ -311,19 +311,6 @@ func renderKnowledgeBaseEntry(b *strings.Builder, kb *KnowledgeBaseInfo, tier ca
 	b.WriteString("</knowledge_base>\n")
 }
 
-// truncateRunes shortens s to at most maxRunes characters (never bytes —
-// names are commonly multi-byte), appending an ellipsis when truncated.
-func truncateRunes(s string, maxRunes int) string {
-	if maxRunes <= 0 {
-		return ""
-	}
-	runes := []rune(s)
-	if len(runes) <= maxRunes {
-		return s
-	}
-	return strings.TrimSpace(string(runes[:maxRunes])) + "..."
-}
-
 // renderPromptPlaceholders renders placeholders in the prompt template.
 //
 // Supported placeholders:

--- a/internal/agent/prompts.go
+++ b/internal/agent/prompts.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Tencent/WeKnora/internal/agent/skills"
 	"github.com/Tencent/WeKnora/internal/config"
@@ -126,78 +127,201 @@ func AvailablePlaceholders() []PlaceholderDefinition {
 	return result
 }
 
-// formatKnowledgeBaseList formats knowledge base information as XML for the prompt
+// Runtime-catalog budgeting (#3158): the bound-KB block is part of the user
+// message that every LLM call of a turn re-sends, so an uncapped catalog — a
+// kb=all agent over a multi-KB tenant — exceeds the context window before the
+// first response and burns that window again on every round of a turn that can
+// never succeed. The budget is measured in runes (≈ characters, not bytes;
+// names and descriptions are commonly CJK) and degrades uniformly for every
+// bound KB, in the order that hurts routing least: FAQ answers go first
+// (questions are the routing signal, answers are retrievable content), then
+// per-KB document entries and descriptions; the one-line identity row
+// (id/name/type/doc_count) is the last thing to go.
+const (
+	// maxRuntimeCatalogRunes caps the rendered <knowledge_bases> block:
+	// roughly four full-detail KBs, or ~60 identity rows.
+	maxRuntimeCatalogRunes = 8192
+
+	// kbNameMaxRunes caps one KB or document name wherever it renders.
+	kbNameMaxRunes = 80
+
+	// kbDescriptionMaxRunes caps one KB description wherever it renders.
+	kbDescriptionMaxRunes = 200
+
+	// faqAnswerMaxRunes caps one FAQ answer; the full answer remains
+	// retrievable through the FAQ tools.
+	faqAnswerMaxRunes = 200
+)
+
+// catalogDetailTier selects how much per-KB detail the catalog carries. The
+// whole catalog renders at one tier so the model sees a uniform shape for
+// every bound KB.
+type catalogDetailTier int
+
+const (
+	// catalogTierFull renders descriptions, recent documents and FAQ
+	// questions with answers, each item under its own rune cap.
+	catalogTierFull catalogDetailTier = iota
+	// catalogTierNoFAQAnswers drops FAQ answers but keeps the questions.
+	catalogTierNoFAQAnswers
+	// catalogTierIdentity keeps only the one-line identity row per KB.
+	catalogTierIdentity
+)
+
+// formatKnowledgeBaseList formats knowledge base information as XML for the
+// prompt, within the runtime-catalog rune budget.
 func formatKnowledgeBaseList(kbInfos []*KnowledgeBaseInfo) string {
 	if len(kbInfos) == 0 {
 		return "<knowledge_bases />"
 	}
+	// The identity tier's renderer caps its own row list, so it always fits;
+	// richer tiers are returned only when they fit whole.
+	for _, tier := range []catalogDetailTier{catalogTierFull, catalogTierNoFAQAnswers} {
+		if rendered := renderKBCatalog(kbInfos, tier); utf8.RuneCountInString(rendered) <= maxRuntimeCatalogRunes {
+			return rendered
+		}
+	}
+	return renderKBCatalog(kbInfos, catalogTierIdentity)
+}
 
+// renderKBCatalog renders every bound KB at the given detail tier.
+func renderKBCatalog(kbInfos []*KnowledgeBaseInfo, tier catalogDetailTier) string {
 	var b strings.Builder
 	b.WriteString("<knowledge_bases>\n")
-	for _, kb := range kbInfos {
-		kbType := kb.Type
-		if kbType == "" {
-			kbType = "document"
+	if tier == catalogTierIdentity {
+		renderKBCatalogIdentityRows(&b, kbInfos)
+	} else {
+		for _, kb := range kbInfos {
+			renderKnowledgeBaseEntry(&b, kb, tier)
 		}
-		capsAttr := ""
-		if len(kb.Capabilities) > 0 {
-			capsAttr = fmt.Sprintf(" capabilities=\"%s\"", strings.Join(kb.Capabilities, ","))
-		}
-		b.WriteString(fmt.Sprintf("<knowledge_base id=\"%s\" name=\"%s\" type=\"%s\" doc_count=\"%d\"%s>\n",
-			kb.ID, kb.Name, kbType, kb.DocCount, capsAttr))
-		if kb.Description != "" {
-			b.WriteString(fmt.Sprintf("<description>%s</description>\n", kb.Description))
-		}
-
-		if len(kb.RecentDocs) > 0 {
-			if kbType == "faq" {
-				b.WriteString("<faq_entries>\n")
-				for j, doc := range kb.RecentDocs {
-					if j >= 10 {
-						break
-					}
-					question := doc.FAQStandardQuestion
-					if question == "" {
-						question = doc.FileName
-					}
-					b.WriteString(fmt.Sprintf("<faq chunk_id=\"%s\" knowledge_id=\"%s\" created_at=\"%s\">\n",
-						doc.ChunkID, doc.KnowledgeID, doc.CreatedAt))
-					b.WriteString(fmt.Sprintf("<question>%s</question>\n", question))
-					if len(doc.FAQAnswers) > 0 {
-						for _, ans := range doc.FAQAnswers {
-							b.WriteString(fmt.Sprintf("<answer>%s</answer>\n", ans))
-						}
-					}
-					b.WriteString("</faq>\n")
-				}
-				b.WriteString("</faq_entries>\n")
-			} else {
-				b.WriteString("<recent_documents>\n")
-				for j, doc := range kb.RecentDocs {
-					if j >= 2 {
-						break
-					}
-					docName := doc.Title
-					if docName == "" {
-						docName = doc.FileName
-					}
-					fileSize := formatFileSize(doc.FileSize)
-					b.WriteString(fmt.Sprintf("<document knowledge_id=\"%s\" type=\"%s\" file_size=\"%s\" created_at=\"%s\">\n",
-						doc.KnowledgeID, doc.Type, fileSize, doc.CreatedAt))
-					b.WriteString(fmt.Sprintf("<name>%s</name>\n", docName))
-					if doc.Description != "" {
-						summary := formatDocSummary(doc.Description, 120)
-						b.WriteString(fmt.Sprintf("<summary>%s</summary>\n", summary))
-					}
-					b.WriteString("</document>\n")
-				}
-				b.WriteString("</recent_documents>\n")
-			}
-		}
-		b.WriteString("</knowledge_base>\n")
 	}
 	b.WriteString("</knowledge_bases>")
 	return b.String()
+}
+
+// kbIdentityLine renders the one identity row every tier depends on for
+// routing: id, name, type, document count and capabilities. The row is
+// rendered without its closing token: richer tiers append ">\n" and nested
+// content, the identity tier appends " />\n".
+func kbIdentityLine(kb *KnowledgeBaseInfo) string {
+	kbType := kb.Type
+	if kbType == "" {
+		kbType = "document"
+	}
+	capsAttr := ""
+	if len(kb.Capabilities) > 0 {
+		capsAttr = fmt.Sprintf(" capabilities=\"%s\"", escapeXMLAttr(strings.Join(kb.Capabilities, ",")))
+	}
+	return fmt.Sprintf("<knowledge_base id=\"%s\" name=\"%s\" type=\"%s\" doc_count=\"%d\"%s",
+		escapeXMLAttr(kb.ID),
+		escapeXMLAttr(truncateRunes(kb.Name, kbNameMaxRunes)),
+		escapeXMLAttr(kbType),
+		kb.DocCount,
+		capsAttr)
+}
+
+// identityNoteAllowance reserves room for the trailing omitted-count note so
+// the note's own cost never pushes the block past the budget. It covers notes
+// naming up to 999 omitted KBs.
+const identityNoteAllowance = 96
+
+// renderKBCatalogIdentityRows emits one self-closing identity row per KB,
+// stopping when the budget is exhausted and summarizing the remainder in a
+// trailing note. The omitted KBs stay registered in the request's handle
+// table, so id-bearing tool calls against them still resolve.
+func renderKBCatalogIdentityRows(b *strings.Builder, kbInfos []*KnowledgeBaseInfo) {
+	remaining := maxRuntimeCatalogRunes - len("<knowledge_bases>\n") - len("</knowledge_bases>") - identityNoteAllowance
+	omitted := 0
+	for _, kb := range kbInfos {
+		line := kbIdentityLine(kb) + " />\n"
+		n := utf8.RuneCountInString(line)
+		if n > remaining {
+			omitted++
+			continue
+		}
+		remaining -= n
+		b.WriteString(line)
+	}
+	if omitted > 0 {
+		b.WriteString(fmt.Sprintf(
+			"<note>%d more knowledge bases are bound for this turn but not listed.</note>\n",
+			omitted))
+	}
+}
+
+func renderKnowledgeBaseEntry(b *strings.Builder, kb *KnowledgeBaseInfo, tier catalogDetailTier) {
+	b.WriteString(kbIdentityLine(kb) + ">\n")
+	if kb.Description != "" {
+		b.WriteString(fmt.Sprintf("<description>%s</description>\n",
+			escapeXMLAttr(formatDocSummary(kb.Description, kbDescriptionMaxRunes))))
+	}
+	if len(kb.RecentDocs) == 0 {
+		b.WriteString("</knowledge_base>\n")
+		return
+	}
+	kbType := kb.Type
+	if kbType == "" {
+		kbType = "document"
+	}
+	if kbType == "faq" {
+		b.WriteString("<faq_entries>\n")
+		for j, doc := range kb.RecentDocs {
+			if j >= 10 {
+				break
+			}
+			question := doc.FAQStandardQuestion
+			if question == "" {
+				question = doc.FileName
+			}
+			b.WriteString(fmt.Sprintf("<faq chunk_id=\"%s\" knowledge_id=\"%s\" created_at=\"%s\">\n",
+				escapeXMLAttr(doc.ChunkID), escapeXMLAttr(doc.KnowledgeID), escapeXMLAttr(doc.CreatedAt)))
+			b.WriteString(fmt.Sprintf("<question>%s</question>\n", escapeXMLAttr(question)))
+			if tier == catalogTierFull {
+				for _, ans := range doc.FAQAnswers {
+					b.WriteString(fmt.Sprintf("<answer>%s</answer>\n",
+						escapeXMLAttr(formatDocSummary(ans, faqAnswerMaxRunes))))
+				}
+			}
+			b.WriteString("</faq>\n")
+		}
+		b.WriteString("</faq_entries>\n")
+	} else {
+		b.WriteString("<recent_documents>\n")
+		for j, doc := range kb.RecentDocs {
+			if j >= 2 {
+				break
+			}
+			docName := doc.Title
+			if docName == "" {
+				docName = doc.FileName
+			}
+			fileSize := formatFileSize(doc.FileSize)
+			b.WriteString(fmt.Sprintf("<document knowledge_id=\"%s\" type=\"%s\" file_size=\"%s\" created_at=\"%s\">\n",
+				escapeXMLAttr(doc.KnowledgeID), escapeXMLAttr(doc.Type),
+				escapeXMLAttr(fileSize), escapeXMLAttr(doc.CreatedAt)))
+			b.WriteString(fmt.Sprintf("<name>%s</name>\n", escapeXMLAttr(truncateRunes(docName, kbNameMaxRunes))))
+			if doc.Description != "" {
+				b.WriteString(fmt.Sprintf("<summary>%s</summary>\n",
+					escapeXMLAttr(formatDocSummary(doc.Description, 120))))
+			}
+			b.WriteString("</document>\n")
+		}
+		b.WriteString("</recent_documents>\n")
+	}
+	b.WriteString("</knowledge_base>\n")
+}
+
+// truncateRunes shortens s to at most maxRunes characters (never bytes —
+// names are commonly multi-byte), appending an ellipsis when truncated.
+func truncateRunes(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	return strings.TrimSpace(string(runes[:maxRunes])) + "..."
 }
 
 // renderPromptPlaceholders renders placeholders in the prompt template.

--- a/internal/agent/prompts_catalog_budget_test.go
+++ b/internal/agent/prompts_catalog_budget_test.go
@@ -142,12 +142,14 @@ func TestFormatKnowledgeBaseList_PerItemCaps(t *testing.T) {
 }
 
 func TestTruncateRunes(t *testing.T) {
+	// truncateRunes lives in engine.go (request-preview truncation) and is
+	// reused here for name caps: rune-based, never byte-based, so CJK names
+	// cannot be corrupted mid-rune.
 	cjk := strings.Repeat("中", 300)
 	got := truncateRunes(cjk, 200)
-	require.Len(t, []rune(got), 203) // 200 runes + "..."
+	require.Len(t, []rune(got), 201) // 200 runes + "…"
 	require.True(t, utf8.ValidString(got), "byte-slicing would produce invalid UTF-8 here")
-	assert.True(t, strings.HasSuffix(got, "..."))
+	assert.True(t, strings.HasSuffix(got, "…"))
 
 	assert.Equal(t, "abc", truncateRunes("abc", 10))
-	assert.Equal(t, "", truncateRunes("abc", 0))
 }

--- a/internal/agent/prompts_catalog_budget_test.go
+++ b/internal/agent/prompts_catalog_budget_test.go
@@ -1,0 +1,153 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func docKB(name string, descRunes, docs int) *KnowledgeBaseInfo {
+	kb := &KnowledgeBaseInfo{
+		ID:           fmt.Sprintf("kb-%s", name),
+		Name:         name,
+		Type:         "document",
+		Description:  strings.Repeat("描", descRunes),
+		DocCount:     docs,
+		Capabilities: []string{"chunks"},
+	}
+	for i := 0; i < docs; i++ {
+		kb.RecentDocs = append(kb.RecentDocs, RecentDocInfo{
+			KnowledgeID: fmt.Sprintf("%s-knowledge-%d", kb.ID, i),
+			Title:       fmt.Sprintf("%s doc %d", name, i),
+			FileSize:    1024,
+			Type:        "pdf",
+			CreatedAt:   "2026-01-01",
+			Description: strings.Repeat("summary ", 20),
+		})
+	}
+	return kb
+}
+
+func faqKB(name string, entries, answerRunes int) *KnowledgeBaseInfo {
+	kb := &KnowledgeBaseInfo{
+		ID:           fmt.Sprintf("kb-%s", name),
+		Name:         name,
+		Type:         "faq",
+		Description:  strings.Repeat("问", 100),
+		DocCount:     entries,
+		Capabilities: []string{"chunks"},
+	}
+	for i := 0; i < entries; i++ {
+		kb.RecentDocs = append(kb.RecentDocs, RecentDocInfo{
+			ChunkID:             fmt.Sprintf("%s-chunk-%d", kb.ID, i),
+			KnowledgeID:         fmt.Sprintf("%s-knowledge-%d", kb.ID, i),
+			FAQStandardQuestion: fmt.Sprintf("question %s %d?", name, i),
+			FAQAnswers:          []string{strings.Repeat("答", answerRunes)},
+			CreatedAt:           "2026-01-01",
+		})
+	}
+	return kb
+}
+
+func TestFormatKnowledgeBaseList_Empty(t *testing.T) {
+	assert.Equal(t, "<knowledge_bases />", formatKnowledgeBaseList(nil))
+}
+
+// A catalog that fits the budget renders at full detail, exactly as before
+// budgeting existed (plus per-item caps and escaping).
+func TestFormatKnowledgeBaseList_SmallCatalogKeepsFullDetail(t *testing.T) {
+	out := formatKnowledgeBaseList([]*KnowledgeBaseInfo{docKB("alpha", 100, 2)})
+	require.True(t, utf8.RuneCountInString(out) <= maxRuntimeCatalogRunes)
+	assert.Contains(t, out, "<description>")
+	assert.Contains(t, out, "<recent_documents>")
+	assert.Contains(t, out, "<summary>")
+	assert.Contains(t, out, `capabilities="chunks"`)
+	assert.NotContains(t, out, "not listed")
+}
+
+// The FAQ answer is the first thing sacrificed: questions — the routing
+// signal — survive for every KB, answers do not. Fixture sized so the full
+// tier exceeds the budget (~9.8k runes) while the answer-free tier fits
+// (~5.5k runes).
+func TestFormatKnowledgeBaseList_DropsFAQAnswersBeforeQuestions(t *testing.T) {
+	var kbs []*KnowledgeBaseInfo
+	for i := 0; i < 10; i++ {
+		kbs = append(kbs, faqKB(fmt.Sprintf("faq%d", i), 2, faqAnswerMaxRunes+100))
+	}
+	out := formatKnowledgeBaseList(kbs)
+	require.True(t, utf8.RuneCountInString(out) <= maxRuntimeCatalogRunes)
+	assert.NotContains(t, out, "<answer>")
+	assert.Contains(t, out, "<faq_entries>")
+	assert.Contains(t, out, "<question>question faq0 0?</question>")
+	assert.Contains(t, out, "<question>question faq9 1?</question>")
+}
+
+// When even question-only rendering cannot fit, every KB collapses to its
+// identity row — the last thing to go — and the block stays within budget.
+func TestFormatKnowledgeBaseList_CollapsesToIdentityRows(t *testing.T) {
+	var kbs []*KnowledgeBaseInfo
+	for i := 0; i < 60; i++ {
+		kbs = append(kbs, docKB(fmt.Sprintf("kb%d", i), kbDescriptionMaxRunes, 2))
+	}
+	out := formatKnowledgeBaseList(kbs)
+	require.True(t, utf8.RuneCountInString(out) <= maxRuntimeCatalogRunes)
+	assert.NotContains(t, out, "<description>")
+	assert.NotContains(t, out, "<recent_documents>")
+	assert.Contains(t, out, `<knowledge_base id="kb-kb0" name="kb0" type="document" doc_count="2"`)
+	assert.Contains(t, out, `<knowledge_base id="kb-kb59"`)
+}
+
+// The identity tier caps its own row list: arbitrarily many bound KBs still
+// produce a block within budget, with the remainder summarized in a note.
+func TestFormatKnowledgeBaseList_IdentityRowsTruncateWithNote(t *testing.T) {
+	var kbs []*KnowledgeBaseInfo
+	for i := 0; i < 541; i++ {
+		kb := docKB(fmt.Sprintf("kb%d", i), 10, 0)
+		kb.RecentDocs = nil
+		kbs = append(kbs, kb)
+	}
+	out := formatKnowledgeBaseList(kbs)
+	require.True(t, utf8.RuneCountInString(out) <= maxRuntimeCatalogRunes)
+	assert.Contains(t, out, "more knowledge bases are bound for this turn but not listed")
+	// The block is still well-formed.
+	assert.True(t, strings.HasPrefix(out, "<knowledge_bases>\n"))
+	assert.True(t, strings.HasSuffix(out, "</knowledge_bases>"))
+}
+
+// KB names and descriptions are user-controlled and were previously
+// interpolated raw into the XML-ish block.
+func TestFormatKnowledgeBaseList_EscapesUserContent(t *testing.T) {
+	kb := docKB("alpha", 20, 0)
+	kb.Name = `<img src=x onerror=alert(1)> "quoted"`
+	kb.Description = `a & b <c> "d"`
+	kb.RecentDocs = nil
+	out := formatKnowledgeBaseList([]*KnowledgeBaseInfo{kb})
+	assert.Contains(t, out, `name="&lt;img src=x onerror=alert(1)&gt; &quot;quoted&quot;"`)
+	assert.Contains(t, out, `a &amp; b &lt;c&gt; &quot;d&quot;`)
+	assert.NotContains(t, out, "<img ")
+}
+
+// Per-item caps hold regardless of the tier that rendered the entry.
+func TestFormatKnowledgeBaseList_PerItemCaps(t *testing.T) {
+	kb := docKB("alpha", 500, 0)
+	kb.RecentDocs = nil
+	faq := faqKB("beta", 1, 500)
+	out := formatKnowledgeBaseList([]*KnowledgeBaseInfo{kb, faq})
+	assert.NotContains(t, out, strings.Repeat("描", kbDescriptionMaxRunes+1))
+	assert.NotContains(t, out, strings.Repeat("答", faqAnswerMaxRunes+1))
+}
+
+func TestTruncateRunes(t *testing.T) {
+	cjk := strings.Repeat("中", 300)
+	got := truncateRunes(cjk, 200)
+	require.Len(t, []rune(got), 203) // 200 runes + "..."
+	require.True(t, utf8.ValidString(got), "byte-slicing would produce invalid UTF-8 here")
+	assert.True(t, strings.HasSuffix(got, "..."))
+
+	assert.Equal(t, "abc", truncateRunes("abc", 10))
+	assert.Equal(t, "", truncateRunes("abc", 0))
+}


### PR DESCRIPTION
## Description

The bound-KB catalog is rendered into the turn's user message (`<runtime_context>` → `<bound_knowledge_bases>`) and re-sent with **every** LLM call of a turn. `formatKnowledgeBaseList` had no size cap:

- linear in the number of bound KBs;
- each KB renders a **full, untruncated `description`** plus recent-document entries (2 for document KBs) and **up to 10 FAQ entries with full answers** for FAQ KBs.

For an agent whose KB selection is `all` (`knowledgeBaseScopesForPrompt` → `SearchTargets.GetAllKnowledgeBaseIDs()` — unbounded) over a multi-KB tenant, the catalog alone exceeds the context window **before the first response**: measured at ~2 KB per KB, strictly linear — 100 KBs ≈ 206 KB, 541 KBs ≈ 1.12 MB (~219k estimated tokens against a ~200k window, reported in #3158).

Every downstream safeguard is structurally blind to this shape:

1. the token estimator correctly alarms, but
2. the compactor cannot help — `FindCutPoint` walks the keep-recent budget, the oversized user turn is a *single* message it cannot cut (`ErrNothingToCompact`), and the tool-result trimmer only touches `tool` messages; and the oversized user message persists in the kept tail, so
3. **no over-window rejection exists before the model call** — every round re-sends the whole catalog (~2.6M prompt tokens per question, none answerable, per #3158's measurement).

This PR adds two independent fixes:

### 1. Budgeted catalog rendering (`internal/agent/prompts.go`)

`formatKnowledgeBaseList` now renders within an **8192-rune** budget (`maxRuntimeCatalogRunes`), degrading **uniformly for every bound KB** in the order that hurts routing least:

1. **full detail** — unchanged shape, with new per-item caps: description ≤ 200 runes, FAQ answer ≤ 200 runes (the full answer remains retrievable through FAQ tools), doc names ≤ 80 runes;
2. **FAQ answers dropped** — questions survive for *every* KB (questions are the routing signal; FAQ-routing agents keep working);
3. **identity rows** — one self-closing `<knowledge_base id name type doc_count capabilities />` line per KB; past the budget the remainder is summarized in a trailing `<note>` (the omitted KBs stay registered in the request's handle table, so id-bearing tool calls still resolve).

The tier choice is global (the model sees one uniform shape), truncation is **rune-safe** (names/descriptions are commonly CJK — byte slicing would corrupt them), and catalogs that fit the budget render exactly as before, so small tenants see zero change.

Also fixed while touching this function (called out explicitly per review norms): KB names, descriptions and doc fields were interpolated **raw** into the XML-ish block — user-controlled `<`/`"`/`&` corrupt the block (and it is a mild prompt-injection surface), while the sibling `pinned_documents` block already escapes. All rendered fields now go through `escapeXMLAttr`.

### 2. Fail-fast request-budget guard (`internal/agent/{engine,observe}.go`)

`runReActIteration` now rejects the round when the projected request — `estimateCurrentTokens` **plus tool schemas** (`Estimator.EstimateTools`, whose doc comment already earmarked it for "request-budget clamping") — exceeds `MaxContextTokens - contextReserveTokens()`:

- compaction runs first, so anything reclaimable is reclaimed before the guard judges;
- a request that is over the window before any response is generated is not something history compaction can fix — failing the turn with a clear, actionable error turns a 2.6M-token question into one clean error;
- engines without a configured window (`MaxContextTokens = 0`) keep the old behavior; #2981 (configurable window) is complementary.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ⚠️ Breaking change
- [ ] 📖 Documentation update
- [ ] 🔧 Refactor
- [ ] ⚡ Performance improvement
- [x] ✅ Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

Fixes #3158

## Testing

`internal/agent/prompts_catalog_budget_test.go`:

- empty catalog, small catalog keeps full detail (zero behavior change below budget);
- FAQ-heavy catalog degrades to question-only entries (answers gone, questions for every KB intact);
- 60-KB catalog collapses to identity rows (no descriptions, every KB still routable);
- 541-KB catalog stays within budget with the trailing note and well-formed envelope;
- escaping of user-controlled names/descriptions; per-item rune caps; `truncateRunes` CJK/UTF-8 safety.

`internal/agent/engine_budget_guard_test.go`:

- no window configured → guard never trips;
- request fits → no error;
- oversized history trips and the error names the numbers, the window, and the remediation;
- oversized **tool schemas** trip the guard even with tiny history (schemas are excluded from the compaction estimate by design).

The budgeted renderer's logic (tier selection arithmetic, identity-row budget accounting, escaping) was additionally validated standalone on the Go Playground before submission; full `go vet/test/build` and `golangci-lint` run as CI on this PR (no local Go toolchain in the authoring environment).

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted (gofmt/gofumpt style)
- [x] Targeted tests for the changed packages/components pass (verified by CI on this PR)
- [x] Diff-scoped lint passes where applicable (go-lint runs on this PR)
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (internal prompt-assembly behavior; no doc surface)
- [x] No breaking changes (catalogs within the budget render byte-identically to before, apart from added escaping of user-controlled fields)
