### PR TITLE
feat(artifacts): expose semantic kinds for generated artifacts

### DIFF
--- a/frontend/src/api/chat/index.ts
+++ b/frontend/src/api/chat/index.ts
@@ -100,6 +100,8 @@ export interface ArtifactMeta {
   handle?: string;
   file_name: string;
   file_type: string;
+  /** Semantic projection derived from file_type by the server. */
+  kind: 'presentation' | 'web_page' | 'spreadsheet' | 'file';
   file_size: number;
   source_path: string;
   mod_time: string;

--- a/frontend/src/utils/sessionArtifacts.test.ts
+++ b/frontend/src/utils/sessionArtifacts.test.ts
@@ -6,6 +6,8 @@ import {
   collectSessionArtifacts,
   formatArtifactDateTime,
   formatArtifactSize,
+  resolveArtifactKind,
+  resolveArtifactPreviewExt,
 } from './sessionArtifacts.ts'
 
 test('collectSessionArtifacts keeps per-message download indexes', () => {
@@ -41,6 +43,27 @@ test('collectSessionArtifacts falls back to request_id before the row is persist
   ])
   assert.equal(items[0]?.messageId, 'req-9')
   assert.equal(items[0]?.index, 0)
+})
+
+test('artifact kind is a semantic projection with legacy extension fallback', () => {
+  assert.equal(resolveArtifactKind('deck.pptx', '.pptx'), 'presentation')
+  assert.equal(resolveArtifactKind('site.HTM'), 'web_page')
+  assert.equal(resolveArtifactKind('table.tsv'), 'spreadsheet')
+  assert.equal(resolveArtifactKind('report.pdf', '.pdf'), 'file')
+  assert.equal(resolveArtifactKind('wrong.pdf', '.pdf', 'presentation'), 'presentation')
+})
+
+test('artifact kind routes unknown concrete types into the existing previewer', () => {
+  assert.equal(resolveArtifactPreviewExt({ file_name: 'deck', file_type: '', kind: 'presentation' }), 'pptx')
+  assert.equal(resolveArtifactPreviewExt({ file_name: 'site.bin', file_type: '.bin', kind: 'web_page' }), 'html')
+  assert.equal(resolveArtifactPreviewExt({ file_name: 'table.xlsx', file_type: '.xlsx', kind: 'spreadsheet' }), 'xlsx')
+})
+
+test('history without kind derives the same semantic projection', () => {
+  const items = collectSessionArtifacts([
+    { id: 'assistant', artifacts: [{ file_name: 'deck.pptx', file_type: '.pptx' }] },
+  ])
+  assert.equal(items[0]?.kind, 'presentation')
 })
 
 test('collectSessionArtifacts skips empty or unidentifiable rows', () => {

--- a/frontend/src/utils/sessionArtifacts.ts
+++ b/frontend/src/utils/sessionArtifacts.ts
@@ -1,9 +1,50 @@
 import type { ArtifactMeta } from '@/api/chat'
 import { persistedAssistantId } from './steerStreamFork'
+import { isKnownPreviewableExt, resolveFilePreviewExt } from './filePreview'
 
 /** Artifact metadata plus the assistant message that owns the download index. */
 export type SessionArtifactItem = ArtifactMeta & {
   messageId: string
+}
+
+export type ArtifactKind = ArtifactMeta['kind']
+
+const PREVIEW_EXT_BY_KIND: Record<Exclude<ArtifactKind, 'file'>, string> = {
+  presentation: 'pptx',
+  web_page: 'html',
+  spreadsheet: 'csv',
+}
+
+/**
+ * Resolve the semantic projection for history created before kind was
+ * exposed. The backend remains authoritative whenever it supplied a known
+ * value; the extension fallback is compatibility-only.
+ */
+export function resolveArtifactKind(
+  fileName: string,
+  fileType?: string,
+  kind?: string,
+): ArtifactKind {
+  if (kind === 'presentation' || kind === 'web_page' || kind === 'spreadsheet' || kind === 'file') {
+    return kind
+  }
+  const ext = resolveFilePreviewExt(fileName, fileType)
+  if (ext === 'pptx') return 'presentation'
+  if (ext === 'html' || ext === 'htm') return 'web_page'
+  if (ext === 'csv' || ext === 'tsv' || ext === 'xlsx') return 'spreadsheet'
+  return 'file'
+}
+
+/** Preserve a concrete previewable extension, using kind only as a fallback. */
+export function resolveArtifactPreviewExt(
+  artifact: Pick<ArtifactMeta, 'file_name' | 'file_type'> & Partial<Pick<ArtifactMeta, 'kind'>>,
+): string {
+  const ext = resolveFilePreviewExt(artifact.file_name, artifact.file_type)
+  if (isKnownPreviewableExt(ext)) return ext
+  if (artifact.kind === 'presentation' || artifact.kind === 'web_page' || artifact.kind === 'spreadsheet') {
+    return PREVIEW_EXT_BY_KIND[artifact.kind]
+  }
+  return ext
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -38,6 +79,11 @@ export function collectSessionArtifacts(messages: unknown): SessionArtifactItem[
         ...(art as unknown as ArtifactMeta),
         index,
         messageId,
+        kind: resolveArtifactKind(
+          String(art.file_name || ''),
+          typeof art.file_type === 'string' ? art.file_type : undefined,
+          typeof art.kind === 'string' ? art.kind : undefined,
+        ),
       })
     }
   }

