### PR TITLE
feat(mcp): expose wiki_graph tool for the link-graph endpoint

### DIFF
--- a/mcp-server/test_wiki_graph.py
+++ b/mcp-server/test_wiki_graph.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Tests for MCP wiki_graph passthrough (issue #3177)."""
+
+import sys
+import types
+import unittest
+from unittest import mock
+
+if "mcp" not in sys.modules:
+    mcp_pkg = types.ModuleType("mcp")
+    mcp_server = types.ModuleType("mcp.server")
+
+    class _MCPServer:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def tool(self):
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+    mcp_server.MCPServer = _MCPServer
+    mcp_pkg.server = mcp_server
+    sys.modules["mcp"] = mcp_pkg
+    sys.modules["mcp.server"] = mcp_server
+
+import weknora_mcp_server as srv  # noqa: E402
+
+
+class WikiGraphClientTest(unittest.TestCase):
+    def test_forwards_ego_params(self):
+        client = srv.WeKnoraClient("http://localhost:8080/api/v1", "k")
+        with mock.patch.object(client, "_request", return_value={"nodes": []}) as req:
+            client.wiki_graph(
+                "kb-1",
+                mode="ego",
+                center="entity/acme",
+                depth=2,
+                limit=100,
+                page_types="entity,concept",
+            )
+        self.assertEqual(req.call_args.args[0], "GET")
+        self.assertEqual(
+            req.call_args.args[1], "/knowledgebase/kb-1/wiki/graph"
+        )
+        params = req.call_args.kwargs["params"]
+        self.assertEqual(params["mode"], "ego")
+        self.assertEqual(params["center"], "entity/acme")
+        self.assertEqual(params["depth"], 2)
+        self.assertEqual(params["limit"], 100)
+        self.assertEqual(params["types"], "entity,concept")
+
+    def test_omits_empty_center_and_types(self):
+        client = srv.WeKnoraClient("http://localhost:8080/api/v1", "k")
+        with mock.patch.object(client, "_request", return_value={"nodes": []}) as req:
+            client.wiki_graph("kb-1")
+        params = req.call_args.kwargs["params"]
+        self.assertNotIn("center", params)
+        self.assertNotIn("types", params)
+        self.assertEqual(params["mode"], "overview")
+
+
+class WikiGraphToolTest(unittest.TestCase):
+    def test_clamps_depth_and_limit(self):
+        with mock.patch.object(
+            srv.client, "wiki_graph", return_value={"nodes": []}
+        ) as method:
+            srv.wiki_graph("kb-1", mode="overview", depth=99, limit=99999)
+        kwargs = method.call_args.kwargs
+        self.assertEqual(kwargs["depth"], 3)
+        self.assertEqual(kwargs["limit"], 2000)
+
+    def test_rejects_invalid_mode(self):
+        with self.assertRaises(ValueError):
+            srv.wiki_graph("kb-1", mode="nope")
+
+    def test_requires_center_for_ego(self):
+        with self.assertRaises(ValueError):
+            srv.wiki_graph("kb-1", mode="ego")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp-server/weknora_mcp_server.py
+++ b/mcp-server/weknora_mcp_server.py
@@ -628,6 +628,32 @@ class WeKnoraClient:
             params={"limit": limit},
         )
 
+    def wiki_graph(
+        self,
+        kb_id: str,
+        mode: str = "overview",
+        center: str = "",
+        depth: int = 1,
+        limit: int = 500,
+        page_types: str = "",
+    ) -> Dict:
+        """Fetch a slice of the wiki link graph (nodes + directed edges).
+
+        ``mode`` is ``overview`` (top-N by connectivity) or ``ego`` (BFS
+        neighborhood of ``center``). Depth is capped at 3 and limit at 2000
+        by the REST handler.
+        """
+        params: Dict[str, object] = {"mode": mode, "depth": depth, "limit": limit}
+        if center:
+            params["center"] = center
+        if page_types:
+            params["types"] = page_types
+        return self._request(
+            "GET",
+            f"/knowledgebase/{kb_id}/wiki/graph",
+            params=params,
+        )
+
 
 # Initialize MCP server instance (mcp 2.x high-level API).
 # MCPServer (formerly FastMCP) builds input schemas from function type hints
@@ -1049,6 +1075,43 @@ def wiki_index_view(kb_id: str, limit: int = 50) -> dict:
     summary, etc.).
     """
     return client.wiki_index_view(kb_id, limit)
+
+
+@mcp.tool()
+def wiki_graph(
+    kb_id: str,
+    mode: str = "overview",
+    center: str = "",
+    depth: int = 1,
+    limit: int = 500,
+    page_types: str = "",
+) -> dict:
+    """Get a slice of the wiki link graph (nodes + directed edges).
+
+    mode=overview returns the top-N most-connected pages. mode=ego returns
+    the BFS neighborhood of ``center`` (a page slug from wiki_search).
+    ``page_types`` is an optional comma-separated type allow-list (e.g.
+    ``entity,concept``). depth max 3, limit max 2000.
+
+    Typical flow: wiki_search → wiki_graph(mode="ego", center=slug) →
+    wiki_read_page.
+    """
+    if mode not in ("overview", "ego"):
+        raise ValueError("mode must be 'overview' or 'ego'")
+    if mode == "ego" and not center:
+        raise ValueError("center slug is required when mode='ego'")
+    # Match REST handler bounds so MCP callers get a clear error instead of
+    # a silent server-side clamp surprise in the response meta.
+    depth = max(1, min(int(depth), 3))
+    limit = max(1, min(int(limit), 2000))
+    return client.wiki_graph(
+        kb_id,
+        mode=mode,
+        center=center,
+        depth=depth,
+        limit=limit,
+        page_types=page_types,
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
﻿## Description

MCP Server 已有 `wiki_search` / `wiki_read_page` / `wiki_index_view`，但未暴露后端已有的链接图端点：

```
GET /knowledgebase/:kb_id/wiki/graph?mode=overview|ego&center=&depth=&limit=&types=
```

MCP 集成方通常只把 WeKnora 当检索后端，拿不到全局/关联结构信息。本 PR 新增 `wiki_graph` 工具，映射该端点：

- `mode=overview`（默认）或 `mode=ego`（需 `center` slug）
- `depth` / `limit` 在工具侧钳到 handler 上限（3 / 2000），非法 `mode`、缺失 `center` 直接报错
- 可选 `page_types` 对应 `types` 查询参数

典型用法：`wiki_search` → `wiki_graph(mode="ego", center=slug)` → `wiki_read_page`。

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue
Fixes #3177

## Testing

```
cd mcp-server
python -m unittest test_wiki_graph.py -v
```

5 tests pass（参数透传、钳位、mode/center 校验）。

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [ ] Diff-scoped lint passes where applicable
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Updated related documentation
- [ ] Breaking changes are clearly called out in the description above
