### PR TITLE
feat(database): make PostgreSQL SSL mode configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,6 +136,10 @@ DB_USER=postgres
 DB_PASSWORD=postgres123!@#
 # 数据库名称。
 DB_NAME=WeKnora
+# PostgreSQL SSL mode: disable (default), require, verify-ca, verify-full.
+# allow/prefer are unsupported by the migration driver. TLS requires server support.
+# For certificate verification, provide PGSSLROOTCERT and mount the CA file in the app.
+DB_SSLMODE=disable
 # SQLite 驱动时使用（DB_DRIVER=sqlite），postgres/mysql 忽略。
 # DB_PATH=./data/weknora.db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,6 +141,7 @@ services:
       - DB_USER=${DB_USER:-}
       - DB_PASSWORD=${DB_PASSWORD:-}
       - DB_NAME=${DB_NAME:-}
+      - DB_SSLMODE=${DB_SSLMODE:-disable}
       # SQLite 驱动时使用（DB_DRIVER=sqlite）；postgres 驱动忽略
       # - DB_PATH=${DB_PATH:-}
       # ========== Langfuse (optional observability) ==========

--- a/docs/postgres-ssl.md
+++ b/docs/postgres-ssl.md
@@ -1,0 +1,46 @@
+# PostgreSQL SSL configuration
+
+Set `DB_SSLMODE` in the application environment (or `.env` with Docker Compose):
+
+```dotenv
+DB_SSLMODE=require
+```
+
+Unset or empty values use `disable`, preserving existing deployments. Restart the
+application after changing the setting; with Compose, recreate the app container
+to apply environment changes. Helm exposes `app.env.DB_SSLMODE`.
+
+The application connection, startup migrations and migration version query use
+the same setting. `scripts/migrate.sh` preserves an explicit `sslmode` in `DB_URL`;
+otherwise it adds `DB_SSLMODE` (default `disable`). `DB_URL` is a migration-script
+override, not an application connection override. Keep it consistent with the app.
+
+Supported values are `disable`, `require`, `verify-ca` and `verify-full`. Other
+values fail validation. Although pgx supports `allow` and `prefer`, the pinned
+lib/pq v1.10.9 migration driver does not, so these modes are rejected consistently.
+
+## Deployment implications
+
+- This configures the client only. The PostgreSQL server must separately enable
+  TLS and have a usable certificate. The bundled local database is not automatically
+  configured for TLS; setting `require` against a server without TLS fails.
+- `require` requires encryption; do not use it as a guarantee of server identity.
+  Use `verify-full` for certificate-chain and hostname verification. `DB_HOST`
+  must match the server certificate, including when connecting through a proxy.
+- For a private CA, set `PGSSLROOTCERT` to a PEM CA file accessible to the app and
+  the migration process. If the server requires client certificates, also set
+  `PGSSLCERT` and `PGSSLKEY`, with appropriate private-key permissions. These
+  standard driver environment variables must be explicitly passed into containers
+  and their files mounted; adding them to the Compose `.env` alone does not pass
+  them through. Paths on the host and inside containers may differ.
+- pgx and lib/pq have different certificate defaults. Supply an explicit CA path
+  for verification and check both application startup and manual migrations.
+  Certificate expiry, trust-chain problems or hostname mismatches can prevent
+  connections and migrations. Do not depend on implicit certificate behavior in
+  `require` mode.
+- SQLite and separate services such as Langfuse are unaffected. No schema or data
+  format changes are introduced. TLS adds connection-handshake and encryption
+  overhead; its actual impact depends on connection reuse and workload.
+
+References: [lib/pq v1.10.9 TLS implementation](https://github.com/lib/pq/blob/v1.10.9/ssl.go),
+[PostgreSQL SSL documentation](https://www.postgresql.org/docs/current/libpq-ssl.html).

--- a/helm/templates/app.yaml
+++ b/helm/templates/app.yaml
@@ -58,6 +58,8 @@ spec:
               value: "postgres"
             - name: DB_PORT
               value: "5432"
+            - name: DB_SSLMODE
+              value: {{ .Values.app.env.DB_SSLMODE | default "disable" | quote }}
             - name: DB_USER
               valueFrom:
                 secretKeyRef:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -88,6 +88,8 @@ app:
   # Ref: https://github.com/Tencent/WeKnora/blob/main/docker-compose.yml
   env:
     GIN_MODE: release
+    # PostgreSQL: disable, require, verify-ca, verify-full (server TLS must be configured separately).
+    DB_SSLMODE: disable
     # -- Retrieval driver: postgres, elasticsearch_v7, elasticsearch_v8, qdrant
     RETRIEVE_DRIVER: postgres
     # -- Storage type: local, minio, cos, tos, s3

--- a/internal/config/postgres.go
+++ b/internal/config/postgres.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// PostgresSSLMode returns the mode shared by pgx (GORM) and lib/pq (migrations).
+// Only their common modes are accepted; lib/pq v1.10.9 rejects allow/prefer.
+func PostgresSSLMode() (string, error) {
+	mode := os.Getenv("DB_SSLMODE")
+	if mode == "" {
+		mode = "disable"
+	}
+	switch mode {
+	case "disable", "require", "verify-ca", "verify-full":
+		return mode, nil
+	default:
+		return "", fmt.Errorf("invalid DB_SSLMODE %q: expected disable, require, verify-ca, or verify-full", mode)
+	}
+}

--- a/internal/config/postgres_test.go
+++ b/internal/config/postgres_test.go
@@ -1,0 +1,26 @@
+package config
+
+import "testing"
+
+func TestPostgresSSLMode(t *testing.T) {
+	for _, mode := range []string{"", "disable", "require", "verify-ca", "verify-full", "allow", "prefer", "nossl", "REQUIRE", "require sslmode=disable"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("DB_SSLMODE", mode)
+			got, err := PostgresSSLMode()
+			switch mode {
+			case "", "disable", "require", "verify-ca", "verify-full":
+				want := mode
+				if want == "" {
+					want = "disable"
+				}
+				if err != nil || got != want {
+					t.Fatalf("got (%q, %v), want (%q, nil)", got, err, want)
+				}
+			default:
+				if err == nil || got != "" {
+					t.Fatalf("unsupported mode accepted: (%q, %v)", got, err)
+				}
+			}
+		})
+	}
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -643,6 +643,10 @@ func initDatabase(cfg *config.Config) (*gorm.DB, error) {
 	var sqliteDBPath string
 	switch os.Getenv("DB_DRIVER") {
 	case "postgres":
+		sslMode, err := config.PostgresSSLMode()
+		if err != nil {
+			return nil, err
+		}
 		// DSN for GORM (key-value format)
 		gormDSN := fmt.Sprintf(
 			"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s TimeZone=UTC",
@@ -651,7 +655,7 @@ func initDatabase(cfg *config.Config) (*gorm.DB, error) {
 			os.Getenv("DB_USER"),
 			os.Getenv("DB_PASSWORD"),
 			os.Getenv("DB_NAME"),
-			"disable",
+			sslMode,
 		)
 		dialector = postgres.Open(gormDSN)
 
@@ -669,12 +673,13 @@ func initDatabase(cfg *config.Config) (*gorm.DB, error) {
 		logger.Infof(context.Background(), "Skip embedding: %s", skipEmbedding)
 
 		migrateDSN = fmt.Sprintf(
-			"postgres://%s:%s@%s:%s/%s?sslmode=disable&options=-c%%20app.skip_embedding=%s",
+			"postgres://%s:%s@%s:%s/%s?sslmode=%s&options=-c%%20app.skip_embedding=%s",
 			os.Getenv("DB_USER"),
 			encodedPassword, // Use encoded password
 			os.Getenv("DB_HOST"),
 			os.Getenv("DB_PORT"),
 			os.Getenv("DB_NAME"),
+			sslMode,
 			skipEmbedding,
 		)
 

--- a/internal/database/migration.go
+++ b/internal/database/migration.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Tencent/WeKnora/internal/config"
 	"github.com/Tencent/WeKnora/internal/logger"
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
@@ -300,13 +301,18 @@ func recoverFromDirtyState(ctx context.Context, m *migrate.Migrate, dirtyVersion
 
 // GetMigrationVersion returns the current migration version
 func GetMigrationVersion() (uint, bool, error) {
+	sslMode, err := config.PostgresSSLMode()
+	if err != nil {
+		return 0, false, err
+	}
 	dbURL := fmt.Sprintf(
-		"postgres://%s:%s@%s:%s/%s?sslmode=disable",
+		"postgres://%s:%s@%s:%s/%s?sslmode=%s",
 		os.Getenv("DB_USER"),
 		os.Getenv("DB_PASSWORD"),
 		os.Getenv("DB_HOST"),
 		os.Getenv("DB_PORT"),
 		os.Getenv("DB_NAME"),
+		sslMode,
 	)
 
 	migrationsPath := "file://migrations/versioned"

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -19,6 +19,7 @@ DB_PORT=${DB_PORT:-5432}
 DB_USER=${DB_USER:-postgres}
 DB_PASSWORD=${DB_PASSWORD:-postgres}
 DB_NAME=${DB_NAME:-WeKnora}
+DB_SSLMODE=${DB_SSLMODE:-disable}
 
 # Use versioned migrations directory
 MIGRATIONS_DIR="${MIGRATIONS_DIR:-migrations/versioned}"
@@ -31,23 +32,21 @@ if ! command -v migrate &> /dev/null; then
 fi
 
 # Construct the database URL
-# If DB_URL is already set in .env, use it but ensure sslmode=disable is set
+# An explicit sslmode in DB_URL takes precedence over DB_SSLMODE.
 # Otherwise, construct it from individual components
 if [ -n "$DB_URL" ]; then
-    # If DB_URL already exists, ensure sslmode=disable is set (unless sslmode is already specified)
-    if [[ "$DB_URL" != *"sslmode="* ]]; then
-        # Add sslmode=disable if not present
+    if [[ "$DB_URL" =~ [\?\&]sslmode=([^\&]*) ]]; then
+        EFFECTIVE_SSLMODE="${BASH_REMATCH[1]}"
+    else
+        EFFECTIVE_SSLMODE="$DB_SSLMODE"
         if [[ "$DB_URL" == *"?"* ]]; then
-            DB_URL="${DB_URL}&sslmode=disable"
+            DB_URL="${DB_URL}&sslmode=${DB_SSLMODE}"
         else
-            DB_URL="${DB_URL}?sslmode=disable"
+            DB_URL="${DB_URL}?sslmode=${DB_SSLMODE}"
         fi
-    elif [[ "$DB_URL" == *"sslmode=require"* ]] || [[ "$DB_URL" == *"sslmode=prefer"* ]]; then
-        # Replace sslmode=require/prefer with sslmode=disable for local dev
-        DB_URL="${DB_URL//sslmode=require/sslmode=disable}"
-        DB_URL="${DB_URL//sslmode=prefer/sslmode=disable}"
     fi
 else
+    EFFECTIVE_SSLMODE="$DB_SSLMODE"
     # Use Python to properly URL encode password if it contains special characters
     # This handles special characters in passwords correctly
     if command -v python3 &> /dev/null; then
@@ -56,8 +55,16 @@ else
         # Fallback: try to use printf for basic encoding (may not work for all special chars)
         ENCODED_PASSWORD="$DB_PASSWORD"
     fi
-    DB_URL="postgres://${DB_USER}:${ENCODED_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?sslmode=disable"
+    DB_URL="postgres://${DB_USER}:${ENCODED_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?sslmode=${DB_SSLMODE}"
 fi
+
+case "$EFFECTIVE_SSLMODE" in
+    disable|require|verify-ca|verify-full) ;;
+    *)
+        echo "Error: invalid PostgreSQL sslmode; expected disable, require, verify-ca, or verify-full" >&2
+        exit 1
+        ;;
+esac
 
 # Execute migration based on command
 case "$1" in
@@ -119,4 +126,4 @@ case "$1" in
         ;;
 esac
 
-echo "Migration command completed successfully" 
+echo "Migration command completed successfully"

--- a/scripts/migrate_sslmode_test.sh
+++ b/scripts/migrate_sslmode_test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -eu
+
+# Exercise URL construction without loading .env or contacting a database.
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+run_case() (
+    DB_HOST=localhost DB_PORT=5432 DB_USER=test DB_PASSWORD=test DB_NAME=test
+    DB_URL="$1" DB_SSLMODE="${2:-disable}"
+    source <(sed -n '/^# Construct the database URL/,/^# Execute migration/{ /^# Execute migration/!p; }' "$SCRIPT_DIR/migrate.sh")
+    printf '%s' "$DB_URL"
+)
+
+for mode in disable require verify-ca verify-full; do
+    result=$(run_case "" "$mode")
+    [[ "$result" == "postgres://test:test@localhost:5432/test?sslmode=$mode" ]]
+    result=$(run_case 'postgres://test@localhost/test?connect_timeout=5' "$mode")
+    [[ "$result" == "postgres://test@localhost/test?connect_timeout=5&sslmode=$mode" ]]
+    result=$(run_case "postgres://test@localhost/test?sslmode=$mode&connect_timeout=5" invalid)
+    [[ "$result" == "postgres://test@localhost/test?sslmode=$mode&connect_timeout=5" ]]
+done
+[[ "$(run_case '' '')" == 'postgres://test:test@localhost:5432/test?sslmode=disable' ]]
+[[ "$(run_case 'postgres://test@localhost/test' require)" == 'postgres://test@localhost/test?sslmode=require' ]]
+for mode in allow prefer nossl ''; do
+    if run_case "postgres://test@localhost/test?sslmode=$mode" disable >/dev/null 2>&1; then
+        echo "Unsupported URL mode accepted: $mode" >&2
+        exit 1
+    fi
+done
+for mode in allow prefer nossl 'require&sslmode=disable'; do
+    if run_case '' "$mode" >/dev/null 2>&1; then
+        echo "Unsupported environment mode accepted: $mode" >&2
+        exit 1
+    fi
+done
+echo 'PostgreSQL migration SSL mode tests passed'

--- a/website-docs/06-development/02-database-schema.md
+++ b/website-docs/06-development/02-database-schema.md
@@ -8,7 +8,7 @@ WeKnora 使用版本化迁移维护数据库结构，PostgreSQL 与 SQLite 分�
 
 | `DB_DRIVER` | 说明 |
 | --- | --- |
-| `postgres` | 标准模式。既支持原生 PostgreSQL（+pgvector），也支持 **ParadeDB**（PostgreSQL 分支，内置 `pg_search`/BM25，官方 compose 默认镜像 `paradedb/paradedb:v0.22.2-pg17`）。GORM DSN 由 `DB_HOST/DB_PORT/DB_USER/DB_PASSWORD/DB_NAME` 拼装，强制 `sslmode=disable`、`TimeZone=UTC` |
+| `postgres` | 标准模式。既支持原生 PostgreSQL（+pgvector），也支持 **ParadeDB**（PostgreSQL 分支，内置 `pg_search`/BM25，官方 compose 默认镜像 `paradedb/paradedb:v0.22.2-pg17`）。GORM DSN 由 `DB_HOST/DB_PORT/DB_USER/DB_PASSWORD/DB_NAME` 拼装，`sslmode` 由 `DB_SSLMODE` 配置（默认 `disable`），`TimeZone=UTC` |
 | `sqlite` | Lite 模式。路径取 `DB_PATH`（默认 `./data/weknora.db`），DSN 附加 `_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=on`，并加载 `sqlite-vec` 扩展（`sqlite_vec.Auto()`）做向量检索 |
 | 其他值 | 直接报错 `unsupported database driver` |
 
@@ -309,7 +309,7 @@ if strings.HasPrefix(dsn, "sqlite3://") {
 `scripts/migrate.sh` 是 `migrate` CLI 的包装（Makefile 的 `migrate-*` 目标调用它）：
 
 - 自动加载根目录 `.env`；
-- DSN 优先取 `DB_URL`（并把 `sslmode=require/prefer` 强制替换为 `disable`），否则由 `DB_HOST/DB_PORT/DB_USER/DB_PASSWORD/DB_NAME` 拼装（默认 `localhost:5432/postgres/WeKnora`），密码用 Python `urllib.parse.quote` URL 编码以兼容特殊字符；
+- DSN 优先取 `DB_URL`（保留显式 `sslmode`；未指定时使用 `DB_SSLMODE`，默认 `disable`；仅支持 `disable/require/verify-ca/verify-full`），否则由 `DB_HOST/DB_PORT/DB_USER/DB_PASSWORD/DB_NAME` 拼装（默认 `localhost:5432/postgres/WeKnora`），密码用 Python `urllib.parse.quote` URL 编码以兼容特殊字符；
 - 迁移目录默认 `MIGRATIONS_DIR=migrations/versioned`；
 - 未安装 `migrate` 时提示：`go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest`。
 


### PR DESCRIPTION
## Description

PostgreSQL connections currently hard-code `sslmode=disable`, preventing WeKnora from connecting to databases that require TLS. This PR introduces `DB_SSLMODE` for the application connection, startup migrations and migration version queries. For example, `DB_SSLMODE=require` enables TLS without modifying source code; unset or empty values preserve the existing `disable` behavior.

- Accept `disable`, `require`, `verify-ca` and `verify-full`, and reject invalid values before connecting. `allow` and `prefer` are intentionally excluded because the pinned lib/pq v1.10.9 migration driver does not support them, although pgx does.
- Pass the setting through Docker Compose and Helm (`app.env.DB_SSLMODE`).
- Preserve an explicit `sslmode` in the migration script's `DB_URL`; otherwise use `DB_SSLMODE`, defaulting to `disable`. The script no longer silently rewrites `require` to `disable`.
- Add configuration and migration-script regression tests, update database documentation, and document TLS deployment requirements.

Compatibility: existing deployments without this setting retain their behavior, and this change introduces no schema changes. An explicit `sslmode=require` in a migration `DB_URL` now actually requires TLS; `prefer` now fails clearly instead of being silently downgraded. Server-side TLS configuration remains necessary. Certificate-verifying modes require appropriate trust material; `verify-full` also requires a matching hostname. Certificate files and standard `PGSSLROOTCERT` / `PGSSLCERT` / `PGSSLKEY` environment variables must be supplied to the relevant containers/processes separately. SQLite and separate services such as Langfuse are unaffected.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [x] 🔧 Configuration / Build / CI

## Related Issue

No linked issue.

## Testing

Passed:
- `go test internal/config/postgres.go internal/config/postgres_test.go` (standalone configuration tests covering default, supported and invalid modes).
- `bash -n scripts/migrate.sh`.
- `bash scripts/migrate_sslmode_test.sh` (generated URLs, existing query parameters, explicit URL precedence, defaults and unsupported modes; no database required).
- `git diff --check origin/main...HEAD`.
- Changed Go files formatted with `gofmt`.

Environment limitations:
- `go test ./internal/config ./internal/database` could not complete in the restricted Windows environment: default Go module/build cache writes were denied; retrying with writable temporary caches and `GOPROXY=off` encountered missing dependencies. The standalone tests above passed with a writable build cache.
- Full repository tests, Go lint and Helm rendering were not run.
- No live PostgreSQL TLS integration test was performed. Application startup and manual migrations should be verified against a TLS-enabled server with the deployment's CA/hostname configuration before production rollout.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [ ] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

Not applicable; no UI changes.