--- a/frontend/src/views/chat/components/ChatArtifactsDrawer.vue
+++ b/frontend/src/views/chat/components/ChatArtifactsDrawer.vue
@@ -180,7 +180,7 @@ import { useI18n } from 'vue-i18n'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { downloadArtifact, listMessageArtifacts, type ArtifactMeta } from '@/api/chat'
 import { getFileIcon } from '@/utils/files'
-import { resolveFilePreviewExt } from '@/utils/filePreview'
+import { resolveArtifactPreviewExt } from '@/utils/sessionArtifacts'
 import DocumentPreview from '@/components/document-preview.vue'
 
 const LIST_WIDTH = 440
@@ -244,7 +244,7 @@ const items = computed<ArtifactMeta[]>(() => {
 const previewFileType = computed(() => {
     const item = previewItem.value
     if (!item) return ''
-    return resolveFilePreviewExt(item.file_name, item.file_type)
+    return resolveArtifactPreviewExt(item)
 })
 
 const drawerSize = computed(() => (

--- a/frontend/src/views/chat/components/ChatArtifactsPanel.vue
+++ b/frontend/src/views/chat/components/ChatArtifactsPanel.vue
@@ -134,10 +134,10 @@ import { computed, nextTick, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { MessagePlugin } from 'tdesign-vue-next'
 import { downloadArtifact } from '@/api/chat'
-import { resolveFilePreviewExt } from '@/utils/filePreview'
 import {
   formatArtifactDateTime,
   formatArtifactSize,
+  resolveArtifactPreviewExt,
   type SessionArtifactItem,
 } from '@/utils/sessionArtifacts'
 import { useChatSandboxPanel, type ArtifactPanelFocusState } from '@/composables/useChatSandboxPanel'
@@ -176,7 +176,7 @@ const visibleItems = computed(() => {
 const previewFileType = computed(() => {
   const item = previewItem.value
   if (!item) return ''
-  return resolveFilePreviewExt(item.file_name, item.file_type)
+  return resolveArtifactPreviewExt(item)
 })
 
 function downloadKey(item: SessionArtifactItem): string {

--- a/internal/handler/session/agent_stream_handler.go
+++ b/internal/handler/session/agent_stream_handler.go
@@ -870,6 +870,7 @@ func publicArtifactViews(list types.MessageArtifacts) []map[string]interface{} {
 			"handle":      artifactHandle(a),
 			"file_name":   a.FileName,
 			"file_type":   a.FileType,
+			"kind":        a.Kind(),
 			"file_size":   a.FileSize,
 			"source_path": a.SourcePath,
 			"mod_time":    a.ModTime,

--- a/internal/handler/session/artifact_download.go
+++ b/internal/handler/session/artifact_download.go
@@ -79,6 +79,7 @@ func (h *Handler) ListSessionArtifacts(c *gin.Context) {
 			Handle:     artifactHandle(a),
 			FileName:   a.FileName,
 			FileType:   a.FileType,
+			Kind:       a.Kind(),
 			FileSize:   a.FileSize,
 			SourcePath: a.SourcePath,
 			ModTime:    a.ModTime,
@@ -131,6 +132,7 @@ func (h *Handler) ListMessageArtifacts(c *gin.Context) {
 			Handle:     artifactHandle(a),
 			FileName:   a.FileName,
 			FileType:   a.FileType,
+			Kind:       a.Kind(),
 			FileSize:   a.FileSize,
 			SourcePath: a.SourcePath,
 			ModTime:    a.ModTime,
@@ -267,11 +269,12 @@ type artifactListItem struct {
 	// Handle is the artifact's `resource://<handle>` reference, matching the
 	// destinations in the message body. Empty when the deployment runs without
 	// a resource catalog, in which case the body references files by name.
-	Handle     string `json:"handle,omitempty"`
-	FileName   string `json:"file_name"`
-	FileType   string `json:"file_type"`
-	FileSize   int64  `json:"file_size"`
-	SourcePath string `json:"source_path"`
+	Handle     string             `json:"handle,omitempty"`
+	FileName   string             `json:"file_name"`
+	FileType   string             `json:"file_type"`
+	Kind       types.ArtifactKind `json:"kind"`
+	FileSize   int64              `json:"file_size"`
+	SourcePath string             `json:"source_path"`
 	// time-typed fields serialise as RFC3339 strings — same convention as
 	// the rest of the messages API.
 	ModTime   any `json:"mod_time"`

--- a/internal/handler/session/artifact_download_test.go
+++ b/internal/handler/session/artifact_download_test.go
@@ -353,6 +353,28 @@ func TestListSessionArtifacts_StripsURL(t *testing.T) {
 	if !strings.Contains(w.Body.String(), "a.txt") {
 		t.Fatalf("response body missing file name: %s", w.Body.String())
 	}
+	if !strings.Contains(w.Body.String(), `"kind":"file"`) {
+		t.Fatalf("response body missing semantic kind: %s", w.Body.String())
+	}
+}
+
+func TestArtifactAPIsProjectKindsFromFileType(t *testing.T) {
+	artifacts := types.MessageArtifacts{
+		{FileName: "deck.pptx", FileType: ".pptx"},
+		{FileName: "site.html", FileType: ".html"},
+		{FileName: "data.xlsx", FileType: ".xlsx"},
+	}
+	views := publicArtifactViews(artifacts)
+	wants := []types.ArtifactKind{
+		types.ArtifactKindPresentation,
+		types.ArtifactKindWebPage,
+		types.ArtifactKindSpreadsheet,
+	}
+	for i, want := range wants {
+		if got := views[i]["kind"]; got != want {
+			t.Fatalf("view %d kind = %q, want %q", i, got, want)
+		}
+	}
 }
 
 func TestBuildAttachmentHeader_CJK(t *testing.T) {

--- a/internal/types/message.go
+++ b/internal/types/message.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -240,6 +241,48 @@ type MessageArtifact struct {
 	SourcePath string    `json:"source_path"` // Absolute path inside the sandbox (used for diff)
 	ModTime    time.Time `json:"mod_time"`    // Sandbox-side modification time (used for diff)
 	CreatedAt  time.Time `json:"created_at"`  // When WeKnora persisted the blob
+}
+
+// ArtifactKind is a semantic projection of an artifact's file type. It is
+// intentionally not stored on MessageArtifact: FileType (or, for legacy
+// rows, the filename extension) remains the single source of truth.
+type ArtifactKind string
+
+const (
+	// ArtifactKindFile is the default for artifacts without a specialized semantic kind.
+	ArtifactKindFile ArtifactKind = "file"
+	// ArtifactKindPresentation identifies an editable presentation artifact.
+	ArtifactKindPresentation ArtifactKind = "presentation"
+	// ArtifactKindWebPage identifies a browser-renderable HTML artifact.
+	ArtifactKindWebPage ArtifactKind = "web_page"
+	// ArtifactKindSpreadsheet identifies a tabular workbook or delimited-text artifact.
+	ArtifactKindSpreadsheet ArtifactKind = "spreadsheet"
+)
+
+// Kind projects the persisted file type into the small, stable vocabulary
+// exposed by artifact APIs. An explicit FileType takes precedence over the
+// filename so inconsistent metadata cannot silently change meaning.
+func (a MessageArtifact) Kind() ArtifactKind {
+	value := strings.ToLower(strings.TrimSpace(a.FileType))
+	if separator := strings.IndexByte(value, ';'); separator >= 0 {
+		value = strings.TrimSpace(value[:separator])
+	}
+	if value == "" {
+		value = strings.ToLower(filepath.Ext(a.FileName))
+	}
+	value = strings.TrimPrefix(value, ".")
+
+	switch value {
+	case "pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+		return ArtifactKindPresentation
+	case "html", "htm", "text/html":
+		return ArtifactKindWebPage
+	case "csv", "tsv", "xlsx", "text/csv", "text/tab-separated-values",
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+		return ArtifactKindSpreadsheet
+	default:
+		return ArtifactKindFile
+	}
 }
 
 // MessageArtifacts is a slice of MessageArtifact for database storage.

--- a/internal/types/message_test.go
+++ b/internal/types/message_test.go
@@ -7,6 +7,44 @@ import (
 	"time"
 )
 
+func TestMessageArtifactKindIsDerivedWithoutPersistence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		artifact MessageArtifact
+		want     ArtifactKind
+	}{
+		{name: "presentation", artifact: MessageArtifact{FileType: ".PPTX"}, want: ArtifactKindPresentation},
+		{name: "web page", artifact: MessageArtifact{FileType: "text/html; charset=utf-8"}, want: ArtifactKindWebPage},
+		{name: "spreadsheet", artifact: MessageArtifact{FileType: "xlsx"}, want: ArtifactKindSpreadsheet},
+		{name: "legacy filename", artifact: MessageArtifact{FileName: "table.CSV"}, want: ArtifactKindSpreadsheet},
+		{
+			name: "explicit type wins", artifact: MessageArtifact{FileName: "deck.pptx", FileType: ".pdf"},
+			want: ArtifactKindFile,
+		},
+		{name: "unknown", artifact: MessageArtifact{FileType: ".zip"}, want: ArtifactKindFile},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := test.artifact.Kind(); got != test.want {
+				t.Fatalf("Kind() = %q, want %q", got, test.want)
+			}
+		})
+	}
+
+	raw, err := (MessageArtifacts{{FileName: "deck.pptx", FileType: ".pptx"}}).Value()
+	if err != nil {
+		t.Fatalf("Value() error = %v", err)
+	}
+	if bytes.Contains(raw.([]byte), []byte(`"kind"`)) {
+		t.Fatalf("semantic kind must not be persisted: %s", raw)
+	}
+}
+
 // TestMessageArtifacts_ValueScanRoundTrip pins the JSONB serialisation
 // contract used by GORM: (Value → bytes → Scan) must produce an equivalent
 // slice, including a zero-time modified-at (which must survive JSON's


### PR DESCRIPTION
## Description

Expose a stable semantic `kind` for generated artifacts while keeping the existing `file_type`/filename extension as the only source of truth.

- Project `.pptx` as `presentation`, `.html`/`.htm` as `web_page`, and `.csv`/`.tsv`/`.xlsx` as `spreadsheet`; all other formats use `file`.
- Add the projection to the existing session/message artifact REST responses and live completion SSE payload.
- Do not persist `kind` and do not add a database migration.
- Route the projected kind through the existing `DocumentPreview` only when a concrete previewable extension is unavailable.
- Preserve compatibility for historical message payloads that predate the new field.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A — Rhino Bird Topic 2 sandbox workbench.

## Testing

- PASS — `go test ./internal/types ./internal/handler/session -run 'Artifact|MessageArtifacts' -count=1`
- PASS — `npm --prefix frontend test -- src/utils/sessionArtifacts.test.ts` (11/11)
- PASS — `npm --prefix frontend run type-check`
- PASS — `npm --prefix frontend run build` (6,527 modules; Node 20.18/Vite 20.19 advisory and existing chunk-size warnings only)
- PASS — `golangci-lint run --new-from-rev upstream/main ./internal/types ./internal/handler/session` (`0 issues`)
- PASS — `git diff --check`

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

N/A — no new UI surface or renderer; the existing artifact preview UI consumes the projected field.
