### PR TITLE
docs: add Parallel Search MCP setup example

### DIFF
--- a/website-docs/03-features/08-mcp.md
+++ b/website-docs/03-features/08-mcp.md
@@ -24,6 +24,33 @@ MCP 用于智能体与外部工具之间的连接。WeKnora 支持接入外部 M
 
 OAuth 服务按调用者分别授权。工具需要审批时，在对话中检查参数并确认；单独停用某个工具后，运行时不会执行该工具。WeKnora 的 MCP 客户端不支持 stdio 传输。
 
+### 示例：无需 API Key 的网页搜索与提取
+
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) 提供 `web_search`（搜索公开网页）和 `web_fetch`（提取网页内容）。匿名接入无需 Parallel 账号或 API Key，免费访问有速率限制。
+
+在「设置 → MCP 服务 → 添加服务」中展开代码导入，粘贴以下配置并解析：
+
+```json
+{
+  "mcpServers": {
+    "Parallel Search": {
+      "type": "http",
+      "url": "https://search.parallel.ai/mcp",
+      "headers": {
+        "User-Agent": "WeKnora"
+      },
+      "usage_instructions": "需要查询公开网页时使用 web_search，提供 objective 和 search_queries；需要读取网页时使用 web_fetch，提供 urls。回答中保留来源链接。"
+    }
+  }
+}
+```
+
+确认传输方式为 Streamable HTTP，认证方式为无认证。点击下一步保存连接，在工具列表中同步工具，确认出现 `web_search` 和 `web_fetch`，再保存使用说明。新建服务默认启用，使用「全部 MCP 服务」的智能体会自动包含它；若只想让指定智能体使用，请先检查各智能体的 MCP 服务范围。在目标智能体中选择该服务或所需工具后，可用「搜索 Parallel Search MCP 的官方文档，再读取文档说明匿名接入方式，并给出来源链接」检查搜索和提取结果。
+
+智能体可在对话中自行调用已选工具，调用时会把查询、请求的 URL、提供的目标或上下文及工具参数中的元数据发送给 Parallel。配置中的 `User-Agent: WeKnora` 用于标识调用项目，方便 Parallel 统计该项目的免费 MCP 总体使用量，不包含用户或设备标识。服务的数据处理规则见 [Parallel 隐私政策](https://parallel.ai/privacy-policy)。
+
+如需停用，在 MCP 服务列表中关闭该服务，或把智能体的 MCP 范围改为指定服务并排除此服务（也可关闭该智能体的 MCP 工具）。此示例只用于新建匿名连接；已有连接的凭据和其他搜索服务无需修改。
+
 ## 供外部客户端调用
 
 在外部客户端所在环境安装 `tencent-weknora-mcp`，配置 WeKnora API 地址与 API Key，再启动 `weknora-mcp-server`。客户端可调用知识库、检索、会话和 Wiki 等 31 个工具，范围受 API Key 权限约束。


### PR DESCRIPTION
## Description

Adds a copyable Parallel Search MCP example to the existing MCP guide so users can connect public web search and page extraction without a Parallel account or API key.

The example uses WeKnora's JSON import and existing Streamable HTTP client. It explains that newly added services are enabled and available to agents configured to use all MCP services, what data goes to Parallel, and how to disable the connection. Requests use `User-Agent: WeKnora` so Parallel can measure aggregate free MCP usage.

I work at Parallel, which operates this service.

## Type of Change

- [x] 📚 Documentation update

## Testing

- Imported the exact JSON through the native `McpServiceDialog` component and checked its generated service payload.
- Loaded that payload with WeKnora's Go MCP client, discovered `web_search` and `web_fetch`, and called both anonymously against the live service. Both returned URLs and nonempty excerpts.
- Captured separate local client requests to verify `User-Agent: WeKnora` and absent auth headers on both tools. Downstream analytics were not checked.
- `go test ./internal/mcp -run TestApplyAuthHeaders -count=1` and six existing MCP dialog tests passed.
- Documentation build, 206 internal links, and 60 Mermaid diagrams passed their checks.
- `git diff --check` passed. Full-repository application checks were not run for this documentation-only change.

The import/client checks used temporary local harnesses. They do not establish a full browser-to-database-to-agent conversation test. No application code changes are included.

## Checklist

- [x] Self-reviewed the change
- [x] Updated related documentation
