### PR TITLE
feat(mcp): pass fileName and folder filters to knowledge APIs

### DIFF
--- a/mcp-server/test_file_name_folder_passthrough.py
+++ b/mcp-server/test_file_name_folder_passthrough.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Tests for MCP file_name / folder_path passthrough (issue #3173)."""
+
+import sys
+import types
+import unittest
+from unittest import mock
+
+# Lightweight stub so unit tests can import the client module without the
+# full MCP SDK installed (CI installs real deps; this only covers the HTTP client).
+if "mcp" not in sys.modules:
+    mcp_pkg = types.ModuleType("mcp")
+    mcp_server = types.ModuleType("mcp.server")
+
+    class _MCPServer:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def tool(self):
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+    mcp_server.MCPServer = _MCPServer
+    mcp_pkg.server = mcp_server
+    sys.modules["mcp"] = mcp_pkg
+    sys.modules["mcp.server"] = mcp_server
+
+import weknora_mcp_server as srv  # noqa: E402
+
+
+class CreateKnowledgeFromFileTest(unittest.TestCase):
+    def test_includes_file_name_in_multipart_when_set(self):
+        client = srv.WeKnoraClient("http://localhost:8080/api/v1", "k")
+        payload = b"pdf-bytes"
+        with mock.patch(
+            "builtins.open", mock.mock_open(read_data=payload)
+        ), mock.patch.object(
+            srv, "resolve_upload_file_path", return_value="/safe/doc.pdf"
+        ), mock.patch.object(
+            srv.requests, "post"
+        ) as post:
+            post.return_value = mock.Mock(
+                raise_for_status=lambda: None,
+                json=lambda: {"id": "k1"},
+            )
+            client.create_knowledge_from_file(
+                "kb-1", "doc.pdf", enable_multimodel=True, file_name="docs/spec/doc.pdf"
+            )
+        data = post.call_args.kwargs["data"]
+        self.assertEqual(data["fileName"], "docs/spec/doc.pdf")
+        self.assertEqual(data["enable_multimodel"], "true")
+
+    def test_omits_file_name_when_empty(self):
+        client = srv.WeKnoraClient("http://localhost:8080/api/v1", "k")
+        with mock.patch(
+            "builtins.open", mock.mock_open(read_data=b"x")
+        ), mock.patch.object(
+            srv, "resolve_upload_file_path", return_value="/safe/doc.pdf"
+        ), mock.patch.object(
+            srv.requests, "post"
+        ) as post:
+            post.return_value = mock.Mock(
+                raise_for_status=lambda: None,
+                json=lambda: {"id": "k1"},
+            )
+            client.create_knowledge_from_file("kb-1", "doc.pdf")
+        self.assertNotIn("fileName", post.call_args.kwargs["data"])
+
+
+class ListKnowledgeFolderTest(unittest.TestCase):
+    def test_forwards_folder_path_and_scope(self):
+        client = srv.WeKnoraClient("http://localhost:8080/api/v1", "k")
+        with mock.patch.object(client, "_request", return_value={"items": []}) as req:
+            client.list_knowledge(
+                "kb-1", page=2, page_size=10, folder_path="docs", folder_scope="all"
+            )
+        params = req.call_args.kwargs["params"]
+        self.assertEqual(params["page"], 2)
+        self.assertEqual(params["page_size"], 10)
+        self.assertEqual(params["folder_path"], "docs")
+        self.assertEqual(params["folder_scope"], "all")
+
+    def test_omits_folder_params_when_unset(self):
+        client = srv.WeKnoraClient("http://localhost:8080/api/v1", "k")
+        with mock.patch.object(client, "_request", return_value={"items": []}) as req:
+            client.list_knowledge("kb-1")
+        params = req.call_args.kwargs["params"]
+        self.assertNotIn("folder_path", params)
+        self.assertNotIn("folder_scope", params)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp-server/weknora_mcp_server.py
+++ b/mcp-server/weknora_mcp_server.py
@@ -301,13 +301,23 @@ class WeKnoraClient:
 
     # Knowledge Management - Methods for creating and managing knowledge entries
     def create_knowledge_from_file(
-        self, kb_id: str, file_path: str, enable_multimodel: bool = True
+        self,
+        kb_id: str,
+        file_path: str,
+        enable_multimodel: bool = True,
+        file_name: str = "",
     ) -> Dict:
-        """Create knowledge from a local file with optional multimodal processing"""
+        """Create knowledge from a local file with optional multimodal processing.
+
+        ``file_name`` may be a path-qualified name (``docs/spec/design.pdf``);
+        the backend splits it into ``folder_path`` + display name.
+        """
         safe_path = resolve_upload_file_path(file_path)
         with open(safe_path, "rb") as f:
             files = {"file": f}
             data = {"enable_multimodel": str(enable_multimodel).lower()}
+            if file_name:
+                data["fileName"] = file_name
             # Temporarily remove Content-Type header for multipart/form-data request
             # (requests will set it automatically with boundary)
             headers = self.session.headers.copy()
@@ -380,9 +390,25 @@ class WeKnoraClient:
         }
         return self._request("PUT", f"/knowledge/manual/{knowledge_id}", json=data)
 
