### PR TITLE
fix(im): re-send final answer when the platform stream expired

### DIFF
--- a/internal/im/service.go
+++ b/internal/im/service.go
@@ -2882,13 +2882,29 @@ loop:
 		answer = appendIMAuthNotice(answer, notice)
 	}
 
-	if err := streamer.FinalizeStream(ctx, msg, streamID, finalDisplay); err != nil {
-		logger.Warnf(ctx, "[IM] FinalizeStream failed: %v", err)
+	finalizeErr := streamer.FinalizeStream(ctx, msg, streamID, finalDisplay)
+	if finalizeErr != nil {
+		logger.Warnf(ctx, "[IM] FinalizeStream failed: %v", finalizeErr)
 	}
 
 	// End the stream
 	if err := streamer.EndStream(ctx, msg, streamID); err != nil {
 		logger.Warnf(ctx, "[IM] EndStream failed: %v", err)
+	}
+
+	// A long answer can outlive the platform's streaming channel (e.g. the WeCom
+	// stream expires after a few minutes), which makes the placeholder
+	// unreplaceable. Re-send the final answer as a plain message so it is not
+	// lost, mirroring the full-output path.
+	var fallbackErr error
+	if finalizeErr != nil {
+		fallbackErr = adapter.SendReply(imOutboundContext(ctx), msg, &ReplyMessage{
+			Content: finalDisplay,
+			IsFinal: true,
+		})
+		if fallbackErr != nil {
+			logger.Errorf(ctx, "[IM] FinalizeStream and plain-reply fallback both failed: %v", fallbackErr)
+		}
 	}
 
 	if answer == "" {
@@ -2901,7 +2917,12 @@ loop:
 		logger.Warnf(ctx, "[IM] Failed to update assistant message: %v", err)
 	}
 
-	logger.Infof(ctx, "[IM] Stream reply sent: platform=%s user=%s answer_len=%d", msg.Platform, msg.UserID, len(answer))
+	if finalizeErr == nil || fallbackErr == nil {
+		logger.Infof(
+			ctx, "[IM] Stream reply sent: platform=%s user=%s answer_len=%d",
+			msg.Platform, msg.UserID, len(answer),
+		)
+	}
 	return nil
 }
 

--- a/internal/im/stream_finalize_fallback_test.go
+++ b/internal/im/stream_finalize_fallback_test.go
@@ -1,0 +1,165 @@
+package im
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Tencent/WeKnora/internal/event"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+// streamFinalizeSessionService answers KnowledgeQA synchronously with a completed
+// final answer, mirroring a quick-QA stream.
+type streamFinalizeSessionService struct {
+	interfaces.SessionService
+	answer string
+}
+
+func (s *streamFinalizeSessionService) KnowledgeQA(
+	ctx context.Context, req *types.QARequest, bus *event.EventBus,
+) error {
+	return bus.Emit(ctx, event.Event{
+		ID:        "answer-1",
+		Type:      event.EventAgentFinalAnswer,
+		SessionID: req.Session.ID,
+		Data: event.AgentFinalAnswerData{
+			Content: s.answer,
+			Done:    true,
+		},
+	})
+}
+
+type streamFinalizeMessageService struct {
+	interfaces.MessageService
+}
+
+func (s *streamFinalizeMessageService) CreateMessage(
+	_ context.Context, msg *types.Message,
+) (*types.Message, error) {
+	created := *msg
+	created.ID = created.Role + "-message"
+	return &created, nil
+}
+
+func (s *streamFinalizeMessageService) UpdateMessage(_ context.Context, _ *types.Message) error {
+	return nil
+}
+
+type streamFinalizeStreamManager struct {
+	interfaces.StreamManager
+}
+
+func (s *streamFinalizeStreamManager) GetEvents(
+	_ context.Context, _, _ string, from int,
+) ([]interfaces.StreamEvent, int, error) {
+	return nil, from, nil
+}
+
+// streamFinalizeAdapter implements Adapter and StreamSender. finalizeErr
+// simulates an expired platform streaming channel (e.g. WeCom errcode 846608).
+type streamFinalizeAdapter struct {
+	Adapter
+	finalContent string
+	finalizeErr  error
+	sendErr      error
+	plainReplies int
+	plainContent string
+}
+
+func (a *streamFinalizeAdapter) StartStream(_ context.Context, _ *IncomingMessage) (string, error) {
+	return "stream-1", nil
+}
+
+func (a *streamFinalizeAdapter) UpdateStreamContent(
+	_ context.Context, _ *IncomingMessage, _ string, _ string,
+) error {
+	return nil
+}
+
+func (a *streamFinalizeAdapter) FinalizeStream(
+	_ context.Context, _ *IncomingMessage, _ string, content string,
+) error {
+	a.finalContent = content
+	return a.finalizeErr
+}
+
+func (a *streamFinalizeAdapter) EndStream(_ context.Context, _ *IncomingMessage, _ string) error {
+	return nil
+}
+
+func (a *streamFinalizeAdapter) SendReply(
+	_ context.Context, _ *IncomingMessage, reply *ReplyMessage,
+) error {
+	if a.sendErr != nil {
+		return a.sendErr
+	}
+	a.plainReplies++
+	if reply != nil {
+		a.plainContent = reply.Content
+	}
+	return nil
+}
+
+func runStreamFinalizeHandler(
+	t *testing.T, adapter *streamFinalizeAdapter, answer string,
+) {
+	t.Helper()
+	service := &Service{
+		sessionService: &streamFinalizeSessionService{answer: answer},
+		messageService: &streamFinalizeMessageService{},
+		streamManager:  &streamFinalizeStreamManager{},
+	}
+	err := service.handleMessageStream(
+		context.Background(),
+		&IncomingMessage{Platform: PlatformFeishu, UserID: "user-1", Content: "问题"},
+		&types.Session{ID: "session-1"}, nil, nil, nil, nil,
+		adapter, adapter, "user-key", nil,
+	)
+	if err != nil {
+		t.Fatalf("handleMessageStream() error = %v", err)
+	}
+}
+
+func TestHandleMessageStreamFinalizeSuccessSkipsPlainReply(t *testing.T) {
+	adapter := &streamFinalizeAdapter{}
+	runStreamFinalizeHandler(t, adapter, "最终答案")
+
+	if adapter.finalContent != "最终答案" {
+		t.Fatalf("final content = %q, want %q", adapter.finalContent, "最终答案")
+	}
+	if adapter.plainReplies != 0 {
+		t.Fatalf("plain fallback replies = %d, want 0", adapter.plainReplies)
+	}
+}
+
+// TestHandleMessageStreamFinalizeFailureSendsPlainReply covers an expired
+// platform streaming channel: the placeholder can no longer be replaced, so the
+// final answer must be re-sent as a plain message instead of being dropped.
+func TestHandleMessageStreamFinalizeFailureSendsPlainReply(t *testing.T) {
+	adapter := &streamFinalizeAdapter{finalizeErr: errors.New("stream expired (errcode 846608)")}
+	runStreamFinalizeHandler(t, adapter, "最终答案")
+
+	if adapter.finalContent != "最终答案" {
+		t.Fatalf("final content = %q, want %q", adapter.finalContent, "最终答案")
+	}
+	if adapter.plainReplies != 1 {
+		t.Fatalf("plain fallback replies = %d, want 1", adapter.plainReplies)
+	}
+	if adapter.plainContent != "最终答案" {
+		t.Fatalf("plain reply = %q, want %q", adapter.plainContent, "最终答案")
+	}
+}
+
+func TestHandleMessageStreamTotalDeliveryFailureStillReturnsCleanly(t *testing.T) {
+	adapter := &streamFinalizeAdapter{
+		finalizeErr: errors.New("stream expired"),
+		sendErr:     errors.New("plain reply rejected"),
+	}
+	runStreamFinalizeHandler(t, adapter, "最终答案")
+
+	if adapter.plainReplies != 0 {
+		t.Fatalf("plain fallback replies = %d, want 0", adapter.plainReplies)
+	}
+}


