### PR TITLE
fix(session): keep leaked answers and stray quotes out of auto-generated session titles

### DIFF
--- a/config/prompt_templates/generate_session_title.yaml
+++ b/config/prompt_templates/generate_session_title.yaml
@@ -12,3 +12,13 @@ templates:
       - Only extract the intent of the user's question, don't answer about it
       - Output only the title, no explanation needed
       - IMPORTANT: Use {{language}} for the title
+
+      NEVER answer the question, no matter how simple it is. If the question
+      has a short factual answer (a number, a name, yes/no), the title must
+      still describe the topic of the question, not give that answer.
+
+      Examples:
+      - Question: "What is 6 multiplied by 7?" -> Title: "Multiplication question"
+      - Question: "珠穆朗玛峰的海拔是多少米？" -> Title: "珠峰海拔查询"
+      - Question: "Is Paris the capital of France?" -> Title: "France capital question"
+      - Question: "帮我总结这份合同的主要风险" -> Title: "合同风险总结"

--- a/internal/application/service/session.go
+++ b/internal/application/service/session.go
@@ -738,6 +738,7 @@ const maxSessionTitleRunes = 100
 // happened so the caller can log it.
 func sanitizeGeneratedTitle(raw string) (string, bool) {
 	title := strings.TrimSpace(strings.TrimPrefix(raw, "<think>\n\n</think>"))
+	title = strings.TrimSpace(strings.Trim(title, "\"'“”‘’「」『』"))
 	runes := []rune(title)
 	if len(runes) <= maxSessionTitleRunes {
 		return title, false

--- a/internal/application/service/session.go
+++ b/internal/application/service/session.go
@@ -745,6 +745,66 @@ func sanitizeGeneratedTitle(raw string) (string, bool) {
 	return strings.TrimSpace(string(runes[:maxSessionTitleRunes])), true
 }
 
+// looksLikeLeakedAnswer reports whether a generated "title" reads like the
+// answer to the conversation's question instead of a title for it. Some
+// instruction-weak models answer the question instead of titling it, and
+// nothing else in the pipeline rejects that — the title is user-visible in
+// the sidebar, where a bare "42" or "Yes, they were both American." leaks
+// the reply before the conversation is even opened. The patterns are kept
+// conservative so legitimate titles never match.
+func looksLikeLeakedAnswer(title string) bool {
+	title = strings.TrimSpace(title)
+	title = strings.Trim(title, "\"'“”‘’「」『』")
+	if title == "" {
+		return false
+	}
+	// A bare equation ("6×7=42") is an answer, never a title.
+	if strings.ContainsRune(title, '=') {
+		return true
+	}
+	// Mostly a number, optionally with a short unit suffix ("42", "8848米",
+	// "3.14", "98%"): reject when everything after the leading digits is
+	// punctuation/whitespace plus at most two unit runes — a real topic title
+	// like "2026年规划" keeps a longer tail and stays legitimate.
+	if r := []rune(title)[0]; (r >= '0' && r <= '9') || r == '.' || r == '-' {
+		rest := strings.TrimLeft(title, "0123456789.,-· ")
+		runes := []rune(rest)
+		if len(runes) <= 2 {
+			return true
+		}
+	}
+	// A bare yes/no, or a short sentence that opens with one ("Yes.",
+	// "Yes, they were both American.", "是的").
+	lower := strings.ToLower(title)
+	for _, lead := range []string{"yes", "no", "是的", "不是", "对的", "错的"} {
+		if lower == lead || strings.HasPrefix(lower, lead+",") || strings.HasPrefix(lower, lead+".") ||
+			strings.HasPrefix(lower, lead+"，") || strings.HasPrefix(lower, lead+"。") ||
+			strings.HasPrefix(lower, lead+" ") || strings.HasPrefix(lower, lead+"! ") {
+			return true
+		}
+	}
+	return false
+}
+
+// fallbackSessionTitleFromQuestion derives a guaranteed-title-shaped fallback
+// from the question itself: first line, trimmed and rune-truncated. Used when
+// the model answered instead of titling, so the sidebar never shows a leaked
+// answer.
+func fallbackSessionTitleFromQuestion(question string) string {
+	if idx := strings.IndexAny(question, "\r\n"); idx >= 0 {
+		question = question[:idx]
+	}
+	question = strings.TrimSpace(question)
+	if question == "" {
+		return ""
+	}
+	runes := []rune(question)
+	if len(runes) <= maxSessionTitleRunes {
+		return question
+	}
+	return strings.TrimSpace(string(runes[:maxSessionTitleRunes]))
+}
+
 // GenerateTitle generates a title for the current conversation content
 // modelID: optional model ID to use for title generation (if empty, uses first available KnowledgeQA model)
 func (s *sessionService) GenerateTitle(ctx context.Context,
@@ -848,6 +908,15 @@ func (s *sessionService) GenerateTitle(ctx context.Context,
 			"Generated session title exceeded %d runes and was truncated, session=%s, model=%s",
 			maxSessionTitleRunes, session.ID, modelID,
 		)
+	}
+	// The model answered the question instead of titling it: fall back to the
+	// question itself rather than leaking the reply into the sidebar (#3108).
+	if looksLikeLeakedAnswer(title) {
+		logger.Warnf(ctx,
+			"Generated session title looks like an answer, falling back to the question, session=%s, model=%s, title=%q",
+			session.ID, modelID, title,
+		)
+		title = fallbackSessionTitleFromQuestion(message.Content)
 	}
 	session.Title = title
 

--- a/internal/application/service/session_title_test.go
+++ b/internal/application/service/session_title_test.go
@@ -42,6 +42,11 @@ func TestSanitizeGeneratedTitle(t *testing.T) {
 			want: strings.Repeat("保", maxSessionTitleRunes),
 		},
 		{
+			name: "wrapping quotes some models add are dropped",
+			raw:  "“询问一加一等于多少”",
+			want: "询问一加一等于多少",
+		},
+		{
 			name: "empty completion stays empty",
 			raw:  "   ",
 			want: "",

--- a/internal/application/service/session_title_test.go
+++ b/internal/application/service/session_title_test.go
@@ -76,3 +76,77 @@ func TestMaxSessionTitleRunesFitsColumn(t *testing.T) {
 		t.Fatalf("maxSessionTitleRunes=%d exceeds the sessions.title column limit", maxSessionTitleRunes)
 	}
 }
+
+func TestLooksLikeLeakedAnswer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		title string
+		want  bool
+	}{
+		// Observed leaks: the model answered instead of titling.
+		{name: "bare number", title: "42", want: true},
+		{name: "number with unit", title: "8848米", want: true},
+		{name: "decimal", title: "3.14", want: true},
+		{name: "percent", title: "98%", want: true},
+		{name: "equation", title: "6×7=42", want: true},
+		{name: "equation with spaces", title: "6 * 7 = 42", want: true},
+		{name: "english yes sentence", title: "Yes, they were both American.", want: true},
+		{name: "bare no", title: "No", want: true},
+		{name: "chinese yes", title: "是的", want: true},
+		{name: "quoted number", title: "\"42\"", want: true},
+
+		// Legitimate titles must never match.
+		{name: "question rephrase", title: "六乘以七等于多少", want: false},
+		{name: "topic title", title: "法国首都城市查询", want: false},
+		{name: "english topic title", title: "France capital question", want: false},
+		{name: "cjk topic with digits inside", title: "2026年预算规划讨论", want: false},
+		{name: "year-scoped topic title", title: "2026年规划", want: false},
+		{name: "name-like title", title: "42号公约解读", want: false},
+		{name: "empty", title: "   ", want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := looksLikeLeakedAnswer(tt.title); got != tt.want {
+				t.Fatalf("looksLikeLeakedAnswer(%q) = %v, want %v", tt.title, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFallbackSessionTitleFromQuestion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("short question is kept as is", func(t *testing.T) {
+		t.Parallel()
+		if got := fallbackSessionTitleFromQuestion("法国的首都是哪里？"); got != "法国的首都是哪里？" {
+			t.Fatalf("fallback = %q", got)
+		}
+	})
+
+	t.Run("multiline question uses only the first line", func(t *testing.T) {
+		t.Parallel()
+		if got := fallbackSessionTitleFromQuestion("帮我看看这段代码\nfunc main() {}"); got != "帮我看看这段代码" {
+			t.Fatalf("fallback = %q", got)
+		}
+	})
+
+	t.Run("long question is truncated by rune and trimmed", func(t *testing.T) {
+		t.Parallel()
+		got := fallbackSessionTitleFromQuestion(strings.Repeat("问", maxSessionTitleRunes+50))
+		if len([]rune(got)) != maxSessionTitleRunes {
+			t.Fatalf("fallback rune count = %d, want %d", len([]rune(got)), maxSessionTitleRunes)
+		}
+	})
+
+	t.Run("empty question yields empty title", func(t *testing.T) {
+		t.Parallel()
+		if got := fallbackSessionTitleFromQuestion("  \n "); got != "" {
+			t.Fatalf("fallback = %q, want empty", got)
+		}
+	})
+}


### PR DESCRIPTION
Implements #3108.

## What changes

Session-title generation currently validates the model's output only by truncating its length, so whether an answer leaks into the title depends entirely on prompt compliance. As recorded on the issue, the leak is model/config dependent — we could not reproduce it on stock main, but we did catch a related first-hand defect (titles persisted with literal wrapping quotes). This PR turns title validation into defense-in-depth instead of prompt-only:

1. **Conservative leak heuristic** (`looksLikeLeakedAnswer`): rejects titles that are bare numbers with at most a 2-character unit ("45 分钟"), equations ("1+1=2"), or yes/no openers — shapes a question never legitimately takes. Kept deliberately narrow to avoid clipping real titles like "2026 年规划" (the first draft's ≤3-char suffix rule did clip it; tightened to ≤2 with negative cases pinned in tests).
2. **Question-derived fallback** (`fallbackSessionTitleFromQuestion`): when the heuristic rejects the generated title, the title falls back to a rune-truncated first line of the user's question instead of leaving the session untitled.
3. **Prompt hardening**: the title prompt gains an explicit never-answer instruction plus 4 few-shot pairs showing question → title (not question → answer).
4. **Quote stripping** in `sanitizeGeneratedTitle`: ASCII and CJK wrapping quotes are removed from persisted titles — the defect we observed first-hand on stock main.

## Tests

- 17 cases for `looksLikeLeakedAnswer` (positive leak shapes + negative real-title shapes)
- 4 cases for `fallbackSessionTitleFromQuestion`
- existing `sanitize` cases still green; full service package green; `go build ./...` clean

## Behavior note

All rejection paths are conservative by design: when in doubt the title survives. The fallback only ever fires on shapes a question cannot legitimately produce, so normal titles are unchanged.