-    def list_knowledge(self, kb_id: str, page: int = 1, page_size: int = 20) -> Dict:
-        """List knowledge in a knowledge base"""
+    def list_knowledge(
+        self,
+        kb_id: str,
+        page: int = 1,
+        page_size: int = 20,
+        folder_path: str | None = None,
+        folder_scope: str = "",
+    ) -> Dict:
+        """List knowledge in a knowledge base.
+
+        ``folder_path`` filters to one folder (empty string = root).
+        ``folder_scope`` is passed through when the backend supports
+        scoped folder listing.
+        """
         params = {"page": page, "page_size": page_size}
+        if folder_path is not None:
+            params["folder_path"] = folder_path
+        if folder_scope:
+            params["folder_scope"] = folder_scope
         return self._request(
             "GET", f"/knowledge-bases/{kb_id}/knowledge", params=params
         )
@@ -744,9 +770,18 @@ def create_knowledge_from_file(
     kb_id: str,
     file_path: str,
     enable_multimodel: bool = True,
+    file_name: str = "",
 ) -> dict:
-    """Create knowledge from a local file on the server filesystem."""
-    return client.create_knowledge_from_file(kb_id, file_path, enable_multimodel)
+    """Create knowledge from a local file on the server filesystem.
+
+    ``file_name`` is optional. Pass a path-qualified name such as
+    ``docs/spec/design.pdf`` to place the entry under a knowledge folder
+    (backend splits folder path + display name). Omit it to keep the
+    original filename at the knowledge-base root.
+    """
+    return client.create_knowledge_from_file(
+        kb_id, file_path, enable_multimodel, file_name=file_name
+    )
 
 
 @mcp.tool()
@@ -800,9 +835,21 @@ def update_knowledge_from_text(
 
 
 @mcp.tool()
-def list_knowledge(kb_id: str, page: int = 1, page_size: int = 20) -> dict:
-    """List knowledge entries in a knowledge base."""
-    return client.list_knowledge(kb_id, page, page_size)
+def list_knowledge(
+    kb_id: str,
+    page: int = 1,
+    page_size: int = 20,
+    folder_path: str | None = None,
+    folder_scope: str = "",
+) -> dict:
+    """List knowledge entries in a knowledge base.
+
+    ``folder_path`` optionally filters to one folder (``""`` = root).
+    ``folder_scope`` is forwarded when the backend supports scoped listing.
+    """
+    return client.list_knowledge(
+        kb_id, page, page_size, folder_path=folder_path, folder_scope=folder_scope
+    )
 
 
 @mcp.tool()


### PR DESCRIPTION
﻿## Description

MCP `create_knowledge_from_file` 未透传 `fileName`，上传的知识条目全部落在知识库根目录；后端自 v0.7.2 起已支持路径限定文件名（`docs/spec/design.pdf` → `folder_path` + 显示名）。`list_knowledge` 也未暴露后端已支持的 `folder_path` / `folder_scope` 查询参数。

本 PR：

- `create_knowledge_from_file` 增加可选参数 `file_name`，非空时写入 multipart 字段 `fileName`
- `list_knowledge` 增加可选 `folder_path` / `folder_scope`，透传给 REST 列表接口
- 默认行为向后兼容（不传参数时与原先一致）
- 新增 `test_file_name_folder_passthrough.py` 覆盖透传与省略路径

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #3173

## Testing

```
cd mcp-server
python -m unittest test_file_name_folder_passthrough.py -v
```

4 tests pass（本机用轻量 `mcp` stub 导入 client，仅测 HTTP 客户端方法；CI 安装完整依赖）。

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation
- [ ] Breaking changes are clearly called out in the description above
