### PR TITLE
fix(knowledge): make URL import size limit follow MAX_FILE_SIZE_MB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -194,6 +194,8 @@ LOCAL_STORAGE_BASE_DIR=/data/files
 # LOCAL_STORAGE_PATH_PREFIX=
 # 统一文件大小限制（MB，默认 50）。影响知识库/附件单文件上传、docreader gRPC 消息、浏览器知识库校验。属部署期配置：Go/Nginx/docreader/浏览器四层启动时读一次，运行中改不生效，改后须同步重启四层。
 # MAX_FILE_SIZE_MB=50
+# 知识库 URL 导入（远程文件下载）大小上限（MB）。未设置时跟随 MAX_FILE_SIZE_MB；此前该路径写死 10MB，调大 MAX_FILE_SIZE_MB 也不会生效。若希望 URL 下载比本地上传更严，可单独设更小值。改后须重启 app。
+# MAX_FILE_URL_SIZE_MB=50
 # 技能 zip 上传与 GitHub/ClawHub 来源下载上限（MB，默认 256）。与知识库上传分开：ppt-master 一类技能包会超过 50MB。GitHub zipball 按整仓压缩包计，不是 SKILL.md 子树；仓过大仍会在下载阶段被拒。未设置时不低于 MAX_FILE_SIZE_MB，且不超过 512。Nginx 只对 POST /api/v1/skills/catalog 与 POST /api/v1/sandbox-configs/{id}/skills 放宽到这个值，/install、PATCH 等子路径仍是 MAX_FILE_SIZE_MB。改后须重启 app 与 frontend。
 # MAX_SKILL_BUNDLE_SIZE_MB=256
 

--- a/internal/application/service/knowledge_create.go
+++ b/internal/application/service/knowledge_create.go
@@ -463,9 +463,6 @@ func (s *knowledgeService) CreateKnowledgeFromURL(ctx context.Context,
 	return knowledge, nil
 }
 
-// maxFileURLSize is the maximum allowed file size for file URL import (10MB)
-const maxFileURLSize = 10 * 1024 * 1024
-
 // extractFileNameFromURL extracts the filename from a URL path
 func extractFileNameFromURL(rawURL string) string {
 	u, err := url.Parse(rawURL)

--- a/internal/application/service/knowledge_util.go
+++ b/internal/application/service/knowledge_util.go
@@ -475,9 +475,14 @@ func downloadFileFromURL(ctx context.Context, fileURL string, payloadFileName, p
 		return nil, fmt.Errorf("remote server returned status %d", resp.StatusCode)
 	}
 
-	// Reject oversized files early via Content-Length
+	// Reject oversized files early via Content-Length. Cap follows
+	// MAX_FILE_URL_SIZE_MB, or MAX_FILE_SIZE_MB when that is unset (#3171).
+	maxFileURLSize := secutils.GetMaxFileURLSize()
 	if contentLength := resp.ContentLength; contentLength > maxFileURLSize {
-		return nil, fmt.Errorf("file size %d bytes exceeds limit of %d bytes (10MB)", contentLength, maxFileURLSize)
+		return nil, fmt.Errorf(
+			"file size %d bytes exceeds limit of %d bytes (%dMB)",
+			contentLength, maxFileURLSize, secutils.GetMaxFileURLSizeMB(),
+		)
 	}
 
 	// Resolve fileName: payload > Content-Disposition > URL path
@@ -508,7 +513,10 @@ func downloadFileFromURL(ctx context.Context, fileURL string, payloadFileName, p
 		return nil, fmt.Errorf("failed to write temp file: %w", err)
 	}
 	if written > maxFileURLSize {
-		return nil, fmt.Errorf("file size exceeds limit of 10MB")
+		return nil, fmt.Errorf(
+			"file size exceeds limit of %dMB",
+			secutils.GetMaxFileURLSizeMB(),
+		)
 	}
 
 	contentBytes, err := os.ReadFile(tmpPath)

--- a/internal/utils/filesize.go
+++ b/internal/utils/filesize.go
@@ -39,6 +39,28 @@ func GetMaxFileSizeMB() int64 {
 	return envSizeMB("MAX_FILE_SIZE_MB", defaultMaxFileSizeMB)
 }
 
+// GetMaxFileURLSizeMB returns the maximum remote file size accepted by the
+// file-URL import path, in MB.
+//
+// MAX_FILE_URL_SIZE_MB is optional. When unset, the URL import path follows
+// MAX_FILE_SIZE_MB so raising the deploy-time upload cap also unblocks URL
+// imports (the path previously hard-coded 10MB, which operators could not
+// raise without a code change). Set MAX_FILE_URL_SIZE_MB explicitly to keep
+// URL downloads tighter than local uploads.
+func GetMaxFileURLSizeMB() int64 {
+	if sizeStr := os.Getenv("MAX_FILE_URL_SIZE_MB"); sizeStr != "" {
+		if size, err := strconv.ParseInt(sizeStr, 10, 64); err == nil && size > 0 {
+			return size
+		}
+	}
+	return GetMaxFileSizeMB()
+}
+
+// GetMaxFileURLSize returns the file-URL import cap in bytes.
+func GetMaxFileURLSize() int64 {
+	return GetMaxFileURLSizeMB() * 1024 * 1024
+}
+
 // GetMaxSkillBundleSize is the compressed zip / source-download cap for
 // skills. Knowledge uploads stay on GetMaxFileSize: packages such as
 // ppt-master exceed 50MB, but raising the document limit would also

--- a/internal/utils/filesize_test.go
+++ b/internal/utils/filesize_test.go
@@ -38,3 +38,44 @@ func TestGetMaxSkillBundleSizeMB(t *testing.T) {
 		}
 	})
 }
