### PR TITLE
test(im): give each lifecycle test its own sqlite database

### DIFF
--- a/internal/im/service_lifecycle_test.go
+++ b/internal/im/service_lifecycle_test.go
@@ -2,7 +2,6 @@ package im
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -45,7 +44,7 @@ func (c *lifecycleFactoryCounters) factory() AdapterFactory {
 
 func newLifecycleTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:im-lifecycle-%d?mode=memory&cache=shared", time.Now().UnixNano())), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open("file:im-lifecycle-"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -72,6 +71,25 @@ func newLifecycleTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("create im_channels: %v", err)
 	}
 	return db
+}
+
+// TestNewLifecycleTestDBIsolatesTests guards the helper's database name: two
+// tests must never share one in-memory database, which used to happen when the
+// name was taken from the wall clock instead of the test name.
+func TestNewLifecycleTestDBIsolatesTests(t *testing.T) {
+	t.Run("first", func(t *testing.T) {
+		createLifecycleChannel(t, newLifecycleTestDB(t), "marker", "agent-1")
+	})
+	t.Run("second", func(t *testing.T) {
+		db := newLifecycleTestDB(t)
+		var count int64
+		if err := db.Table("im_channels").Count(&count).Error; err != nil {
+			t.Fatalf("count im_channels: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("im_channels has %d rows, want a fresh database", count)
+		}
+	})
 }
 
 func newLifecycleTestService(db *gorm.DB, redisClient *redis.Client, instanceID string) *Service {


### PR DESCRIPTION
## Description

`newLifecycleTestDB` (`internal/im/service_lifecycle_test.go`) derived its in-memory SQLite database name from `time.Now().UnixNano()` alone. Two tests whose helper calls land in the same wall-clock tick therefore share one `cache=shared` database, and the second `CREATE TABLE im_channels` fails with `table im_channels already exists`. A shared database also means a test can observe tables or rows created by another test.

Every other test database in the tree names itself from `t.Name()` or a UUID (`internal/application/repository/tenant_api_key_test.go`, `internal/application/service/memory/service_test.go`, `internal/application/repository/chunk_revision_test.go`, and others); this helper was the only outlier. It now uses `t.Name()`, matching the existing convention, and a guard test opens the helper in two subtests and asserts the second database is empty.

Measured on `7a98a8e3` with go1.26.3 / Windows 10, `CGO_ENABLED=1`, 8 consecutive `go test ./internal/im/ -count=1` runs:

- before: 6 failed, 2 passed (`table im_channels already exists`; a different lifecycle test failing each time)
- after: 8 passed, 0 failed

The window is the platform's wall-clock granularity — on Windows the wall clock advances in ~15.6 ms steps, so two tests that each open a database within one step collide; the same holds for any sandboxed or virtualized host with a coarse or paused clock. The failure is independent of the code under test: the affected tests are unrelated to each other and pass in isolation.

Fixes #3198.

## Type of Change
- [x] 🧪 Test

## Related Issue
Fixes #3198

## Testing

- `go test ./internal/im/ -count=1` — 8/8 consecutive runs pass with the change; 2/8 pass without it (same environment, base commit `7a98a8e3`)
- `go test ./internal/im/ -run 'TestNewLifecycleTestDBIsolatesTests|TestServiceLifecycle|TestLeadershipLoss' -count=1` — pass
- `go vet ./internal/im/...`, `go build ./internal/im/...` — clean
- `gofmt -l internal/im/service_lifecycle_test.go`, `git diff --check` — clean
- `golangci-lint run --new-from-rev=origin/main ./internal/im/...` — 0 issues (v2.12.2)

Note on the guard test: `TestNewLifecycleTestDBIsolatesTests` is an isolation guard, not a deterministic reproducer of the old behaviour. With `t.Name()` the two subtests are guaranteed distinct names; with the clock-derived name a collision is timing-dependent, so the guard can pass on a fine-grained clock even against the old helper. The reproduction evidence is the repeated suite runs above.

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation (README, `docs/`, Swagger annotations, etc.) — not applicable, test-only change
- [x] Breaking changes are clearly called out in the description above — none

## Screenshots / Recordings
Not applicable (test-only change).
