### PR TITLE
fix(agent): honor MCP service advanced_config.timeout for CallTool window

### DIFF
--- a/internal/agent/tools/mcp_tool.go
+++ b/internal/agent/tools/mcp_tool.go
@@ -109,6 +109,34 @@ func (t *MCPTool) Parameters() json.RawMessage {
 	}`)
 }
 
+// serviceCallTimeout returns the MCP service's configured per-call timeout
+// (advanced_config.timeout, in seconds), or 0 when unset or not positive.
+func (t *MCPTool) serviceCallTimeout() time.Duration {
+	if t.service == nil || t.service.AdvancedConfig == nil || t.service.AdvancedConfig.Timeout <= 0 {
+		return 0
+	}
+	return time.Duration(t.service.AdvancedConfig.Timeout) * time.Second
+}
+
+// callToolTimeout returns the timeout governing the actual MCP CallTool window.
+// The agent engine derives the per-tool budget from a blanket 60s
+// (toolExecutionTimeout in internal/agent), while the service-level
+// advanced_config.timeout was only honored by the transport layers — a service
+// configured with a longer timeout still had every call cancelled at 60s (#3135).
+// The service timeout therefore extends the engine window when it is longer; it
+// never shortens it, so services without an explicit (longer) timeout keep
+// today's behavior and shorter values stay enforced where they already apply
+// (the HTTP transport timeout in internal/mcp/client.go).
+func (t *MCPTool) callToolTimeout(engineTimeout time.Duration) time.Duration {
+	if engineTimeout <= 0 {
+		engineTimeout = 60 * time.Second
+	}
+	if st := t.serviceCallTimeout(); st > engineTimeout {
+		return st
+	}
+	return engineTimeout
+}
+
 // Execute executes the MCP tool
 func (t *MCPTool) Execute(ctx context.Context, args json.RawMessage) (*types.ToolResult, error) {
 	logger.GetLogger(ctx).Infof("Executing MCP tool: %s from service: %s", t.mcpTool.Name, t.service.Name)
@@ -201,12 +229,9 @@ func (t *MCPTool) Execute(ctx context.Context, args json.RawMessage) (*types.Too
 				// Approval may have consumed most/all of the per-tool exec budget set by the
 				// agent engine (act.go). Re-derive a fresh tool-exec ctx from ApprovalCtx so
 				// the actual MCP CallTool gets a full timeout window. (issue #1173 follow-up)
+				// callToolTimeout honors the service's advanced_config.timeout (#3135).
 				if meta.ApprovalCtx != nil {
-					freshTimeout := meta.ExecTimeout
-					if freshTimeout <= 0 {
-						freshTimeout = 60 * time.Second
-					}
-					freshCtx, freshCancel := context.WithTimeout(meta.ApprovalCtx, freshTimeout)
+					freshCtx, freshCancel := context.WithTimeout(meta.ApprovalCtx, t.callToolTimeout(meta.ExecTimeout))
 					defer freshCancel()
 					ctx = freshCtx
 				}
@@ -220,6 +245,20 @@ func (t *MCPTool) Execute(ctx context.Context, args json.RawMessage) (*types.Too
 	toolCallID := ""
 	if meta != nil {
 		toolCallID = meta.ToolCallID
+	}
+
+	// The service's advanced_config.timeout must govern the actual CallTool window
+	// (#3135): the agent engine derives the per-tool ctx from a blanket 60s budget
+	// (toolExecutionTimeout in internal/agent), so calls on services configured
+	// with a longer timeout were silently cancelled mid-flight even though the
+	// transport layers honor the value. Re-derive the window from ApprovalCtx —
+	// the round-level parent without the per-tool deadline. Skipped on the
+	// post-approval path, which already re-derived its window above and whose
+	// swapped ctx no longer carries the exec meta.
+	if meta != nil && meta.ApprovalCtx != nil {
+		callCtx, callCancel := context.WithTimeout(meta.ApprovalCtx, t.callToolTimeout(meta.ExecTimeout))
+		defer callCancel()
+		ctx = callCtx
 	}
 
 	connectAndCall := func(callCtx context.Context) (*mcp.CallToolResult, error) {

--- a/internal/agent/tools/mcp_tool_timeout_test.go
+++ b/internal/agent/tools/mcp_tool_timeout_test.go
@@ -1,0 +1,97 @@
+package tools
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func mcpServiceWithTimeout(seconds int) *types.MCPService {
+	if seconds <= 0 {
+		return &types.MCPService{}
+	}
+	return &types.MCPService{AdvancedConfig: &types.MCPAdvancedConfig{Timeout: seconds}}
+}
+
+func TestServiceCallTimeout(t *testing.T) {
+	tests := []struct {
+		name           string
+		serviceTimeout int
+		expected       time.Duration
+	}{
+		{"nil advanced config", 0, 0},
+		{"zero timeout", 0, 0},
+		{"negative timeout", -5, 0},
+		{"positive timeout", 300, 300 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tool := &MCPTool{service: mcpServiceWithTimeout(tt.serviceTimeout)}
+			assert.Equal(t, tt.expected, tool.serviceCallTimeout())
+		})
+	}
+
+	t.Run("nil service", func(t *testing.T) {
+		tool := &MCPTool{}
+		assert.Equal(t, time.Duration(0), tool.serviceCallTimeout())
+	})
+}
+
+// TestCallToolTimeout covers the per-call budget derivation for MCP CallTool
+// (#3135): the service's advanced_config.timeout extends the engine-derived
+// window when longer, and never shortens it.
+func TestCallToolTimeout(t *testing.T) {
+	const engineWindow = 60 * time.Second
+
+	tests := []struct {
+		name           string
+		serviceTimeout int
+		engineTimeout  time.Duration
+		expected       time.Duration
+	}{
+		{
+			name:           "no advanced config keeps engine window",
+			serviceTimeout: 0,
+			engineTimeout:  engineWindow,
+			expected:       engineWindow,
+		},
+		{
+			name:           "longer service timeout wins (#3135)",
+			serviceTimeout: 300,
+			engineTimeout:  engineWindow,
+			expected:       300 * time.Second,
+		},
+		{
+			name:           "equal service timeout keeps engine window",
+			serviceTimeout: 60,
+			engineTimeout:  engineWindow,
+			expected:       engineWindow,
+		},
+		{
+			name:           "shorter service timeout never shortens",
+			serviceTimeout: 30,
+			engineTimeout:  engineWindow,
+			expected:       engineWindow,
+		},
+		{
+			name:           "missing engine timeout falls back to 60s then extends",
+			serviceTimeout: 300,
+			engineTimeout:  0,
+			expected:       300 * time.Second,
+		},
+		{
+			name:           "missing engine timeout with short service keeps 60s",
+			serviceTimeout: 30,
+			engineTimeout:  0,
+			expected:       engineWindow,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tool := &MCPTool{service: mcpServiceWithTimeout(tt.serviceTimeout)}
+			assert.Equal(t, tt.expected, tool.callToolTimeout(tt.engineTimeout))
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixes #3135

An MCP service's `advanced_config.timeout` (default `30`, `types.GetDefaultAdvancedConfig`) is honored by the transport layers — the MCP HTTP client timeout (`internal/mcp/client.go:165-166`) and the `initialize` handshake (`internal/mcp/manager.go:190-194`) — but never by the agent-side per-call budget. `toolExecutionTimeout` in `internal/agent/const.go:55-60` decides from the tool name alone (`shell_exec` → 10m5s, everything else → 60s), and `internal/agent/act.go:528` applies it to MCP tools too. The post-approval path in `internal/agent/tools/mcp_tool.go` re-derived the same 60s (`meta.ExecTimeout` with a hardcoded 60s fallback). Result: an operator can raise a service to `timeout: 300`, watch the transport honor it, and still have every individual CallTool cancelled at 60s — the configuration is silently partially applied.

### Change

- Add `MCPTool.serviceCallTimeout()` reading `service.AdvancedConfig.Timeout` (0 when unset/non-positive).
- Add `MCPTool.callToolTimeout(engineTimeout)`: the service timeout **extends** the engine-derived window when it is longer; it never shortens it. Widening-only keeps every existing deployment's behavior identical and leaves shorter values enforced where they already apply (the HTTP transport timeout).
- Normal path: after the exec-meta read in `Execute`, re-derive the CallTool window from `meta.ApprovalCtx` (the round-level parent without the per-tool deadline) when the service timeout extends it. The swapped ctx is created after `oauthSess`/`toolCallID` are read, so they keep using the meta-carrying ctx.
- Post-approval path: the existing fresh-window re-derivation now goes through `callToolTimeout`, so approved MCP calls get the configured window too.

### Type of Change

- [x] 🐛 Bug fix

### Related Issue

- Fixes #3135

### Testing

- New tests (`internal/agent/tools/mcp_tool_timeout_test.go`):
  - `TestServiceCallTimeout` — nil service / nil advanced config / zero / negative / positive values.
  - `TestCallToolTimeout` — longer service timeout wins (#3135); equal and shorter never shorten; missing engine timeout falls back to 60s then extends; missing engine timeout with short service keeps 60s.
- `go test ./internal/agent/tools/ -count=1` — pass (full package)
- `go vet ./internal/agent/tools/` — clean
- `gofmt -l` no output; `git diff --check` clean
- Pre-existing issues: none observed in the affected package.

### Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Breaking changes are clearly called out in the description above → none (widening-only: calls previously succeeding at ≤60s are unaffected)
