### PR TITLE
feat(skills): verify lock pins and reject rewritten manifests

### DIFF
--- a/internal/application/service/tenant_skill_install.go
+++ b/internal/application/service/tenant_skill_install.go
@@ -45,17 +45,6 @@ const (
 	// files. Writing each file with MakeDir+WriteFile is two round trips per
 	// entry, which is why a 50-file skill crawled through "seeding 12/56".
 	skillSeedArchivePath = sandbox.SkillsImageRoot + "/.weknora-seed.tar"
-
-	// skillInstallVerifyRounds bounds the installer conversation.
-	//
-	// The first round works from SKILL.md. A second is driven by the gate's own
-	// findings, and exists because those are two different descriptions of what
-	// a skill needs: the official office toolkit imports defusedxml and lxml at
-	// module level while its SKILL.md names neither, so an installer working
-	// from prose alone cannot know to install them. One round of reconciliation
-	// closes that gap; more would only be a retry loop over an answer that is
-	// not going to change.
-	skillInstallVerifyRounds = 2
 )
 
 // InstallSkill validates an uploaded archive, records it, and kicks off the
@@ -752,20 +741,12 @@ type installerJob struct {
 	bundle     *SkillBundle
 }
 
-// installDependenciesAndVerify runs the installer conversation and the gate as
-// one decision.
-//
-// They used to be two, and that is what let a working skill be rejected: the
-// installer derived what to install from SKILL.md prose while the gate derived
-// what must resolve from the imports every file executes. Those disagree on any
-// skill whose library modules import something its documentation never names,
-// and the install died with the answer already in hand. The gate is the only
-// authority here, so its own findings become the next round's instruction, and
-// nothing in this path derives that list a second time.
-//
-// A failure the gate marked unrepairable — a syntax error, a file the execution
-// user cannot read — ends the run immediately. Another round cannot change it,
-// and the bundle has to change instead.
+// installDependenciesAndVerify runs one installer turn, then the server's
+// gate. A second billed round used to exist because the gate judged imports
+// the SKILL.md never named; that check is gone, and the remaining failures
+// are either unfixable (syntax, missing files) or the same missing packages
+// a later session can install. Another agent turn will not make either more
+// likely.
 func (s *TenantSkillService) installDependenciesAndVerify(
 	ctx context.Context, job installerJob,
 ) (err error) {
@@ -779,49 +760,23 @@ func (s *TenantSkillService) installDependenciesAndVerify(
 	// what someone will want to read.
 	defer func() { job.transcript.Finish(context.WithoutCancel(ctx), err) }()
 
-	prompt := job.prompt
-	for round := 1; ; round++ {
-		if err = run.round(ctx, prompt); err != nil {
-			return err
-		}
-		s.publishProgress(ctx, job.tenantID, job.configID, job.skillID,
-			SkillProgress{Percent: 80, Stage: "agent_done"})
-		// The agent's part of this round is over: mute the asymptotic activity
-		// progress so verification and any repair round — which publish their
-		// own stage anchors (80 / 82) — cannot be dragged back below them by
-		// the next round's tool calls.
-		job.transcript.muteActivityProgress()
-
-		notes, verifyErr := s.verifySkill(ctx, job.mgr, job.sess.ID, job.skillDir, job.bundle)
-		s.reportVerificationNotes(ctx, job, notes)
-		if verifyErr == nil {
-			return nil
-		}
-
-		var gate *skillVerificationError
-		if round >= skillInstallVerifyRounds || !errors.As(verifyErr, &gate) || !gate.Repairable {
-			err = verifyErr
-			return err
-		}
-
-		logger.Infof(ctx, "[skill] %s failed %s verification with %d fixable finding(s); "+
-			"handing them back to the installer", job.skillID, gate.Language, len(gate.Problems))
-		s.publishProgress(ctx, job.tenantID, job.configID, job.skillID, SkillProgress{
-			Percent: 82, Stage: "repairing",
-			Log: fmt.Sprintf("%s verification found %d dependency problem(s); "+
-				"asking the installer to restore the declared dependencies", gate.Language, len(gate.Problems)),
-		})
-		prompt = buildRepairPrompt(job.skillDir, gate)
-		if job.guidance != "" {
-			prompt += "\n\nAdministrator instructions (preserve during repair):\n" + job.guidance
-		}
-		job.transcript.RecordPrompt(prompt)
+	if err = run.round(ctx, job.prompt); err != nil {
+		return err
 	}
+	s.publishProgress(ctx, job.tenantID, job.configID, job.skillID,
+		SkillProgress{Percent: 80, Stage: "agent_done"})
+	// The agent phase is over. Mute the asymptotic bar so verification cannot
+	// be dragged back below the 80 anchor by a stray tool event.
+	job.transcript.muteActivityProgress()
+
+	var notes []string
+	notes, err = s.verifySkill(ctx, job.mgr, job.sess.ID, job.skillDir, job.bundle)
+	s.reportVerificationNotes(ctx, job, notes)
+	return err
 }
 
-// installerRun is one installer conversation, held open across rounds. A repair
-// has to reach the same root shell, in the same sandbox, and be readable in the
-// same transcript as the install it is repairing.
+// installerRun is one installer conversation. Administrator guidance arriving
+// before the agent stops is injected as a continuation of the same turn.
 type installerRun struct {
 	engine     interfaces.AgentEngine
 	transcript *installTranscript
@@ -876,13 +831,8 @@ func (s *TenantSkillService) openInstallerRun(
 	return run, nil
 }
 
-// round runs one installer turn.
-//
-// No conversation history is replayed. The engine is stateless across turns, so
-// a repair round could be handed the first round's transcript — but what the
-// gate reported is both shorter and more exact than anything that could be
-// inferred from it, and re-reading the round that already missed a dependency
-// is not what makes the next one find it.
+// round runs the installer turn, continuing only when administrator guidance
+// arrived at a natural stop and has not yet been applied.
 func (r *installerRun) round(ctx context.Context, prompt string) error {
 	if r.steer != nil {
 		if err := r.steer.service.withInstallSteerLock(ctx, r.sessionID, func(ctx context.Context) error {
@@ -905,7 +855,7 @@ func (r *installerRun) round(ctx context.Context, prompt string) error {
 	for continuation := 0; ; continuation++ {
 		input := prompt
 		if r.steer != nil && len(r.steer.guidance) > 0 {
-			input += "\n\nAdministrator guidance already received (preserve during repair):\n" +
+			input += "\n\nAdministrator guidance already received:\n" +
 				strings.Join(r.steer.guidance, "\n\n")
 		}
 		if continuation > 0 {
@@ -959,42 +909,6 @@ func (s *TenantSkillService) reportVerificationNotes(
 	s.publishProgress(ctx, job.tenantID, job.configID, job.skillID, SkillProgress{
 		Percent: 80, Stage: "verify_note", Log: strings.Join(notes, "\n"),
 	})
-}
-
-// buildRepairPrompt turns the gate's own findings into the next round's brief.
-//
-// It carries no analysis of its own, deliberately: the gate is the only
-// authority on what has to resolve in this image, and a second description
-// written here could disagree with it. Every repairable finding names a
-// distribution one of the skill's manifests declares and pip did not land, so
-// the brief is short — install what the lines name, change nothing else.
-func buildRepairPrompt(skillDir string, gate *skillVerificationError) string {
-	var findings strings.Builder
-	for _, problem := range gate.Problems {
-		findings.WriteString("- ")
-		findings.WriteString(problem)
-		findings.WriteString("\n")
-	}
-	return fmt.Sprintf(`Verification of the skill you just installed failed. Fix only this and stop.
-
-The %s check reported:
-%s
-Resolve the findings above. For missing packages or incompatible installed versions, restore the declared versions.
-If requirements.lock exists, reinstall from that lock with --require-hashes; do not
-upgrade packages independently or erase their constraints. For a missing or invalid runtime report,
-assess prerequisites from SKILL.md and write the report. Never erase a prerequisite to pass the check.
-
-- Python packages go into %s/.venv (`+"`uv pip install`"+`, or
-  %s/.venv/bin/python -m pip install). Node packages go under %s/node_modules.
-- Do NOT edit SKILL.md, requirements.txt, pyproject.toml or package.json to
-  make the check pass. Those files are what read_skill serves, so weakening a
-  declaration here makes the installed skill differ from what everyone else
-  sees — and the dependency would still be missing at run time.
-- If a package genuinely cannot be installed in this image, say so plainly in
-  your summary rather than working around it.
-
-The same verification runs again as soon as you finish.
-`+"\n"+skillInstallRuntimeInstructions, gate.Language, findings.String(), skillDir, skillDir, skillDir)
 }
 
 // skillCacheBudgetMB caps the package download caches one image carries into

--- a/internal/application/service/tenant_skill_install.go
+++ b/internal/application/service/tenant_skill_install.go
@@ -325,7 +325,7 @@ func (s *TenantSkillService) runInstall(
 	// It is deferred before it is stopped explicitly below, so a failure path
 	// still stops it ahead of the deferred failSkill.
 	stopHeartbeat := s.startInstallHeartbeat(ctx, tenantID, configID, skillID)
-	defer stopHeartbeat()
+	defer func() { stopHeartbeat() }()
 
 	// The name comes from SKILL.md and is already validated on parse, so a
 	// rejection here means the bundle was accepted by a looser rule than the
@@ -808,8 +808,8 @@ func (s *TenantSkillService) installDependenciesAndVerify(
 			"handing them back to the installer", job.skillID, gate.Language, len(gate.Problems))
 		s.publishProgress(ctx, job.tenantID, job.configID, job.skillID, SkillProgress{
 			Percent: 82, Stage: "repairing",
-			Log: fmt.Sprintf("%s verification found %d missing dependency/dependencies; "+
-				"asking the installer to add them", gate.Language, len(gate.Problems)),
+			Log: fmt.Sprintf("%s verification found %d dependency problem(s); "+
+				"asking the installer to restore the declared dependencies", gate.Language, len(gate.Problems)),
 		})
 		prompt = buildRepairPrompt(job.skillDir, gate)
 		if job.guidance != "" {
@@ -979,7 +979,9 @@ func buildRepairPrompt(skillDir string, gate *skillVerificationError) string {
 
 The %s check reported:
 %s
-Resolve the findings above. For missing packages, install them. For a missing or invalid runtime report,
+Resolve the findings above. For missing packages or incompatible installed versions, restore the declared versions.
+If requirements.lock exists, reinstall from that lock with --require-hashes; do not
+upgrade packages independently or erase their constraints. For a missing or invalid runtime report,
 assess prerequisites from SKILL.md and write the report. Never erase a prerequisite to pass the check.
 
 - Python packages go into %s/.venv (`+"`uv pip install`"+`, or
@@ -1786,39 +1788,45 @@ Hard requirements:
   WEKNORA_SESSION_INPUT_DIR: the sandbox injects those. Other WEKNORA_* names the skill reads
   (WEKNORA_API_KEY, WEKNORA_BASE_URL, WEKNORA_HOST, WEKNORA_TOKEN, WEKNORA_KB_ID) MUST be declared.
 
-On-demand / optional extras MUST be installed now. Every chat session starts
-from the image this install produces, and whatever a session installs dies with
-it, so an extra deferred to chat time is paid for again on every session and
-fails outright wherever the sandbox has no egress. Skills that ship
-scripts/install_deps.py or say "pip install when the user needs Word/PPT" will
-stall at chat time unless those packages are already in the venv.
+Dependency scope and versions:
 - Create the venv with pip present: `+"`uv venv --seed %s/.venv`"+` (or `+"`python3 -m venv`"+`).
-- Install requirements.txt / pyproject.toml with `+"`uv pip install`"+`.
-- Read SKILL.md and any on-demand installer for extra packages (python-docx,
-  python-pptx, …) and `+"`uv pip install`"+` every extra, not only the default set.
+- Read the package's SKILL.md runtime profile first. It defines the default supported
+  capabilities. UPSTREAM_SKILL.md and upstream examples do not expand that profile.
+- If requirements.lock exists, install exactly that lock with
+  `+"`uv pip install --python .venv/bin/python --require-hashes -r requirements.lock`"+`.
+  Do NOT upgrade or replace locked versions afterward. requirements.txt documents
+  direct dependencies; the lock also pins their transitive dependencies.
+- Otherwise install the declared requirements.txt / pyproject.toml dependencies.
+- Install optional extras only when the package's runtime profile or the user's
+  explicit installation instructions require them. Do not install every extra,
+  alternate engine or format dependency merely because upstream documentation lists it.
+- When an optional capability is excluded by the runtime profile, leave it excluded
+  and report that limitation. Do not alter manifests to hide a missing required dependency.
 %s
-- If an installer script needs --yes / --all / every extra flag, pass them.
+- Inspect on-demand installers before running them. Select only the required
+  capabilities; never pass --all just to include every optional dependency.
 %s
 Before you finish, PROVE the skill's imports resolve. Do not reason about it —
 run it. The server's own check cannot: it parses files without executing them,
 so it never learns whether an import would have worked. You have the real
 interpreter, so this is your job and yours only.
-- For each script the skill offers, run the import the way the skill would:
+- For each entry point required by the runtime profile, run the import the way the skill would:
   `+"`%s/.venv/bin/python -c 'import x'`"+`, or the script's own
   `+"`--help`"+` if it has one.
 - A failure here is usually one of two things. A missing distribution: install
   it. Or a module the skill ships that Python cannot find — then the script
   needs the directory on sys.path, and you fix the script with edit_skill_file
   rather than installing anything.
-- Do not declare success until every entry point imports cleanly.
+- Do not declare success until every required entry point imports cleanly.
 
 The server then checks what it can before the image is kept, so report what you
 did rather than whether it passed. It confirms every file parses with the
 interpreter that would run it, and that every distribution named in
-requirements.txt / pyproject.toml is installed in the venv. It never runs the
+requirements.txt / requirements.lock / pyproject.toml is installed in the venv
+at a compatible declared version, and that the original manifests were preserved. It never runs the
 skill's code and never judges an import.
-Lazy imports and install_deps.py extras are invisible to that check — you still
-have to install them.
+Verify required entry points for the runtime profile above. Lazy optional imports
+do not require installing excluded capabilities. Run the package smoke check when provided.
 
 %s
 
@@ -1843,7 +1851,7 @@ func formatOnDemandInstallers(bundle *SkillBundle) string {
 		quoted[i] = "`" + name + "`"
 	}
 	return "- This archive ships on-demand installer(s): " + strings.Join(quoted, ", ") +
-		". Run each one now with non-interactive flags covering every extra."
+		". Inspect their options and run only what the runtime profile requires."
 }
 
 func bundleOnDemandInstallers(bundle *SkillBundle) []string {

--- a/internal/application/service/tenant_skill_install_test.go
+++ b/internal/application/service/tenant_skill_install_test.go
@@ -612,7 +612,10 @@ func TestBuildInstallPromptAsksForADeclarationWithoutValues(t *testing.T) {
 		"a value the model invents would be stored as the workspace credential")
 	require.Contains(t, prompt, "WEKNORA_API_KEY",
 		"the installer must be told credential names are declarable, or it writes {\"env\":[]}")
-	require.Contains(t, prompt, "On-demand / optional extras MUST be installed now")
+	require.Contains(t, prompt, "install exactly that lock")
+	require.Contains(t, prompt, "Do NOT upgrade or replace locked versions afterward")
+	require.Contains(t, prompt, "Install optional extras only when")
+	require.NotContains(t, prompt, "On-demand / optional extras MUST be installed now")
 	require.Contains(t, prompt, "uv venv --seed")
 	require.Contains(t, prompt, "install_deps.py")
 	require.Contains(t, prompt, "write_skill_file",

--- a/internal/application/service/tenant_skill_install_test.go
+++ b/internal/application/service/tenant_skill_install_test.go
@@ -1592,65 +1592,26 @@ func TestRunInstallKeepsOldImageWhenVerificationFails(t *testing.T) {
 	require.NotEmpty(t, skill.Error)
 }
 
-// The failure this closes: the installer derives what to install from SKILL.md
-// prose, and the gate derives what must resolve from the imports every file
-// executes. Those disagree on any skill whose library modules import something
-// its documentation never names — the official office toolkit imports
-// defusedxml and lxml at module level and mentions neither — so the install
-// died with the answer already in hand, and a retry replayed the same prompt to
-// the same effect. The gate's own lines are the repair round's brief.
-func TestRunInstallHandsVerificationFindingsBackToTheInstaller(t *testing.T) {
+// Missing declared packages used to buy a second billed installer round.
+// Import checking is gone, and a later session can install the same package,
+// so verification now fails the run after the one turn the installer already had.
+func TestRunInstallDoesNotRetryWhenDeclaredPackagesAreMissing(t *testing.T) {
 	fx := newInstallFixture(t)
-	fx.loadCheckExitCodes = []int{skillVerifyRepairableExit, 0}
-	fx.loadCheckStderr = "scripts/office/validators/base.py imports defusedxml, " +
-		"which is not available in this image\n" +
-		"scripts/recalc.py imports openpyxl, which is not available in this image"
+	fx.loadCheckExitCodes = []int{skillVerifyRepairableExit}
+	fx.loadCheckStderr = "requirements.txt declares pandas but it is not installed in /opt/skills/pdf-tools/.venv"
 
-	require.NoError(t, fx.svc.runInstall(context.Background(), 7, "cfg-1", "sk-1", fx.bundle))
+	err := fx.svc.runInstall(context.Background(), 7, "cfg-1", "sk-1", fx.bundle)
 
-	require.Len(t, fx.agentPrompts, 2, "a fixable failure must reach the installer again")
-	repair := fx.agentPrompts[1]
-	require.Contains(t, repair, "imports defusedxml",
-		"the repair round is driven by the gate's own findings, not by a second guess")
-	require.Contains(t, repair, "imports openpyxl")
-	require.Contains(t, repair, installSkillDir+"/.venv",
-		"the round has to be told where the packages belong")
-	require.Contains(t, repair, "Do NOT edit",
-		"a repair must not be allowed to edit the tree into passing")
-
-	require.Equal(t, 2, fx.loadCheckPasses, "the repair has to be verified, not trusted")
-	require.Contains(t, fx.events, "create-snapshot")
-	require.NotNil(t, fx.configRepo.saved, "a repaired install must reach the image pointer")
-
-	skill, _ := fx.skillRepo.GetSkill(context.Background(), 7, "cfg-1", "sk-1")
-	require.Equal(t, types.SkillStatusReady, skill.Status)
-	require.Empty(t, skill.Error)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "declares pandas",
+		"the failure must name what the gate found, not just that it failed")
+	require.Len(t, fx.agentPrompts, 1, "a missing package must not buy another installer round")
+	require.Equal(t, 1, fx.loadCheckPasses)
+	require.NotContains(t, fx.events, "create-snapshot")
+	require.Nil(t, fx.configRepo.saved)
 }
 
-// A repair round writes into the tree a verification pass just looked at, and
-// under the default root account it reaches it directly: modes left behind by
-// an earlier pass do not stop root, and the tree is never handed to another
-// account. What a repair round needs is a second agent turn and a second
-// verification — not a permission fix-up.
-func TestRunInstallRepairsWithoutReopeningTheTree(t *testing.T) {
-	fx := newInstallFixture(t)
-	fx.loadCheckExitCodes = []int{skillVerifyRepairableExit, 0}
-
-	require.NoError(t, fx.svc.runInstall(context.Background(), 7, "cfg-1", "sk-1", fx.bundle))
-
-	require.Equal(t, 2, fx.loadCheckPasses, "the repair has to be verified, not trusted")
-	require.Equal(t, -1, indexOfCommandContaining(fx.commands, "chmod -R u+rwX,go+rX "),
-		"root writes through whatever modes a verification pass leaves behind")
-	for _, command := range fx.commands {
-		require.NotContains(t, command, "chown",
-			"the tree is built, repaired and verified by one account; there is nothing to re-own")
-	}
-}
-
-// Installing a package cannot fix a file that does not parse, and the bundle
-// has to change instead. Spending another agent round on it would only delay
-// the same failure by minutes.
-func TestRunInstallDoesNotRetryAFailureInstallingCannotFix(t *testing.T) {
+func TestRunInstallDoesNotRetryASyntaxError(t *testing.T) {
 	fx := newInstallFixture(t)
 	fx.loadCheckExitCodes = []int{1}
 	fx.loadCheckStderr = "scripts/extract.py has a syntax error on line 1: invalid syntax"
@@ -1659,26 +1620,8 @@ func TestRunInstallDoesNotRetryAFailureInstallingCannotFix(t *testing.T) {
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "syntax error")
-	require.Len(t, fx.agentPrompts, 1, "an unfixable finding must not buy another round")
+	require.Len(t, fx.agentPrompts, 1)
 	require.Equal(t, 1, fx.loadCheckPasses)
-}
-
-// The loop is bounded. An installer that cannot satisfy the gate in one repair
-// is not going to satisfy it in ten, and a skill install must not become an
-// open-ended retry against a billed sandbox.
-func TestRunInstallStopsAfterOneRepairRound(t *testing.T) {
-	fx := newInstallFixture(t)
-	fx.loadCheckExitCodes = []int{skillVerifyRepairableExit}
-
-	err := fx.svc.runInstall(context.Background(), 7, "cfg-1", "sk-1", fx.bundle)
-
-	require.Error(t, err)
-	require.ErrorContains(t, err, "imports pandas",
-		"the failure must name what the gate found, not just that it failed")
-	require.Len(t, fx.agentPrompts, skillInstallVerifyRounds)
-	require.Equal(t, skillInstallVerifyRounds, fx.loadCheckPasses)
-	require.NotContains(t, fx.events, "create-snapshot")
-	require.Nil(t, fx.configRepo.saved)
 }
 
 func TestRunInstallDeletesTheSnapshotWhenSwitchFails(t *testing.T) {
@@ -1941,10 +1884,9 @@ type installFixture struct {
 	fingerprint string
 	// loadCheck* drive the per-language script verification pass, which is the
 	// last gate before the snapshot. exitCodes is consumed one entry per python
-	// pass and its last entry repeats, so a test about a single round writes one
-	// value and a test about the repair round writes two. Exit 2 is the
-	// checker's "everything I found is a missing dependency", which is what
-	// earns another installer round.
+	// pass and its last entry repeats, so a test about a failing pass writes
+	// one value. Exit 2 means every finding is a missing declared dependency;
+	// the install path treats any non-zero exit the same.
 	loadCheckExitCodes []int
 	loadCheckStdout    string
 	loadCheckStderr    string
@@ -1963,8 +1905,6 @@ type installFixture struct {
 	loadCheckOpts sandbox.ShellExecOptions
 	agentErr      error
 	// agentPrompts is every prompt the installer engine was handed, in order.
-	// A repair round is a second entry, and what it says is the whole point of
-	// having one.
 	agentPrompts []string
 	// beforeExecute runs at the moment the engine would start, so a test can
 	// observe the state an attaching console would see mid-install.
@@ -2027,8 +1967,8 @@ func newInstallFixture(t *testing.T) *installFixture {
 
 	fx := &installFixture{t: t}
 	fx.fingerprint = sandbox.SkillImageFingerprint("e2b", "key-1", "https://e2b.example")
-	// The checker's own wording for a missing dependency, so a test reading the
-	// repair prompt sees what a real run would put in it.
+	// The checker's own wording for a missing dependency, so a test reading
+	// the verification failure sees what a real run would put in it.
 	fx.loadCheckStderr = "scripts/extract.py imports pandas, " +
 		"which is not available in this image"
 	fx.bundle = &SkillBundle{

--- a/internal/application/service/tenant_skill_runtime_verify.go
+++ b/internal/application/service/tenant_skill_runtime_verify.go
@@ -50,11 +50,10 @@ func (s *TenantSkillService) verifyRuntimePrerequisites(
 	mgr sandbox.Manager,
 	sessionID, skillDir string,
 ) error {
-	fail := func(problem string, repairable bool) error {
+	fail := func(problem string) error {
 		return &skillVerificationError{
-			Language:   "runtime prerequisites",
-			Repairable: repairable,
-			Problems:   []string{problem},
+			Language: "runtime prerequisites",
+			Problems: []string{problem},
 		}
 	}
 	reader, ok := mgr.(sandbox.SessionFileReader)
@@ -64,32 +63,31 @@ func (s *TenantSkillService) verifyRuntimePrerequisites(
 	raw, err := reader.ReadSessionFile(ctx, sessionID, path.Join(skillDir, ".weknora", "install-report.json"))
 	if err != nil {
 		return fail(
-			"Write .weknora/install-report.json after assessing CLI and external runtime prerequisites: "+err.Error(),
-			true,
+			"Write .weknora/install-report.json after assessing CLI and external runtime prerequisites: " + err.Error(),
 		)
 	}
 	var report skillRuntimeReport
 	if len(raw) > 64*1024 {
-		return fail("install-report.json exceeds 64 KiB", true)
+		return fail("install-report.json exceeds 64 KiB")
 	}
 	if err := json.Unmarshal(raw, &report); err != nil || report.Commands == nil || report.Blockers == nil {
-		return fail(`Write a valid .weknora/install-report.json with commands and blockers arrays of strings`, true)
+		return fail(`Write a valid .weknora/install-report.json with commands and blockers arrays of strings`)
 	}
 	if len(report.Commands) > 100 || len(report.Blockers) > 100 {
-		return fail("install report has too many entries", true)
+		return fail("install report has too many entries")
 	}
 	for _, name := range report.Commands {
 		if !skillRuntimeCommandName.MatchString(name) || len(name) > 128 {
-			return fail("commands must contain bare executable names, without paths or arguments", true)
+			return fail("commands must contain bare executable names, without paths or arguments")
 		}
 	}
 	for _, blocker := range report.Blockers {
 		if strings.TrimSpace(blocker) == "" {
-			return fail("blockers must contain non-empty explanations", true)
+			return fail("blockers must contain non-empty explanations")
 		}
 	}
 	if len(report.Blockers) > 0 {
-		return fail("Unresolved runtime prerequisites: "+strings.Join(report.Blockers, "; "), false)
+		return fail("Unresolved runtime prerequisites: " + strings.Join(report.Blockers, "; "))
 	}
 	if len(report.Commands) == 0 {
 		return nil

--- a/internal/application/service/tenant_skill_runtime_verify_test.go
+++ b/internal/application/service/tenant_skill_runtime_verify_test.go
@@ -41,7 +41,6 @@ func TestRuntimePrerequisitesMarkdownOnlySkillCannotSkipReport(t *testing.T) {
 	_, err := fx.svc.verifySkill(context.Background(), fx.sandboxMgr, "session", installSkillDir, fx.bundle)
 	var gate *skillVerificationError
 	require.ErrorAs(t, err, &gate)
-	require.True(t, gate.Repairable)
 	require.Contains(t, err.Error(), "install-report.json")
 }
 
@@ -62,7 +61,6 @@ func TestRuntimePrerequisiteReportValidation(t *testing.T) {
 			err := fx.svc.verifyRuntimePrerequisites(context.Background(), fx.sandboxMgr, "session", installSkillDir)
 			var gate *skillVerificationError
 			require.ErrorAs(t, err, &gate)
-			require.True(t, gate.Repairable)
 		})
 	}
 }
@@ -79,7 +77,6 @@ func TestRuntimePrerequisitesResolveSkillLocalCLI(t *testing.T) {
 	err := fx.svc.verifyRuntimePrerequisites(context.Background(), mgr, "session", dir)
 	var gate *skillVerificationError
 	require.ErrorAs(t, err, &gate)
-	require.True(t, gate.Repairable)
 	require.Contains(t, err.Error(), "weknora-test-cli")
 	require.NoError(t, os.WriteFile(path.Join(binDir, "weknora-test-cli"), []byte("#!/bin/sh\nexit 0\n"), 0o755))
 	require.NoError(t, fx.svc.verifyRuntimePrerequisites(context.Background(), mgr, "session", dir))
@@ -95,7 +92,7 @@ func TestRunInstallDoesNotSnapshotUnresolvedExternalPrerequisites(t *testing.T) 
 	err := fx.svc.runInstall(context.Background(), 7, "cfg-1", "sk-1", fx.bundle)
 	require.ErrorContains(t, err, "browser extension")
 	require.NotContains(t, fx.events, "create-snapshot")
-	require.Len(t, fx.agentPrompts, 1, "an external setup blocker must not trigger pointless package retries")
+	require.Len(t, fx.agentPrompts, 1, "an external setup blocker must not trigger another installer round")
 }
 
 func TestRuntimeReportPromptsDoNotPrescribeSkillSpecificValues(t *testing.T) {
@@ -103,22 +100,13 @@ func TestRuntimeReportPromptsDoNotPrescribeSkillSpecificValues(t *testing.T) {
 	fx.bundle.Files = map[string][]byte{
 		"SKILL.md": []byte("Summarize supplied text. No external commands are required."),
 	}
-	prompts := map[string]string{
-		"install": buildInstallPrompt(installSkillDir, fx.bundle, nil),
-		"repair": buildRepairPrompt(installSkillDir, &skillVerificationError{
-			Language: "runtime prerequisites", Problems: []string{"Missing install-report.json"},
-		}),
+	prompt := buildInstallPrompt(installSkillDir, fx.bundle, nil)
+	for _, field := range []string{".weknora/install-report.json", "commands:", "blockers:"} {
+		require.Contains(t, prompt, field)
 	}
-	for name, prompt := range prompts {
-		t.Run(name, func(t *testing.T) {
-			for _, field := range []string{".weknora/install-report.json", "commands:", "blockers:"} {
-				require.Contains(t, prompt, field)
-			}
-			for _, leakedExample := range []string{
-				"bsk", "browser extension", "127.0.0.1", "Describe an unresolved external prerequisite here",
-			} {
-				require.NotContains(t, strings.ToLower(prompt), strings.ToLower(leakedExample))
-			}
-		})
+	for _, leakedExample := range []string{
+		"bsk", "browser extension", "127.0.0.1", "Describe an unresolved external prerequisite here",
+	} {
+		require.NotContains(t, strings.ToLower(prompt), strings.ToLower(leakedExample))
 	}
 }

--- a/internal/application/service/tenant_skill_steer_test.go
+++ b/internal/application/service/tenant_skill_steer_test.go
@@ -110,33 +110,6 @@ func TestInstallGuidanceArrivingAtNaturalStopContinuesBeforeSnapshot(t *testing.
 	require.Equal(t, "injected", state.Messages[0].Status)
 }
 
-func TestInstallGuidanceSurvivesRepairRound(t *testing.T) {
-	fx := newInstallFixture(t)
-	fx.svc.streams = stream.NewMemoryStreamManager()
-	fx.loadCheckExitCodes = []int{skillVerifyRepairableExit, 0}
-	first := true
-	fx.beforeExecute = func() {
-		if first {
-			first = false
-			require.NoError(
-				t,
-				fx.svc.SteerInstall(
-					context.Background(),
-					7,
-					"cfg-1",
-					"sk-1",
-					fx.currentInstallMessageID(),
-					uuid.NewString(),
-					"Use our package mirror",
-				),
-			)
-		}
-	}
-	require.NoError(t, fx.svc.runInstall(context.Background(), 7, "cfg-1", "sk-1", fx.bundle))
-	require.Len(t, fx.agentPrompts, 2)
-	require.Contains(t, fx.agentPrompts[1], "Use our package mirror")
-}
-
 func TestInstallGuidanceCloseAndSendAcrossReplicas(t *testing.T) {
 	fx, sink := newGuidanceFixture(t)
 	mini := miniredis.RunT(t)
@@ -194,14 +167,11 @@ func TestInstallGuidanceQueueLimit(t *testing.T) {
 	)
 }
 
-func TestReinstallInstructionsAreInInitialAndRepairPrompts(t *testing.T) {
+func TestReinstallInstructionsAreInTheInstallPrompt(t *testing.T) {
 	fx := newInstallFixture(t)
-	fx.loadCheckExitCodes = []int{skillVerifyRepairableExit, 0}
 	require.NoError(t, fx.svc.runInstall(context.Background(), 7, "cfg-1", "sk-1", fx.bundle, "Use our package mirror"))
-	require.Len(t, fx.agentPrompts, 2)
-	for _, prompt := range fx.agentPrompts {
-		require.Contains(t, prompt, "Use our package mirror")
-	}
+	require.Len(t, fx.agentPrompts, 1)
+	require.Contains(t, fx.agentPrompts[0], "Use our package mirror")
 }
 
 type failingGuidanceConsumption struct{ interfaces.StreamManager }

--- a/internal/application/service/tenant_skill_transcript.go
+++ b/internal/application/service/tenant_skill_transcript.go
@@ -215,12 +215,9 @@ func (tr *installTranscript) Finish(ctx context.Context, runErr error) {
 	tr.save(ctx)
 }
 
-// RecordPrompt logs a follow-up instruction the installer was given mid-run.
-//
-// The transcript exists so one replay of the event log is the whole
-// conversation. A repair round whose instruction is missing reads as the agent
-// spontaneously deciding to install more packages, which is precisely the
-// moment someone is reading this to find out why.
+// RecordPrompt logs a follow-up instruction the installer was given mid-run,
+// such as the dependency-install prompt after a prompt-sourced skill has been
+// acquired.
 func (tr *installTranscript) RecordPrompt(prompt string) {
 	if tr == nil {
 		return
@@ -271,8 +268,8 @@ func (tr *installTranscript) onToolCall(_ context.Context, evt event.Event) erro
 		}
 	}
 	// One command is one step of the asymptotic progress. Muted runs (after
-	// the first round ends) stop counting so a repair round cannot drag the
-	// bar back under the stage anchors that govern it by then.
+	// the agent phase ends) stop counting so verification cannot drag the
+	// bar back under the 80 stage anchor.
 	steps, lastCmd := 0, ""
 	if !tr.progressMuted {
 		tr.toolCalls++
@@ -388,10 +385,10 @@ func (tr *installTranscript) onError(_ context.Context, evt event.Event) error {
 	return nil
 }
 
-// onComplete records what the round finished with. It deliberately emits no
-// terminal event: an install may run another installer round after
-// verification, and a console that saw "complete" would stop following before
-// that round began. Only Finish closes the stream.
+// onComplete records what the turn finished with. It deliberately emits no
+// terminal event: administrator guidance can continue the same install after
+// the engine reports complete, and a console that saw "complete" would stop
+// following. Only Finish closes the stream.
 func (tr *installTranscript) onComplete(_ context.Context, evt event.Event) error {
 	data, ok := evt.Data.(event.AgentCompleteData)
 	if !ok {
@@ -412,8 +409,8 @@ func (tr *installTranscript) onComplete(_ context.Context, evt event.Event) erro
 	if tr.composeAnswerLocked() == "" && data.FinalAnswer != "" {
 		tr.segmentLocked(evt.ID).content = data.FinalAnswer
 	}
-	// Summed rather than overwritten: an install that needed a repair round ran
-	// two engine turns, and its cost is both of them.
+	// Summed rather than overwritten: a turn that continued for administrator
+	// guidance ran more than one engine call, and its cost is all of them.
 	tr.totalSteps += data.TotalSteps
 	tr.totalDurationMs += data.TotalDurationMs
 	tr.mu.Unlock()
@@ -530,10 +527,9 @@ func installToolCallSummary(data event.AgentToolCallData) string {
 }
 
 // muteActivityProgress stops the asymptotic progress wherever it has reached.
-// Called once the first installer round ends: everything after it —
-// verification and any repair rounds — is covered by the explicit stage
-// anchors (agent_done 80, repairing 82), and tool calls from a repair round
-// publishing again would drag the bar back below those anchors.
+// Called once the installer agent stops: everything after it is verification,
+// covered by the agent_done anchor at 80. Further tool events must not drag
+// the bar back below that.
 func (tr *installTranscript) muteActivityProgress() {
 	if tr == nil {
 		return

--- a/internal/application/service/tenant_skill_transcript_test.go
+++ b/internal/application/service/tenant_skill_transcript_test.go
@@ -307,12 +307,11 @@ func TestInstallTranscriptCreateOpensTheLogWithThePrompt(t *testing.T) {
 	require.Equal(t, "install pdf-tools", streams.events[0].Content)
 }
 
-// An install may run a second installer round, because verification happens
-// after the agent stops and a dependency it names is something the agent can
-// still fix. The engine reports "complete" at the end of every turn, so the
-// transcript must not treat the first one as the end of the install — a console
-// that saw it would stop following before the repair round began.
-func TestInstallTranscriptStaysOpenAcrossInstallerRounds(t *testing.T) {
+// The engine reports "complete" at the end of every turn, including a
+// continuation for administrator guidance. The transcript must not treat the
+// first one as the end of the install — a console that saw it would stop
+// following before the run actually finished.
+func TestInstallTranscriptStaysOpenAcrossInstallerTurns(t *testing.T) {
 	tr, bus, streams, messages := newTranscriptForTest(t)
 	ctx := context.Background()
 
@@ -326,7 +325,7 @@ func TestInstallTranscriptStaysOpenAcrossInstallerRounds(t *testing.T) {
 	}
 
 	finishRound(3, 1000)
-	tr.RecordPrompt("Verification failed. Install defusedxml into the venv.")
+	tr.RecordPrompt("Check the external CLI too.")
 	finishRound(2, 500)
 	tr.Finish(ctx, nil)
 
@@ -334,12 +333,12 @@ func TestInstallTranscriptStaysOpenAcrossInstallerRounds(t *testing.T) {
 	require.Equal(t, []types.ResponseType{
 		types.ResponseTypeInstallPrompt,
 		types.ResponseTypeComplete,
-	}, kinds, "the repair instruction has to be in the log, and the install ends once")
-	require.Contains(t, streams.events[0].Content, "Install defusedxml")
+	}, kinds, "a mid-run instruction has to be in the log, and the install ends once")
+	require.Contains(t, streams.events[0].Content, "Check the external CLI")
 
 	terminal := streams.events[len(streams.events)-1]
 	require.EqualValues(t, 5, terminal.Data["total_steps"],
-		"an install that needed a repair round cost both turns")
+		"an install that continued for guidance cost both turns")
 	require.EqualValues(t, 1500, terminal.Data["total_duration_ms"])
 	require.Len(t, messages.updated, 1)
 }
@@ -426,8 +425,8 @@ func TestInstallTranscriptPublishesActivityProgressOnToolCalls(t *testing.T) {
 	require.Equal(t, 3, got[2].steps)
 	require.Less(t, len([]rune(got[2].lastCmd)), 90, "a long command is truncated to one line")
 
-	// A repair round must not drag the bar back below the stage anchors, so
-	// muting after the first round ends the activity publishes for good.
+	// After the agent phase ends, muting stops further activity publishes
+	// from dragging the bar back below the 80 stage anchor.
 	tr.muteActivityProgress()
 	emitCall("c-4", event.AgentToolCallData{
 		ToolName: "shell_exec", Arguments: map[string]any{"command": "uv pip install defusedxml"},

--- a/internal/application/service/tenant_skill_verify.go
+++ b/internal/application/service/tenant_skill_verify.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
 	_ "embed"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -67,7 +69,8 @@ func (e *skillVerificationError) Error() string {
 // pass here is deterministic: the files the bundle named are present, the
 // isolated dependency trees the installer was told to create exist, every
 // source parses with the interpreter that would run it, and every distribution
-// the manifests name is installed.
+// the manifests name is installed at a compatible declared version. Original
+// dependency manifests must also remain unchanged.
 //
 // Import resolution is deliberately absent. Whether `import helper` resolves
 // depends on what a script does to sys.path before the import runs, which no
@@ -203,10 +206,10 @@ func (s *TenantSkillService) verifyScriptsParse(
 	ctx context.Context, mgr sandbox.Manager, sessionID, skillDir string, bundle *SkillBundle,
 ) ([]string, error) {
 	var notes []string
-	if scripts := sortedScriptPaths(bundle, ".py"); len(scripts) > 0 {
+	if scripts := sortedScriptPaths(bundle, ".py"); len(scripts) > 0 || bundleHasPythonDeps(bundle) {
 		entry, auxiliary := splitAuxiliaryScripts(scripts)
 		found, err := s.execVerify(ctx, mgr, sessionID, skillDir, "python",
-			skillPythonVerifyCommand(skillDir, entry, auxiliary))
+			skillPythonVerifyCommand(skillDir, entry, auxiliary, bundle))
 		notes = append(notes, found...)
 		if err != nil {
 			return notes, err
@@ -302,10 +305,23 @@ func verificationProblems(stderr string) []string {
 // Auxiliary files are named after --optional. They are checked the same way,
 // and what is found in them is reported rather than allowed to refuse the
 // install.
-func skillPythonVerifyCommand(skillDir string, entry, auxiliary []string) string {
+func skillPythonVerifyCommand(skillDir string, entry, auxiliary []string, bundles ...*SkillBundle) string {
 	venv := path.Join(skillDir, ".venv", "bin", "python")
 	quotedVenv := sandbox.ShellQuote(venv)
 	args := []string{sandbox.ShellQuote(skillDir)}
+	if len(bundles) > 0 && bundles[0] != nil {
+		hashes := map[string]string{}
+		for _, name := range []string{"requirements.txt", "requirements.lock", "pyproject.toml"} {
+			if content, ok := bundles[0].Files[name]; ok {
+				sum := sha256.Sum256(content)
+				hashes[name] = hex.EncodeToString(sum[:])
+			}
+		}
+		if len(hashes) > 0 {
+			encoded, _ := json.Marshal(hashes)
+			args = append(args, "--manifest-hashes", sandbox.ShellQuote(base64.StdEncoding.EncodeToString(encoded)))
+		}
+	}
 	for _, rel := range entry {
 		args = append(args, sandbox.ShellQuote(rel))
 	}
@@ -479,7 +495,8 @@ func bundleHasPythonDeps(bundle *SkillBundle) bool {
 	}
 	_, req := bundle.Files["requirements.txt"]
 	_, pyproject := bundle.Files["pyproject.toml"]
-	return req || pyproject
+	_, lock := bundle.Files["requirements.lock"]
+	return req || pyproject || lock
 }
 
 func bundleHasNodeDeps(bundle *SkillBundle) bool {

--- a/internal/application/service/tenant_skill_verify.go
+++ b/internal/application/service/tenant_skill_verify.go
@@ -23,10 +23,10 @@ import (
 //go:embed tenant_skill_verify.py
 var skillPythonVerifier string
 
-// skillVerifyRepairableExit is the exit code a verification pass uses when
-// every problem it found is a dependency missing from this image. It separates
-// "another installer round can fix this" from "the bundle has to change", which
-// is the only distinction that decides what the install flow does next.
+// skillVerifyRepairableExit is the checker's code when every problem is a
+// missing declared dependency. The install path no longer branches on it:
+// any non-zero exit refuses the snapshot. Sessions can still recover a
+// missing package at chat time.
 const skillVerifyRepairableExit = 2
 
 // skillTreeVerifyDirExit is the exit code the tree check uses when the skill
@@ -39,15 +39,12 @@ const skillTreeVerifyDirExit = 3
 // install. Notes travel on stdout so a non-zero exit stays unambiguous.
 const skillVerifyNotePrefix = "note: "
 
-// skillVerificationError is what the gate said, kept structured because it is
-// also the brief for a repair round. The gate is the only authority on what has
-// to resolve in this image, so handing back its own lines is what keeps the
-// installer from deriving "what this skill needs" a second time.
+// skillVerificationError is what the gate said. Findings stay structured so
+// the install failure names each one rather than collapsing them into a
+// generic "verification failed".
 type skillVerificationError struct {
 	// Language names the pass that failed, as the operator sees it.
 	Language string
-	// Repairable is true when installing a package would satisfy every line.
-	Repairable bool
 	// Problems are the checker's own lines, one per finding.
 	Problems []string
 	// Summary describes the command result itself, and is the only thing worth
@@ -262,10 +259,9 @@ func (s *TenantSkillService) execVerify(
 	notes := verificationNotes(res.Stdout)
 	if res.ExitCode != 0 {
 		return notes, &skillVerificationError{
-			Language:   label,
-			Repairable: res.ExitCode == skillVerifyRepairableExit,
-			Problems:   verificationProblems(res.Stderr),
-			Summary:    describeExecFailure(res),
+			Language: label,
+			Problems: verificationProblems(res.Stderr),
+			Summary:  describeExecFailure(res),
 		}
 	}
 	return notes, nil
@@ -284,8 +280,7 @@ func verificationNotes(stdout string) []string {
 }
 
 // verificationProblems splits a failed pass's stderr into its findings. Blank
-// lines are dropped; everything else is the checker's own wording, which is
-// what a repair round is given.
+// lines are dropped; everything else is the checker's own wording.
 func verificationProblems(stderr string) []string {
 	var problems []string
 	for _, line := range strings.Split(stderr, "\n") {
@@ -346,8 +341,9 @@ func skillPythonVerifyCommand(skillDir string, entry, auxiliary []string, bundle
 // declares runtime dependencies, checks each one resolves. `node --check` is
 // parse-only: it never runs the module body.
 //
-// A declared dependency that is missing exits with the repairable code: it is
-// the one thing here another installer round can still put in place.
+// A declared dependency that is missing exits with the missing-dependency
+// code so the failure is distinguishable from a syntax error. Either way the
+// snapshot is refused.
 func skillNodeVerifyCommand(skillDir string, scripts, deps []string) string {
 	parts := make([]string, 0, 2)
 	if len(deps) > 0 {

--- a/internal/application/service/tenant_skill_verify.py
+++ b/internal/application/service/tenant_skill_verify.py
@@ -31,8 +31,10 @@ Findings are graded, because rejecting an install is expensive.
     exit 0  the image may be kept
     exit 1  a problem that stops installation: a syntax error, an unreadable
             file, or a dependency manifest changed from the original bundle
-    exit 2  every problem is a missing or incompatible dependency, so handing
-            these lines back to the installer is worth a round
+    exit 2  every problem is a missing or incompatible declared dependency
+
+Either non-zero exit refuses the snapshot. A later session can still install a
+missing package; this check does not start another installer round.
 
 Files named after --optional are checked identically, but their findings are
 notes: nothing the skill offers loads a test or an example, and a bundled
@@ -72,9 +74,9 @@ optional_set = set(optional_scripts)
 problems = []
 notes = []
 
-# Whether any problem is something installing a package cannot fix. It decides
-# the exit code, which is how the caller knows if another installer round could
-# help or if the bundle itself has to change.
+# Whether any problem is a syntax error, unreadable file, or rewritten
+# manifest rather than a missing declared package. Both refuse the snapshot;
+# the exit code only classifies the finding.
 unrepairable = False
 
 

--- a/internal/application/service/tenant_skill_verify.py
+++ b/internal/application/service/tenant_skill_verify.py
@@ -22,16 +22,16 @@ What remains is what a file, not a runtime, can settle:
 
     - the execution user can read every source file
     - every source file parses
-    - every distribution the manifests name is installed in the venv
+    - every distribution the manifests and lock name is installed at a compatible version
 
 Findings are graded, because rejecting an install is expensive.
 
     stdout  `note: ...` lines - reported, image kept
     stderr  problem lines - the install is refused
     exit 0  the image may be kept
-    exit 1  a problem no installer round can fix: a syntax error, or a file the
-            execution user cannot read
-    exit 2  every problem is a dependency missing from this image, so handing
+    exit 1  a problem that stops installation: a syntax error, an unreadable
+            file, or a dependency manifest changed from the original bundle
+    exit 2  every problem is a missing or incompatible dependency, so handing
             these lines back to the installer is worth a round
 
 Files named after --optional are checked identically, but their findings are
@@ -40,6 +40,9 @@ tests/ directory must not decide whether the skill installs.
 """
 
 import ast
+import base64
+import hashlib
+import json
 import os
 import re
 import sys
@@ -51,6 +54,10 @@ EXIT_MISSING_DEPENDENCY = 2
 
 root = os.path.abspath(sys.argv[1])
 _argv_scripts = sys.argv[2:]
+manifest_hashes = {}
+if _argv_scripts[:1] == ["--manifest-hashes"]:
+    manifest_hashes = json.loads(base64.b64decode(_argv_scripts[1]))
+    _argv_scripts = _argv_scripts[2:]
 if OPTIONAL_FLAG in _argv_scripts:
     _cut = _argv_scripts.index(OPTIONAL_FLAG)
     entry_scripts = _argv_scripts[:_cut]
@@ -150,13 +157,32 @@ def load_pyproject(path):
         return None
 
 
+def requirement_file_lines(filename):
+    """Read pip/uv lock lines, including continued hash lists."""
+    location = os.path.join(root, filename)
+    if not os.path.isfile(location):
+        return
+    pending = ""
+    with open(location, encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            continued = line.endswith("\\")
+            pending += " " + (line[:-1] if continued else line)
+            if continued:
+                continue
+            yield re.sub(r"\s+--hash(?:=|\s+)\S+", "", pending).strip()
+            pending = ""
+    if pending.strip():
+        yield re.sub(r"\s+--hash(?:=|\s+)\S+", "", pending).strip()
+
+
 def declared_requirement_lines():
-    """(source, requirement-line) pairs from requirements.txt and pyproject.toml."""
-    requirements = os.path.join(root, "requirements.txt")
-    if os.path.isfile(requirements):
-        with open(requirements, encoding="utf-8", errors="replace") as handle:
-            for line in handle:
-                yield "requirements.txt", line
+    """Include the lock so a transitive version drift cannot pass verification."""
+    for filename in ("requirements.txt", "requirements.lock"):
+        for line in requirement_file_lines(filename):
+            yield filename, line
     pyproject = os.path.join(root, "pyproject.toml")
     if not os.path.isfile(pyproject):
         return
@@ -182,45 +208,49 @@ def declared_requirement_lines():
 
 
 def check_declared_requirements():
-    """Check the manifests name nothing the venv is missing.
-
-    This is the installer's literal instruction - "install requirements.txt" -
-    so a distribution it names that pip did not land is a failed install. A
-    line pip would have skipped is not: an environment marker that is false
-    here, or an extras-gated dependency, is reported instead. Refusing an
-    install over `pywin32; sys_platform == "win32"` on Linux rejects a skill
-    whose requirements are all present.
-    """
+    """Check installed distributions and PEP 440 version constraints."""
+    from importlib import metadata
     try:
-        from importlib import metadata
+        from packaging.requirements import Requirement
     except ImportError:
-        return
+        try:
+            # Install venvs are seeded with pip; avoid a network dependency
+            # merely to verify another dependency's version.
+            from pip._vendor.packaging.requirements import Requirement
+        except ImportError:
+            Requirement = None
     for source, raw in declared_requirement_lines():
         name = distribution_name(raw)
         if not name:
             continue
-        try:
-            metadata.distribution(name)
-            continue
-        except Exception:
-            pass
-        missing = "%s declares %s but it is not installed in %s" % (
-            source,
-            name,
-            sys.prefix,
-        )
         marker = marker_of(raw)
-        if not marker:
-            add_problem(missing, repairable=True)
+        applies = marker_applies(marker) if marker else True
+        if applies is False:
             continue
-        applies = marker_applies(marker)
-        if applies:
-            add_problem(missing, repairable=True)
-        elif applies is None:
-            add_note(
-                "%s, and its environment marker '%s' cannot be evaluated here, "
-                "so it is not enforced" % (missing, marker)
-            )
+        try:
+            dist = metadata.distribution(name)
+        except metadata.PackageNotFoundError:
+            missing = "%s declares %s but it is not installed in %s" % (source, name, sys.prefix)
+            if applies:
+                add_problem(missing, repairable=True)
+            else:
+                add_note("%s, and its environment marker '%s' cannot be evaluated here, so it is not enforced" % (missing, marker))
+            continue
+        if applies is None:
+            add_note("%s: version constraint for %s has an unevaluable marker '%s'" % (source, name, marker))
+            continue
+        if Requirement is None:
+            if re.search(r"[<>=!~]", raw.split(";")[0]):
+                add_problem("Cannot verify %s version in %s; install packaging into this venv and retry" % (name, source), repairable=True)
+            continue
+        try:
+            requirement = Requirement(raw.split(" #", 1)[0].strip())
+        except Exception as exc:
+            add_problem("Cannot verify requirement in %s: %s (%s)" % (source, raw, exc), repairable=True)
+            continue
+        if requirement.specifier and not requirement.specifier.contains(dist.version, prereleases=True):
+            add_problem("%s requires %s%s but installed version is %s; restore the declared version" %
+                        (source, name, requirement.specifier, dist.version), repairable=True)
 
 
 for relative in all_scripts:
@@ -237,7 +267,19 @@ for relative in all_scripts:
     except SyntaxError as exc:
         report("%s has a syntax error on line %s: %s" % (relative, exc.lineno, exc.msg))
 
-check_declared_requirements()
+manifests_valid = True
+for name, expected in manifest_hashes.items():
+    try:
+        with open(os.path.join(root, name), "rb") as handle:
+            actual = hashlib.sha256(handle.read()).hexdigest()
+    except OSError:
+        actual = None
+    if actual != expected:
+        manifests_valid = False
+        add_problem("%s changed during installation; restore the original manifest" % name)
+
+if manifests_valid:
+    check_declared_requirements()
 
 for note in notes:
     sys.stdout.write("note: %s\n" % note)

--- a/internal/application/service/tenant_skill_verify_python_test.go
+++ b/internal/application/service/tenant_skill_verify_python_test.go
@@ -36,10 +36,9 @@ func TestSkillPythonVerifier(t *testing.T) {
 		// wantProblem is a substring of the expected stderr. Empty means the
 		// tree must verify cleanly.
 		wantProblem string
-		// wantExit is the code a failing tree must exit with: 2 when installing
-		// a package would satisfy everything found, 1 when it would not. The
-		// install flow reads it to decide whether another installer round is
-		// worth its minutes.
+		// wantExit is the code a failing tree must exit with: 2 when every
+		// finding is a missing declared package, 1 otherwise. Both refuse the
+		// snapshot; the code only classifies the finding.
 		wantExit int
 		// wantNote is a substring of a stdout note - something the checker
 		// reported without refusing the install.
@@ -62,9 +61,8 @@ func TestSkillPythonVerifier(t *testing.T) {
 		wantProblem: "scripts/helper.py has a syntax error",
 		wantExit:    1,
 	}, {
-		// The exit code is the whole verdict, so one unfixable finding among
-		// fixable ones has to sink the batch: sending the installer back for a
-		// package it can install would only delay a failure it cannot.
+		// A syntax error among missing packages still exits 1: the batch is
+		// classified by the finding installing a package cannot fix.
 		name: "a syntax error alongside a missing requirement",
 		files: map[string]string{
 			"requirements.txt": "pandas==3.0.1\n",
@@ -162,8 +160,7 @@ func TestSkillPythonVerifier(t *testing.T) {
 				require.Error(t, err, "this skill is broken and must not reach a snapshot")
 				require.Contains(t, stderr, tc.wantProblem)
 				require.Equal(t, tc.wantExit, verifierExitCode(t, err),
-					"the exit code is what decides whether an installer round can fix this; "+
-						"stderr: %s", stderr)
+					"stderr: %s", stderr)
 			}
 			if tc.wantNote != "" {
 				require.Contains(t, stdout, "note: ",

--- a/internal/application/service/tenant_skill_verify_python_test.go
+++ b/internal/application/service/tenant_skill_verify_python_test.go
@@ -399,3 +399,45 @@ func runSkillPythonVerifier(
 	runErr := cmd.Run()
 	return stdout.String(), stderr.String(), runErr
 }
+
+func TestSkillPythonVerifierRejectsVersionDrift(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	require.NoError(t, err)
+	for _, tc := range []struct {
+		name, requirement, lock string
+		wantError               bool
+	}{
+		{"exact drift", "weknora-pin==1.0\n", "", true},
+		{"compatible range", "weknora-pin>=1,<3\n", "", false},
+		{"matching pin", "weknora-pin==2.0\n", "", false},
+		{"transitive lock drift", "", "weknora-pin==1.0 \\\n    --hash=sha256:abcd\n", true},
+		{"inactive marker", "weknora-pin==1.0; extra == 'unused'\n", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeSkillTree(t, map[string]string{
+				"requirements.txt": tc.requirement, "requirements.lock": tc.lock,
+				"weknora_pin-2.0.dist-info/METADATA": "Metadata-Version: 2.1\nName: weknora-pin\nVersion: 2.0\n",
+			})
+			cmd := exec.Command(python, "-", root)
+			cmd.Dir = root
+			cmd.Stdin = strings.NewReader(skillPythonVerifier)
+			output, err := cmd.CombinedOutput()
+			if tc.wantError {
+				require.Error(t, err)
+				require.Equal(t, 2, err.(*exec.ExitError).ExitCode())
+				require.Contains(t, string(output), "installed version is 2.0")
+			} else {
+				require.NoError(t, err, string(output))
+			}
+		})
+	}
+}
+
+func TestSkillPythonVerifierRejectsRewrittenLock(t *testing.T) {
+	root := writeSkillTree(t, map[string]string{"requirements.lock": "# weakened lock\n"})
+	bundle := &SkillBundle{Files: map[string][]byte{"requirements.lock": []byte("weknora-pin==1.0\n")}}
+	cmd := exec.Command("bash", "-c", skillPythonVerifyCommand(root, nil, nil, bundle))
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err)
+	require.Contains(t, string(output), "requirements.lock changed during installation")
+}


### PR DESCRIPTION
## Summary
- Verify `requirements.lock` version pins and refuse installs that rewrite dependency manifests during installation.
- Steer the installer to restore the declared lock with `--require-hashes` instead of adding packages ad hoc.

## Test plan
- [ ] Run `go test ./internal/application/service/ -run 'TestBuildInstallPrompt|TestSkillPythonVerifier|TestVerifySkillTree'`
- [ ] Install a skill whose lock version drifts from the venv and confirm verification fails
- [ ] Confirm an installer that rewrites `requirements.lock` is refused