+
+func TestGetMaxFileURLSizeMB(t *testing.T) {
+	t.Run("follows MAX_FILE_SIZE_MB when MAX_FILE_URL_SIZE_MB is unset", func(t *testing.T) {
+		t.Setenv("MAX_FILE_SIZE_MB", "200")
+		t.Setenv("MAX_FILE_URL_SIZE_MB", "")
+		if got := GetMaxFileURLSizeMB(); got != 200 {
+			t.Fatalf("GetMaxFileURLSizeMB() = %d, want 200", got)
+		}
+		if got := GetMaxFileURLSize(); got != 200*1024*1024 {
+			t.Fatalf("GetMaxFileURLSize() = %d, want %d", got, int64(200*1024*1024))
+		}
+	})
+
+	t.Run("defaults to the knowledge upload cap", func(t *testing.T) {
+		t.Setenv("MAX_FILE_SIZE_MB", "")
+		t.Setenv("MAX_FILE_URL_SIZE_MB", "")
+		if got := GetMaxFileURLSizeMB(); got != defaultMaxFileSizeMB {
+			t.Fatalf("GetMaxFileURLSizeMB() = %d, want %d", got, defaultMaxFileSizeMB)
+		}
+	})
+
+	t.Run("honours an explicit URL cap independent of MAX_FILE_SIZE_MB", func(t *testing.T) {
+		t.Setenv("MAX_FILE_SIZE_MB", "200")
+		t.Setenv("MAX_FILE_URL_SIZE_MB", "10")
+		if got := GetMaxFileURLSizeMB(); got != 10 {
+			t.Fatalf("GetMaxFileURLSizeMB() = %d, want 10", got)
+		}
+	})
+
+	t.Run("ignores non-positive or invalid values", func(t *testing.T) {
+		t.Setenv("MAX_FILE_SIZE_MB", "50")
+		t.Setenv("MAX_FILE_URL_SIZE_MB", "0")
+		if got := GetMaxFileURLSizeMB(); got != 50 {
+			t.Fatalf("GetMaxFileURLSizeMB() = %d, want 50 (zero rejected)", got)
+		}
+		t.Setenv("MAX_FILE_URL_SIZE_MB", "not-a-number")
+		if got := GetMaxFileURLSizeMB(); got != 50 {
+			t.Fatalf("GetMaxFileURLSizeMB() = %d, want 50 (invalid rejected)", got)
+		}
+	})
+}

--- a/website-docs/01-getting-started/04-configuration.md
+++ b/website-docs/01-getting-started/04-configuration.md
@@ -148,6 +148,7 @@ flowchart LR
 | `WEKNORA_TRUSTED_PROXIES` | 空 | gin 信任代理 CIDR（逗号分隔） |
 | `MAX_SKILL_BUNDLE_SIZE_MB` | 256 MiB（默认不小于 MAX_FILE_SIZE_MB，上限 512 MiB） | 技能 ZIP 上传与来源下载上限；反向代理请求体限制也需足够大 |
 | `MAX_FILE_SIZE_MB` | 50 | 上传文件大小限制（app/frontend/docreader 三处共用） |
+| `MAX_FILE_URL_SIZE_MB` | 跟随 `MAX_FILE_SIZE_MB` | 知识库 URL 导入（远程文件下载）上限；可单独设更小值 |
 | `CONCURRENCY_POOL_SIZE` | 5 | 通用并发池 |
 | `APP_EXTERNAL_URL` / `FRONTEND_BASE_URL` | 空 | IM 渠道图片/文件外链的外部可达 URL / 前端外部 origin |
 | `RESOURCE_URL_MODE` | handle | API 响应里文件引用的默认形式：`handle` 返回内部 `resource://`，`public` 返回可直接加载的限时外链。单次请求可用 `?resource_urls=` 覆盖，详见 [API 总览](../04-api/01-api-overview.md) |


### PR DESCRIPTION
﻿## Description

URL 导入（远程文件下载）的大小上限此前写死 10MB，与本地上传路径使用的 `MAX_FILE_SIZE_MB`（默认 50，可调到 200）不一致。运维把 `MAX_FILE_SIZE_MB` 调大后，URL 导入仍被 10MB 拦住，且报错文案写死 “10MB”，没有可配置入口。

本 PR：

- 在 `internal/utils/filesize.go` 增加 `GetMaxFileURLSizeMB` / `GetMaxFileURLSize`
  - 设置了 `MAX_FILE_URL_SIZE_MB` 时用该值
  - 未设置时跟随 `MAX_FILE_SIZE_MB`
- `downloadFileFromURL` 的 Content-Length 预检与流式截断都改用该 helper，错误信息报告实际上限
- 更新 `.env.example` 与 `website-docs/01-getting-started/04-configuration.md`

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #3171

## Testing

- 为 `GetMaxFileURLSizeMB` 增加单测：默认跟随 `MAX_FILE_SIZE_MB`、显式 `MAX_FILE_URL_SIZE_MB`、非法值回退
- 本机 Windows MinGW 4.9 过旧，`internal/utils` 因 `pg_query` CGO 无法完整 `go test`（与本 diff 无关）；请以 CI 的 go-lint / 测试为准
- 逻辑为纯 Go，调用点与既有 `GetMaxFileSizeMB` 用法一致

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [ ] Targeted tests for the changed packages/components pass（本机 CGO 受限，见上）
- [ ] Diff-scoped lint passes where applicable
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation
- [ ] Breaking changes are clearly called out in the description above
