### PR TITLE
feat(web-search): add GLM Coding Plan MCP provider

### DIFF
--- a/docs/api/web-search.md
+++ b/docs/api/web-search.md
@@ -147,6 +147,32 @@ curl --location --request POST 'http://localhost:8080/api/v1/web-search-provider
 `search_engine` 支持 `search_std`、`search_pro`、`search_pro_sogou` 和
 `search_pro_quark`；`content_size` 支持 `medium` 和 `high`。
 
+### 智谱 GLM Coding Plan 配置
+
+选择 `zhipu_prime` 可通过套餐专属 MCP 服务调用联网搜索，使用 GLM Coding Plan 的搜索额度。
+从[套餐联网搜索文档](https://docs.bigmodel.cn/cn/coding-plan/mcp/search-mcp-server)中所指的
+个人或团队套餐页面获取对应 API Key；团队额度需使用团队套餐 Key。
+
+```json
+{
+    "name": "GLM Coding Plan Search",
+    "provider": "zhipu_prime",
+    "parameters": {
+        "api_key": "your-coding-plan-api-key"
+    }
+}
+```
+
+此配置可用于创建提供方，`provider` 和 `parameters` 也可用于 `/web-search-providers/test`。
+Key 沿用现有 AES-GCM 加密落库及 `/credentials` 管理流程，响应不会返回密钥。
+现有 `zhipu` 使用常规 REST API；需要套餐 MCP 搜索时，应选择 `zhipu_prime`，仅更换原配置的 Key 不会切换端点。
+
+该提供方固定访问 `https://open.bigmodel.cn/api/mcp/web_search_prime/mcp`，通过 Bearer 请求头鉴权，
+不需要额外创建 MCP 服务。暂不支持单独配置 `proxy_url`，也不使用 REST 提供方的 `search_engine` / `content_size` 选项。
+每次搜索建立独立会话，执行握手、发现搜索工具、调用并关闭会话。兼容 `webSearchPrime` 与 `web_search_prime` 工具名。
+结果包含标题、链接、摘要及可选日期；结果数量默认 10、最多 50，并在本地截断到请求数量。
+调用失败或返回无法解析的结果时会报告错误，不会回退到按量计费的 REST API。
+
 ## POST `/web-search-providers` - 创建 Provider
 
 **参数说明（请求体）**:

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -22798,6 +22798,7 @@ const docTemplate = `{
                 "searxng",
                 "keenable",
                 "zhipu",
+                "zhipu_prime",
                 "exa",
                 "metaso",
                 "bocha"
@@ -22813,6 +22814,7 @@ const docTemplate = `{
                 "WebSearchProviderTypeSearxng",
                 "WebSearchProviderTypeKeenable",
                 "WebSearchProviderTypeZhipu",
+                "WebSearchProviderTypeZhipuPrime",
                 "WebSearchProviderTypeExa",
                 "WebSearchProviderTypeMetaso",
                 "WebSearchProviderTypeBocha"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -22791,6 +22791,7 @@
                 "searxng",
                 "keenable",
                 "zhipu",
+                "zhipu_prime",
                 "exa",
                 "metaso",
                 "bocha"
@@ -22806,6 +22807,7 @@
                 "WebSearchProviderTypeSearxng",
                 "WebSearchProviderTypeKeenable",
                 "WebSearchProviderTypeZhipu",
+                "WebSearchProviderTypeZhipuPrime",
                 "WebSearchProviderTypeExa",
                 "WebSearchProviderTypeMetaso",
                 "WebSearchProviderTypeBocha"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4424,6 +4424,7 @@ definitions:
     - searxng
     - keenable
     - zhipu
+    - zhipu_prime
     - exa
     - metaso
     - bocha
@@ -4439,6 +4440,7 @@ definitions:
     - WebSearchProviderTypeSearxng
     - WebSearchProviderTypeKeenable
     - WebSearchProviderTypeZhipu
+    - WebSearchProviderTypeZhipuPrime
     - WebSearchProviderTypeExa
     - WebSearchProviderTypeMetaso
     - WebSearchProviderTypeBocha

--- a/frontend/src/api/web-search-provider.ts
+++ b/frontend/src/api/web-search-provider.ts
@@ -5,7 +5,7 @@ export interface WebSearchProviderEntity {
   id?: string
   tenant_id?: number
   name: string
-  provider: 'brave' | 'bing' | 'google' | 'duckduckgo' | 'tavily' | 'ollama' | 'baidu' | 'searxng' | 'keenable' | 'zhipu' | 'metaso' | 'exa' | 'bocha'
+  provider: 'brave' | 'bing' | 'google' | 'duckduckgo' | 'tavily' | 'ollama' | 'baidu' | 'searxng' | 'keenable' | 'zhipu' | 'zhipu_prime' | 'metaso' | 'exa' | 'bocha'
   description?: string
   parameters: {
     // api_key is never returned by the server in this shape; it lives behind

--- a/frontend/src/views/settings/WebSearchSettings.vue
+++ b/frontend/src/views/settings/WebSearchSettings.vue
@@ -915,7 +915,8 @@ onMounted(async () => {
   background: rgba(20, 158, 130, 0.12);
   color: #149E82;
 }
-.provider-card--zhipu .provider-card__badge {
+.provider-card--zhipu .provider-card__badge,
+.provider-card--zhipu_prime .provider-card__badge {
   background: rgba(37, 99, 235, 0.12);
   color: #2563EB;
 }
@@ -1197,7 +1198,8 @@ onMounted(async () => {
   background: rgba(20, 158, 130, 0.12);
   color: #149E82;
 }
-.websearch-drawer--zhipu .setting-drawer__header-icon {
+.websearch-drawer--zhipu .setting-drawer__header-icon,
+.websearch-drawer--zhipu_prime .setting-drawer__header-icon {
   background: rgba(37, 99, 235, 0.12);
   color: #2563EB;
 }

--- a/internal/application/service/web_search_provider.go
+++ b/internal/application/service/web_search_provider.go
@@ -140,6 +140,7 @@ func isValidProviderType(provider types.WebSearchProviderType) bool {
 		types.WebSearchProviderTypeKeenable,
 		types.WebSearchProviderTypeMetaso,
 		types.WebSearchProviderTypeZhipu,
+		types.WebSearchProviderTypeZhipuPrime,
 		types.WebSearchProviderTypeExa,
 		types.WebSearchProviderTypeBocha:
 		return true
@@ -184,6 +185,10 @@ func validateProviderParameters(provider types.WebSearchProviderType, params typ
 		}
 	case types.WebSearchProviderTypeZhipu:
 		if err := infra_web_search.ValidateZhipuParameters(params); err != nil {
+			return err
+		}
+	case types.WebSearchProviderTypeZhipuPrime:
+		if err := infra_web_search.ValidateZhipuPrimeParameters(params); err != nil {
 			return err
 		}
 	case types.WebSearchProviderTypeMetaso:

--- a/internal/application/service/web_search_provider_test.go
+++ b/internal/application/service/web_search_provider_test.go
@@ -6,6 +6,19 @@ import (
 	"github.com/Tencent/WeKnora/internal/types"
 )
 
+func TestValidateProviderParametersZhipuPrime(t *testing.T) {
+	if !isValidProviderType(types.WebSearchProviderTypeZhipuPrime) {
+		t.Fatal("Zhipu Prime provider type is not accepted")
+	}
+	for _, key := range []string{"", " ", "coding-plan-key"} {
+		params := types.WebSearchProviderParameters{APIKey: key}
+		err := validateProviderParameters(types.WebSearchProviderTypeZhipuPrime, params)
+		if (err == nil) != (key == "coding-plan-key") {
+			t.Fatalf("unexpected validation for key %q: %v", key, err)
+		}
+	}
+}
+
 func TestValidateProviderParametersZhipu(t *testing.T) {
 	valid := types.WebSearchProviderParameters{
 		APIKey: "key",

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -1639,6 +1639,7 @@ func registerWebSearchProviders(registry *infra_web_search.Registry) {
 	registry.Register("searxng", infra_web_search.NewSearxngProvider)
 	registry.Register("keenable", infra_web_search.NewKeenableProvider)
 	registry.Register("zhipu", infra_web_search.NewZhipuProvider)
+	registry.Register("zhipu_prime", infra_web_search.NewZhipuPrimeProvider)
 	registry.Register("exa", infra_web_search.NewExaProvider)
 	registry.Register("metaso", infra_web_search.NewMetasoProvider)
 	registry.Register("bocha", infra_web_search.NewBochaProvider)

--- a/internal/infrastructure/web_search/zhipu_prime.go
+++ b/internal/infrastructure/web_search/zhipu_prime.go
@@ -1,0 +1,192 @@
+package web_search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/mcp"
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/types/interfaces"
+)
+
+const (
+	// Fixed official endpoint; tenant credentials must never be sent to a custom URL.
+	defaultZhipuPrimeURL = "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp"
+	zhipuPrimeTimeout    = 30 * time.Second
+)
+
+// ZhipuPrimeProvider uses the GLM Coding Plan search MCP service.
+type ZhipuPrimeProvider struct {
+	apiKey   string
+	endpoint string
+}
+
+// NewZhipuPrimeProvider creates a provider using the existing encrypted API key parameters.
+func NewZhipuPrimeProvider(params types.WebSearchProviderParameters) (interfaces.WebSearchProvider, error) {
+	if err := ValidateZhipuPrimeParameters(params); err != nil {
+		return nil, err
+	}
+	return &ZhipuPrimeProvider{apiKey: strings.TrimSpace(params.APIKey), endpoint: defaultZhipuPrimeURL}, nil
+}
+
+// ValidateZhipuPrimeParameters validates Coding Plan credentials and supported options.
+func ValidateZhipuPrimeParameters(params types.WebSearchProviderParameters) error {
+	if strings.TrimSpace(params.APIKey) == "" {
+		return fmt.Errorf("coding plan API key is required for Zhipu Prime provider")
+	}
+	if strings.TrimSpace(params.ProxyURL) != "" {
+		return fmt.Errorf("zhipu prime provider does not support a per-provider proxy_url")
+	}
+	return nil
+}
+
+// Name returns the provider identifier.
+func (p *ZhipuPrimeProvider) Name() string { return "zhipu_prime" }
+
+// Search uses a separate MCP session per call so credentials and sessions are never shared across workspaces.
+func (p *ZhipuPrimeProvider) Search(
+	ctx context.Context, query string, maxResults int, includeDate bool,
+) ([]*types.WebSearchResult, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, fmt.Errorf("search query cannot be empty")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if maxResults <= 0 {
+		maxResults = defaultZhipuResults
+	}
+	if maxResults > maxZhipuResults {
+		maxResults = maxZhipuResults
+	}
+	ctx, cancel := context.WithTimeout(ctx, zhipuPrimeTimeout)
+	defer cancel()
+	client, err := mcp.NewMCPClient(&mcp.ClientConfig{Service: &types.MCPService{
+		ID: "zhipu-prime-search", Name: "Zhipu Prime Search", URL: &p.endpoint,
+		TransportType:  types.MCPTransportHTTPStreamable,
+		AuthConfig:     &types.MCPAuthConfig{AuthType: types.MCPAuthBearer, Token: p.apiKey},
+		AdvancedConfig: &types.MCPAdvancedConfig{Timeout: int(zhipuPrimeTimeout / time.Second)},
+	}})
+	if err != nil {
+		return nil, fmt.Errorf("create Zhipu Prime MCP client: %w", err)
+	}
+	defer func() { _ = client.Disconnect() }()
+	if err := client.Connect(ctx); err != nil {
+		return nil, fmt.Errorf("connect Zhipu Prime MCP: %w", err)
+	}
+	if _, err := client.Initialize(ctx); err != nil {
+		return nil, fmt.Errorf("initialize Zhipu Prime MCP: %w", err)
+	}
+	tools, err := client.ListTools(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list Zhipu Prime MCP tools: %w", err)
+	}
+	name, args, err := zhipuPrimeTool(tools, query, maxResults)
+	if err != nil {
+		return nil, err
+	}
+	response, err := client.CallTool(ctx, name, args)
+	if err != nil {
+		return nil, fmt.Errorf("call Zhipu Prime search: %w", err)
+	}
+	if response == nil || response.IsError {
+		return nil, fmt.Errorf("zhipu prime search failed; check Coding Plan credentials and search quota")
+	}
+	results := make([]*types.WebSearchResult, 0, maxResults)
+	foundPayload := false
+	for _, content := range response.Content {
+		if content.Type != "text" || strings.TrimSpace(content.Text) == "" {
+			continue
+		}
+		items, err := parseZhipuPrimeResults(content.Text)
+		if err != nil {
+			return nil, err
+		}
+		foundPayload = true
+		for _, item := range items {
+			if strings.TrimSpace(item.Link) == "" {
+				continue
+			}
+			result := &types.WebSearchResult{
+				Title: item.Title, URL: item.Link, Snippet: item.Content, Source: p.Name(),
+			}
+			if includeDate {
+				if publishedAt, ok := parseZhipuDate(item.PublishDate); ok {
+					result.PublishedAt = &publishedAt
+				}
+			}
+			results = append(results, result)
+			if len(results) >= maxResults {
+				return results, nil
+			}
+		}
+	}
+	if !foundPayload {
+		return nil, fmt.Errorf("zhipu prime MCP response contains no search payload")
+	}
+	return results, nil
+}
+
+func zhipuPrimeTool(tools []*types.MCPTool, query string, count int) (string, map[string]interface{}, error) {
+	// The documented camelCase name and the newer snake_case name share the same search input.
+	for _, name := range []string{"webSearchPrime", "web_search_prime"} {
+		for _, tool := range tools {
+			if tool == nil || tool.Name != name {
+				continue
+			}
+			var schema struct {
+				Properties map[string]json.RawMessage `json:"properties"`
+			}
+			if err := json.Unmarshal(tool.InputSchema, &schema); err != nil {
+				return "", nil, fmt.Errorf("invalid Zhipu Prime tool schema: %w", err)
+			}
+			args := map[string]interface{}{"search_query": query}
+			// Some versions expose only search_query and filters; always enforce the count locally.
+			if _, ok := schema.Properties["count"]; ok {
+				args["count"] = count
+			}
+			return name, args, nil
+		}
+	}
+	return "", nil, fmt.Errorf("zhipu prime MCP server does not expose a supported search tool")
+}
+
+func parseZhipuPrimeResults(text string) ([]zhipuSearchResult, error) {
+	if len(text) > maxZhipuResponseBytes {
+		return nil, fmt.Errorf("zhipu prime search payload exceeds %d bytes", maxZhipuResponseBytes)
+	}
+	// MCP text can contain an array directly, or a JSON-encoded string holding that array.
+	for depth := 0; depth < 3; depth++ {
+		text = strings.TrimSpace(text)
+		if strings.HasPrefix(text, "\"") {
+			var decoded string
+			if err := json.Unmarshal([]byte(text), &decoded); err != nil {
+				return nil, fmt.Errorf("invalid Zhipu Prime search payload: %w", err)
+			}
+			text = decoded
+			continue
+		}
+		if strings.HasPrefix(text, "{") {
+			var envelope struct {
+				SearchResult json.RawMessage `json:"search_result"`
+			}
+			if err := json.Unmarshal([]byte(text), &envelope); err != nil {
+				return nil, fmt.Errorf("invalid Zhipu Prime search payload: %w", err)
+			}
+			text = strings.TrimSpace(string(envelope.SearchResult))
+		}
+		if !strings.HasPrefix(text, "[") {
+			break
+		}
+		var results []zhipuSearchResult
+		if err := json.Unmarshal([]byte(text), &results); err != nil {
+			return nil, fmt.Errorf("invalid Zhipu Prime search results: %w", err)
+		}
+		return results, nil
+	}
+	return nil, fmt.Errorf("zhipu prime search payload is not a results array")
+}

--- a/internal/infrastructure/web_search/zhipu_prime_test.go
+++ b/internal/infrastructure/web_search/zhipu_prime_test.go
@@ -1,0 +1,246 @@
+package web_search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Tencent/WeKnora/internal/types"
+	"github.com/Tencent/WeKnora/internal/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type primeRPCRequest struct {
+	ID     json.RawMessage `json:"id"`
+	Method string          `json:"method"`
+	Params struct {
+		Name      string                 `json:"name"`
+		Arguments map[string]interface{} `json:"arguments"`
+	} `json:"params"`
+}
+
+func primeTestServer(t *testing.T, call func(http.ResponseWriter, *http.Request, primeRPCRequest)) *httptest.Server {
+	t.Helper()
+	utils.SetSSRFWhitelistFromRaw("127.0.0.1")
+	t.Cleanup(utils.ResetSSRFWhitelistForTest)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request primeRPCRequest
+		if r.Method == http.MethodPost {
+			if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&request)) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+		}
+		call(w, r, request)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func primeRPCReply(t *testing.T, w http.ResponseWriter, id json.RawMessage, result interface{}) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	assert.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
+		"jsonrpc": "2.0", "id": id, "result": result,
+	}))
+}
+
+func TestZhipuPrimeSearchProtocolAndSessionIsolation(t *testing.T) {
+	var mu sync.Mutex
+	var methods []string
+	server := primeTestServer(t, func(w http.ResponseWriter, r *http.Request, req primeRPCRequest) {
+		mu.Lock()
+		defer mu.Unlock()
+		if r.Method == http.MethodDelete {
+			assert.Contains(t, []string{"session-first", "session-second"}, r.Header.Get("Mcp-Session-Id"))
+			methods = append(methods, "DELETE")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		auth := r.Header.Get("Authorization")
+		assert.Contains(t, []string{"Bearer first", "Bearer second"}, auth)
+		session := "session-" + strings.TrimPrefix(auth, "Bearer ")
+		methods = append(methods, req.Method)
+		if req.Method != "initialize" {
+			assert.Equal(t, session, r.Header.Get("Mcp-Session-Id"))
+		}
+		switch req.Method {
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", session)
+			primeRPCReply(t, w, req.ID, map[string]interface{}{
+				"protocolVersion": "2025-03-26",
+				"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				"serverInfo":      map[string]string{"name": "prime-test", "version": "1"},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			primeRPCReply(t, w, req.ID, map[string]interface{}{"tools": []interface{}{
+				map[string]interface{}{"name": "webSearchPrime", "inputSchema": map[string]interface{}{
+					"type":       "object",
+					"properties": map[string]interface{}{"search_query": map[string]string{"type": "string"}},
+				}},
+			}})
+		case "tools/call":
+			assert.Equal(t, "webSearchPrime", req.Params.Name)
+			assert.Equal(t, map[string]interface{}{"search_query": "WeKnora 中文"}, req.Params.Arguments)
+			payload, err := json.Marshal(`[{"title":"No URL"},{"title":"WeKnora","link":"https://example.com",` +
+				`"content":"搜索摘要","publish_date":"2026-01-02"},{"title":"Extra","link":"https://example.org"}]`)
+			assert.NoError(t, err)
+			primeRPCReply(t, w, req.ID, map[string]interface{}{
+				"content": []map[string]string{{"type": "text", "text": string(payload)}}, "isError": false,
+			})
+		default:
+			t.Errorf("unexpected MCP method: %s", req.Method)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	})
+	for _, key := range []string{"first", "second"} {
+		provider := &ZhipuPrimeProvider{apiKey: key, endpoint: server.URL}
+		results, err := provider.Search(context.Background(), "  WeKnora 中文  ", 1, key == "first")
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "WeKnora", results[0].Title)
+		assert.Equal(t, "https://example.com", results[0].URL)
+		assert.Equal(t, "搜索摘要", results[0].Snippet)
+		assert.Equal(t, "zhipu_prime", results[0].Source)
+		if key == "first" {
+			require.NotNil(t, results[0].PublishedAt)
+			assert.Equal(t, "2026-01-02", results[0].PublishedAt.Format("2006-01-02"))
+		} else {
+			assert.Nil(t, results[0].PublishedAt)
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	sequence := []string{"initialize", "notifications/initialized", "tools/list", "tools/call", "DELETE"}
+	assert.Equal(t, append(sequence, sequence...), methods)
+}
+
+func TestZhipuPrimeSearchFailureAndCancellation(t *testing.T) {
+	for _, failure := range []string{"unauthorized", "rpc", "tool", "malformed", "cancel"} {
+		t.Run(failure, func(t *testing.T) {
+			started := make(chan struct{})
+			server := primeTestServer(t, func(w http.ResponseWriter, r *http.Request, req primeRPCRequest) {
+				if failure == "unauthorized" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				switch req.Method {
+				case "initialize":
+					primeRPCReply(t, w, req.ID, map[string]interface{}{
+						"protocolVersion": "2025-03-26", "capabilities": map[string]interface{}{},
+						"serverInfo": map[string]string{"name": "prime-test", "version": "1"},
+					})
+				case "notifications/initialized":
+					w.WriteHeader(http.StatusAccepted)
+				case "tools/list":
+					primeRPCReply(t, w, req.ID, map[string]interface{}{"tools": []interface{}{
+						map[string]interface{}{
+							"name": "web_search_prime", "inputSchema": map[string]string{"type": "object"},
+						},
+					}})
+				case "tools/call":
+					if failure == "cancel" {
+						close(started)
+						<-r.Context().Done()
+						return
+					}
+					if failure == "rpc" {
+						w.Header().Set("Content-Type", "application/json")
+						assert.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
+							"jsonrpc": "2.0", "id": req.ID,
+							"error": map[string]interface{}{"code": -32000, "message": "quota exceeded"},
+						}))
+						return
+					}
+					primeRPCReply(t, w, req.ID, map[string]interface{}{
+						"content": []map[string]string{{"type": "text", "text": "upstream failure"}},
+						"isError": failure == "tool",
+					})
+				}
+			})
+			provider := &ZhipuPrimeProvider{apiKey: "test", endpoint: server.URL}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if failure == "cancel" {
+				done := make(chan error, 1)
+				go func() { _, err := provider.Search(ctx, "query", 1, false); done <- err }()
+				select {
+				case <-started:
+				case <-time.After(3 * time.Second):
+					t.Fatal("search did not start")
+				}
+				cancel()
+				select {
+				case err := <-done:
+					require.ErrorIs(t, err, context.Canceled)
+				case <-time.After(time.Second):
+					t.Fatal("cancellation did not stop search")
+				}
+				return
+			}
+			_, err := provider.Search(ctx, "query", 1, false)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestParseZhipuPrimeResults(t *testing.T) {
+	array := `[{"title":"Result","link":"https://example.com","content":"summary"}]`
+	encoded, err := json.Marshal(array)
+	require.NoError(t, err)
+	doubleEncoded, err := json.Marshal(string(encoded))
+	require.NoError(t, err)
+	for _, payload := range []string{array, string(encoded), string(doubleEncoded), `{"search_result":` + array + `}`} {
+		results, err := parseZhipuPrimeResults(payload)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "summary", results[0].Content)
+	}
+	for _, payload := range []string{"[]", `"[]"`, `{"search_result":[]}`} {
+		results, err := parseZhipuPrimeResults(payload)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	}
+	for _, payload := range []string{
+		"", "null", "{}", "[broken", `{"error":{"message":"quota exceeded"}}`,
+		strings.Repeat("x", maxZhipuResponseBytes+1),
+	} {
+		_, err := parseZhipuPrimeResults(payload)
+		require.Error(t, err)
+	}
+}
+
+func TestZhipuPrimeToolDiscoveryAndValidation(t *testing.T) {
+	for _, name := range []string{"webSearchPrime", "web_search_prime"} {
+		toolName, args, err := zhipuPrimeTool([]*types.MCPTool{{
+			Name: name, InputSchema: json.RawMessage(`{"properties":{"count":{"type":"integer"}}}`),
+		}}, "query", 5)
+		require.NoError(t, err)
+		assert.Equal(t, name, toolName)
+		assert.Equal(t, map[string]interface{}{"search_query": "query", "count": 5}, args)
+	}
+	_, _, err := zhipuPrimeTool([]*types.MCPTool{{Name: "unrelated"}}, "query", 1)
+	require.ErrorContains(t, err, "does not expose")
+	for i, params := range []types.WebSearchProviderParameters{
+		{}, {APIKey: " "}, {APIKey: "test", ProxyURL: "http://127.0.0.1:8080"},
+	} {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			_, err := NewZhipuPrimeProvider(params)
+			require.Error(t, err)
+		})
+	}
+	provider, err := NewZhipuPrimeProvider(types.WebSearchProviderParameters{APIKey: "test"})
+	require.NoError(t, err)
+	assert.Equal(t, defaultZhipuPrimeURL, provider.(*ZhipuPrimeProvider).endpoint)
+	_, err = provider.Search(context.Background(), " \t", 1, false)
+	require.ErrorContains(t, err, "cannot be empty")
+}

--- a/internal/types/web_search_provider.go
+++ b/internal/types/web_search_provider.go
@@ -26,6 +26,7 @@ const (
 	WebSearchProviderTypeSearxng    WebSearchProviderType = "searxng"
 	WebSearchProviderTypeKeenable   WebSearchProviderType = "keenable"
 	WebSearchProviderTypeZhipu      WebSearchProviderType = "zhipu"
+	WebSearchProviderTypeZhipuPrime WebSearchProviderType = "zhipu_prime"
 	WebSearchProviderTypeExa        WebSearchProviderType = "exa"
 	WebSearchProviderTypeMetaso     WebSearchProviderType = "metaso"
 	WebSearchProviderTypeBocha      WebSearchProviderType = "bocha"
@@ -270,6 +271,13 @@ func GetWebSearchProviderTypes() []WebSearchProviderTypeInfo {
 					},
 				},
 			},
+		},
+		{
+			ID:             "zhipu_prime",
+			Name:           "Zhipu GLM Coding Plan",
+			RequiresAPIKey: true,
+			Description:    "GLM Coding Plan webSearchPrime MCP (requires a Coding Plan API key)",
+			DocsURL:        "https://docs.bigmodel.cn/cn/coding-plan/mcp/search-mcp-server",
 		},
 		{
 			ID:             "zhipu",

--- a/internal/types/web_search_provider_test.go
+++ b/internal/types/web_search_provider_test.go
@@ -2,6 +2,23 @@ package types
 
 import "testing"
 
+func TestGetWebSearchProviderTypesZhipuPrime(t *testing.T) {
+	for _, provider := range GetWebSearchProviderTypes() {
+		if provider.ID != string(WebSearchProviderTypeZhipuPrime) {
+			continue
+		}
+		if !provider.RequiresAPIKey || provider.SupportsProxy || provider.RequiresBaseURL ||
+			len(provider.ConfigFields) != 0 {
+			t.Fatalf("unexpected Coding Plan metadata: %+v", provider)
+		}
+		if provider.DocsURL != "https://docs.bigmodel.cn/cn/coding-plan/mcp/search-mcp-server" {
+			t.Fatalf("unexpected Coding Plan documentation: %s", provider.DocsURL)
+		}
+		return
+	}
+	t.Fatal("Zhipu Prime provider type not found")
+}
+
 func TestGetWebSearchProviderTypesIncludesZhipuConfig(t *testing.T) {
 	var zhipu *WebSearchProviderTypeInfo
 	providerTypes := GetWebSearchProviderTypes()

--- a/website-docs/03-features/11-web-search.md
+++ b/website-docs/03-features/11-web-search.md
@@ -18,6 +18,7 @@ registry.Register("baidu", infra_web_search.NewBaiduProvider)
 registry.Register("searxng", infra_web_search.NewSearxngProvider)
 registry.Register("keenable", infra_web_search.NewKeenableProvider)
 registry.Register("zhipu", infra_web_search.NewZhipuProvider)
+registry.Register("zhipu_prime", infra_web_search.NewZhipuPrimeProvider)
 registry.Register("metaso", infra_web_search.NewMetasoProvider)
 registry.Register("exa", infra_web_search.NewExaProvider)
 registry.Register("bocha", infra_web_search.NewBochaProvider)
@@ -35,12 +36,19 @@ registry.Register("brave", infra_web_search.NewBraveProvider)
 | SearXNG | `searxng.go` | 否 | 租户自填 `base_url`（自托管实例） | 唯一允许自定义地址的引擎，需过 SSRF 校验 |
 | Keenable | `keenable.go` | 可选 | `https://api.keenable.ai`（硬编码） | 无 Key 走公共限速端点，有 Key 解除限制 |
 | 智谱搜索 | `zhipu.go` | 是 | `https://open.bigmodel.cn/api/paas/v4/web_search`（硬编码），默认引擎 `search_std` | |
+| 智谱 GLM Coding Plan | `zhipu_prime.go` | 是（套餐 API Key） | `https://open.bigmodel.cn/api/mcp/web_search_prime/mcp` | 复用套餐搜索额度，独立 MCP 会话 |
 | 秘塔 Metaso | `metaso.go` | 是 | `https://metaso.cn/api/v1/search` | extra_config.scope 选择资源范围，默认 webpage |
 | Exa | `exa.go` | 是 | `https://api.exa.ai/search` | 默认 highlights，可用 extra_config.include_text 获取正文 |
 | 博查 Bocha | `bocha.go` | 是 | `https://api.bochaai.com/v1/web-search` | extra_config.freshness、summary |
 | Brave Search | `brave.go` | 是 | `https://api.search.brave.com/res/v1/web/search` | 支持按次传 country/freshness |
 
-在「设置 → 网络搜索」选择提供商、填写 API Key 并测试，然后在智能体中选择该配置。当前注册 13 个引擎；实际结果数仍受智能体最大结果数约束。
+在「设置 → 网络搜索」选择提供商、填写 API Key 并测试，然后在智能体中选择该配置。当前注册 14 个引擎；实际结果数仍受智能体最大结果数约束。
+
+已订阅 GLM Coding Plan 的用户可选择 **Zhipu GLM Coding Plan**（`zhipu_prime`），使用套餐页面获取的 Key。
+团队额度需要团队套餐 Key，详见[智谱官方接入说明](https://docs.bigmodel.cn/cn/coding-plan/mcp/search-mcp-server)。
+此选项通过项目已有 MCP 客户端调用套餐搜索工具，无需在「MCP服务」中另建配置；现有「Zhipu AI」仍走常规 REST API。
+Key 沿用搜索提供方的加密与凭证管理。`zhipu_prime` 暂不提供单独的代理配置或 REST 搜索引擎选项，
+单次搜索超时 30 秒，结果数默认 10、最多 50。上游出错时直接返回错误，不回退到常规 REST API。
 
 | 提供商附加配置 | 值 |
 | --- | --- |

--- a/website-docs/06-development/03-extension-points.md
+++ b/website-docs/06-development/03-extension-points.md
@@ -385,7 +385,11 @@ func (r *Registry) CreateProvider(providerType string, params types.WebSearchPro
 
 ### 现有实现
 
-`internal/infrastructure/web_search/` 目录：`duckduckgo.go`、`google.go`、`bing.go`、`tavily.go`、`ollama.go`、`baidu.go`、`searxng.go`、`keenable.go`、`zhipu.go`（另有 `proxy.go` 出站代理支持）。类型常量在 `internal/types/web_search_provider.go`（`WebSearchProviderTypeBing/Google/DuckDuckGo/Tavily/Ollama/Baidu/Searxng/Keenable/Zhipu`）。
+`internal/infrastructure/web_search/` 目录：`duckduckgo.go`、`google.go`、`bing.go`、`tavily.go`、`ollama.go`、`baidu.go`、`searxng.go`、`keenable.go`、`zhipu.go`、`zhipu_prime.go`（另有 `proxy.go` 出站代理支持）。类型常量在 `internal/types/web_search_provider.go`（包括 `WebSearchProviderTypeZhipuPrime`）。
+
+`zhipu_prime.go` 是 MCP 搜索适配示例：复用 `internal/mcp.NewMCPClient` 的 Streamable HTTP、Bearer 鉴权与 SSRF 保护，
+按调用创建并释放会话，通过 `initialize`、`tools/list`、`tools/call` 取得搜索结果，再映射为 `WebSearchResult`。
+协议、会话隔离、取消和异常响应的回归测试位于 `zhipu_prime_test.go`。
 
 ### 新增步骤
 


### PR DESCRIPTION
## Description
GLM Coding Plan subscribers cannot use their included MCP search through the existing `zhipu` REST provider. Add `zhipu_prime`, exposed in search settings as **Zhipu GLM Coding Plan**, using the official `https://open.bigmodel.cn/api/mcp/web_search_prime/mcp` endpoint and Bearer authentication. The existing REST provider retains its behavior.

Reuse `internal/mcp.NewMCPClient` for SSRF protection and Streamable HTTP. Each search creates its own bounded session, initializes it, discovers `webSearchPrime` (or `web_search_prime`), calls the tool, and disconnects. Request `count` only when advertised by the tool schema, and enforce the result limit locally. Decode plain/JSON-string-encoded result arrays and `search_result` envelopes into titles, URLs, snippets, and optional dates; report protocol/tool/payload errors without falling back to the REST endpoint.

Credentials use the existing encrypted search-provider parameters and credential subresource. Includes provider validation, registry/UI metadata, TypeScript and Swagger enums, matching badge styling, and configuration/developer documentation. No new dependencies or database migrations. Per-provider `proxy_url` is not supported and is rejected explicitly.

Official setup reference: https://docs.bigmodel.cn/cn/coding-plan/mcp/search-mcp-server

## Type of Change
- [x] ✨ New feature
- [x] 📚 Documentation update
- [x] 🧪 Test

## Related Issue
Fixes #3129

## Testing
Passed using Go 1.26.7 and golangci-lint 2.12.2:
- `go test ./internal/infrastructure/web_search ./internal/types ./internal/mcp ./internal/container -count=1`
- `go test ./internal/infrastructure/web_search ./internal/types ./internal/application/service -run 'ZhipuPrime|WebSearchProvider|ValidateProviderParameters|IsValidProvider' -count=1`
- `go test -race ./internal/infrastructure/web_search -run ZhipuPrime -count=1`
- `golangci-lint run --new-from-rev=origin/main ./...`
- `git diff --check origin/main...HEAD`
- `bash scripts/check-license-bundle.sh`, `go vet` over root-module packages excluding `/docreader/`, and `go build ./cmd/server`.
- In `frontend`: `npm test` (850 passed), `npm run type-check`, and `npm run build`.
- Parsed the Swagger JSON and verified the new enum value and matching enum variable name.

Protocol tests use a local HTTP MCP server with the real project client: initialize/initialized/list/call ordering, bearer headers, session IDs and cleanup, different credentials across calls, missing/renamed tools, optional count arguments, result limits, date mapping, encoded and empty arrays, malformed/oversized payloads, HTTP 401, JSON-RPC errors, `isError`, and caller cancellation.

Manual local UI/API verification: selected the new provider, verified its official documentation link and API-key-only form, created a configuration with a synthetic placeholder key, and confirmed the key is encrypted in SQLite and absent from API responses. No production API key or real Coding Plan search was used; successful paid-service integration still needs verification with a valid subscription key.

Full-suite limitations, recorded as allowed by the focused-contribution guidance:
- Full root-module `go test` over packages from `go list ./...` excluding `/docreader/` (matching app CI) reproduces the same 52 top-level failures as unmodified base `462999ec3f5c1467ef0ccf5cf8c422393f40a0e6`, with no additional failing test names.
- Representative failures: `TestUpdateMCPService_AppliesNonScalarUpdateWithoutName` and sandbox provisioning tests reject public hosts that this environment resolves into `198.18.0.0/15`; `TestPutTenantParserConfigAdminPreservesRedactedSecrets` receives HTTP 400 instead of 200; `TestSkillPythonVerifier` expects a Python dependency to be absent. Other unchanged failing packages are `service/file`, `datasource` and IMA/Notion/Yuque connectors, `models/chat`, `models/embedding`, `sandbox`, and `utils` (URL/HTTP environment checks). Full-suite success is not claimed.
- Docker image builds were not run because Docker is unavailable locally; native backend and frontend production builds passed.

## Checklist
- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above (none)

## Screenshots / Recordings
New Coding Plan provider form, with the credential field empty:

![Zhipu GLM Coding Plan provider](https://raw.githubusercontent.com/tianhaotian/WeKnora/pr-evidence-3167-3129/pr-evidence/3129-public-form.jpg)