### PR DESCRIPTION
## Description

When an IM answer outlives the platform's streaming channel, `FinalizeStream` can no longer replace the thinking placeholder — WeCom streams expire after a few minutes and further refreshes fail with errcode 846608 (see #3189). `handleMessageStream` only logged a WARN and returned, so the final answer was silently dropped: the assistant message was written to the database but nothing was delivered to the user.

This change re-sends the final answer with `adapter.SendReply` when the finalize fails, mirroring the recovery the full-output path already performs (`handleMessageFullOutput` in `internal/im/service.go`). A total delivery failure is escalated to ERROR, and the misleading `Stream reply sent` INFO is no longer emitted when neither path delivered.

- The `FinalizeStream` error is now captured and, when non-nil, the final answer is re-sent as a plain message on a context detached from cancellation (`imOutboundContext`), so a cancelled or timed-out QA context cannot suppress the fallback.
- Delivery semantics become at-least-once: if the platform applied the final content but the call still returned an error, the user may receive the answer twice. This is the same trade-off the existing full-output path makes.
- `EndStream` keeps its WARN and does not trigger a re-send. After a successful finalize the placeholder already shows the final answer, so re-sending would duplicate it.
- New tests in `internal/im/stream_finalize_fallback_test.go` drive the real `handleMessageStream` with fake adapters, covering finalize success, finalize failure, and total delivery failure.

Closes #3189.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🧪 Test

## Related Issue
Fixes #3189

## Testing

Reproduced on the base commit `7a98a8e3` with this test file and the source change removed: `TestHandleMessageStreamFinalizeFailureSendsPlainReply` fails with `plain fallback replies = 0, want 1`, while the log shows only `WARNING FinalizeStream failed` followed by `INFO Stream reply sent`. It passes with the change.

Commands run (Go 1.26.3, `CGO_ENABLED=1`):

- `go test ./internal/im/ -run 'TestHandleMessageStream' -count=1 -v` — 3/3 pass, stable over 6 consecutive runs
- `go vet ./internal/im/...` — clean
- `golangci-lint run --new-from-rev=origin/main ./internal/im/...` — 0 issues (v2.12.2)
- `gofmt -l` on both changed files, `git diff --check` — clean
- `go build ./...` — clean

Full-repository test caveat (pre-existing, unrelated to this change): `go test ./internal/im/ -count=1` intermittently fails with

```
service_lifecycle_test.go:383: create im_channels: table im_channels already exists
```

in roughly 1 of 3 runs here, with a different IM lifecycle test failing each time. `newLifecycleTestDB` (`internal/im/service_lifecycle_test.go:46`) derives the shared-cache in-memory SQLite database name from `time.Now().UnixNano()` alone, so two tests that start in the same clock tick share one database and collide on `CREATE TABLE im_channels`. It is reproducible on the base commit with this change removed, is independent of the streaming path, and is not addressed here.

Environment caveat: `github.com/asg017/sqlite-vec-go-bindings` (cgo) requires a system `sqlite3.h`, which the toolchain used here does not ship. The full `go build ./...` was therefore run with a local `CGO_CFLAGS=-I` shim pointing at a copy of the SQLite amalgamation header from the module cache. No repository file was modified for this.

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.) — not applicable, no user-facing API or documented behavior changes
- [x] Breaking changes are clearly called out in the description above — none

## Screenshots / Recordings
Not applicable (backend delivery path, no UI change).
