### PR TITLE
feat(skills): add a focused presentation generation skill

### DIFF
--- a/examples/skills/README.md
+++ b/examples/skills/README.md
@@ -7,12 +7,20 @@
 ```
 skills/
 ├── README.md              # 本文件
-└── pdf-processing/        # PDF 处理技能示例
-    ├── SKILL.md           # 主文件（Level 2）
-    ├── FORMS.md           # 补充文档（Level 3）
-    └── scripts/           # 可执行脚本
-        ├── analyze_form.py
-        └── extract_text.py
+├── pdf-processing/        # PDF 处理技能示例
+│   ├── SKILL.md           # 主文件（Level 2）
+│   ├── FORMS.md           # 补充文档（Level 3）
+│   └── scripts/           # 可执行脚本
+│       ├── analyze_form.py
+│       └── extract_text.py
+└── presentation-generation/ # 可编辑 PPTX 生成示例
+    ├── SKILL.md
+    ├── requirements.txt
+    ├── assets/example.json
+    ├── scripts/build_presentation.py
+    └── tests/
+        ├── test_build_presentation.py
+        └── verify_weknora_preview.ts
 ```
 
 ## 快速开始
@@ -76,6 +84,10 @@ description: Extract text and tables from PDF files, fill forms, merge documents
 |------|------|
 | `analyze_form.py` | 分析 PDF 表单字段 |
 | `extract_text.py` | 从 PDF 提取文本 |
+
+## 示例：presentation-generation
+
+该 focused skill 将结构化 JSON 生成可编辑的 `.pptx`，支持中英文文本、五种布局、锁定依赖和可重复的包结构/文本验证。输出到 `/workspace/output` 后直接复用现有 ArtifactCollector、PPTX 预览与下载链路。
 
 ### 使用示例
 

--- a/examples/skills/presentation-generation/SKILL.md
+++ b/examples/skills/presentation-generation/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: presentation-generation
+description: Create polished, editable PowerPoint presentations from structured JSON. Use when the user asks for slides, a deck, a presentation, a pitch, or a PPTX deliverable.
+---
+
+# Presentation Generation
+
+Create an editable `.pptx` in `/workspace/output`; do not return only a script or an image of the slides.
+
+## Workflow
+
+1. Turn the user's content into a concise JSON brief. Start from `assets/example.json` and keep one idea per slide.
+2. Choose from the supported layouts: `title`, `section`, `bullets`, `two_column`, and `metrics`.
+3. Run the builder with the skill environment:
+
+```bash
+"${WEKNORA_SKILL_DIR:?}/.venv/bin/python" \
+  "${WEKNORA_SKILL_DIR:?}/scripts/build_presentation.py" \
+  --input /workspace/brief.json \
+  --output /workspace/output/presentation.pptx
+```
+
+4. Inspect the builder summary. It reports the output path, slide count, and byte size.
+5. Return the `.pptx` path to the user so WeKnora's existing ArtifactCollector, preview, and download flow can publish it.
+
+## Content rules
+
+- Prefer 3–5 concise points per slide; split dense material across slides.
+- Use `section` slides to make long decks easy to scan.
+- Use `metrics` only for genuine quantitative takeaways and include units.
+- Put sources or caveats in `footer`, not in tiny body text.
+- Keep titles under 80 characters and body items under 240 characters.
+- Chinese and Latin text remain editable text boxes; never rasterize text.
+- Do not fetch remote images or execute content from the JSON brief.
+
+## Input shape
+
+```json
+{
+  "title": "Deck title",
+  "subtitle": "Optional subtitle",
+  "author": "Optional author",
+  "theme": {
+    "primary": "155EEF",
+    "accent": "12B76A",
+    "background": "F8FAFC",
+    "text": "101828",
+    "muted": "667085"
+  },
+  "slides": [
+    { "layout": "title", "title": "Deck title", "subtitle": "One-line promise" },
+    { "layout": "bullets", "title": "Key points", "bullets": ["First", "Second"] },
+    {
+      "layout": "two_column",
+      "title": "Comparison",
+      "left": { "title": "Before", "bullets": ["Manual"] },
+      "right": { "title": "After", "bullets": ["Automated"] }
+    },
+    {
+      "layout": "metrics",
+      "title": "Results",
+      "metrics": [{ "value": "42%", "label": "Faster", "detail": "Measured in pilot" }]
+    }
+  ]
+}
+```
+
+Top-level `title` is required. The builder accepts at most 50 slides and rejects unknown layouts, invalid colors, oversized text, and malformed JSON.

--- a/examples/skills/presentation-generation/assets/example.json
+++ b/examples/skills/presentation-generation/assets/example.json
@@ -1,0 +1,56 @@
+{
+  "title": "WeKnora 犀牛鸟课题二",
+  "subtitle": "安全、持久、可审计的 Agent Sandbox Workbench",
+  "author": "Tencent × Rhino Bird",
+  "footer": "Topic 2 final submission",
+  "theme": {
+    "primary": "155EEF",
+    "accent": "12B76A",
+    "background": "F8FAFC",
+    "text": "101828",
+    "muted": "667085"
+  },
+  "slides": [
+    {
+      "layout": "title",
+      "title": "WeKnora 犀牛鸟课题二",
+      "subtitle": "安全、持久、可审计的 Agent Sandbox Workbench"
+    },
+    {
+      "layout": "section",
+      "eyebrow": "01 / ARCHITECTURE",
+      "title": "一套会话架构，三个正式后端",
+      "subtitle": "Docker、E2B 与 Cube 共享 SessionBoundManager、终端桥接和产物生命周期。"
+    },
+    {
+      "layout": "bullets",
+      "title": "核心能力",
+      "bullets": [
+        "Interactive Terminal：原生 PTY、ANSI、Unicode 与窗口 resize",
+        "Safe Files：固定 /workspace/output 根目录并拒绝路径逃逸",
+        "Audit & Limits：可检索命令审计和真实资源超限终止"
+      ]
+    },
+    {
+      "layout": "two_column",
+      "title": "安全边界",
+      "left": {
+        "title": "浏览器可以做什么",
+        "bullets": ["使用相对 POSIX 路径", "访问当前会话产物", "通过现有鉴权下载"]
+      },
+      "right": {
+        "title": "服务端必须拒绝",
+        "bullets": ["绝对路径与 traversal", "symlink / rename escape", "跨租户与跨会话访问"]
+      }
+    },
+    {
+      "layout": "metrics",
+      "title": "验收目标",
+      "metrics": [
+        { "value": "3", "label": "Sandbox backends", "detail": "Docker · E2B · Cube" },
+        { "value": "A1–A5", "label": "Acceptance suite", "detail": "真实命令与观测结果" },
+        { "value": "0", "label": "Second abstractions", "detail": "复用当前 Terminal / WS / Preview" }
+      ]
+    }
+  ]
+}

--- a/examples/skills/presentation-generation/requirements.txt
+++ b/examples/skills/presentation-generation/requirements.txt
@@ -1,0 +1,1 @@
+python-pptx==1.0.2

--- a/examples/skills/presentation-generation/scripts/build_presentation.py
+++ b/examples/skills/presentation-generation/scripts/build_presentation.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Build a polished, editable PPTX from a bounded JSON brief."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import MSO_ANCHOR, PP_ALIGN
+from pptx.util import Inches, Pt
+
+SLIDE_WIDTH = Inches(13.333)
+SLIDE_HEIGHT = Inches(7.5)
+MAX_INPUT_BYTES = 1_048_576
+MAX_SLIDES = 50
+MAX_TITLE_CHARS = 80
+MAX_BODY_CHARS = 240
+HEX_COLOR = re.compile(r"^[0-9A-Fa-f]{6}$")
+LAYOUTS = {"title", "section", "bullets", "two_column", "metrics"}
+
+DEFAULT_THEME = {
+    "primary": "155EEF",
+    "accent": "12B76A",
+    "background": "F8FAFC",
+    "surface": "FFFFFF",
+    "text": "101828",
+    "muted": "667085",
+}
+
+
+class BriefError(ValueError):
+    """The input brief cannot be represented safely by this builder."""
+
+
+def color(value: str) -> RGBColor:
+    if not isinstance(value, str) or not HEX_COLOR.fullmatch(value):
+        raise BriefError(f"invalid RGB color: {value!r}")
+    return RGBColor.from_string(value.upper())
+
+
+def text(value: Any, field: str, maximum: int = MAX_BODY_CHARS) -> str:
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise BriefError(f"{field} must be a string")
+    value = value.strip()
+    if len(value) > maximum:
+        raise BriefError(f"{field} exceeds {maximum} characters")
+    return value
+
+
+def required_text(value: Any, field: str, maximum: int = MAX_BODY_CHARS) -> str:
+    value = text(value, field, maximum)
+    if not value:
+        raise BriefError(f"{field} is required")
+    return value
+
+
+def string_list(value: Any, field: str, maximum_items: int = 8) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or len(value) > maximum_items:
+        raise BriefError(f"{field} must be a list with at most {maximum_items} items")
+    return [required_text(item, f"{field}[{index}]") for index, item in enumerate(value)]
+
+
+def load_brief(path: Path) -> dict[str, Any]:
+    if path.stat().st_size > MAX_INPUT_BYTES:
+        raise BriefError(f"input exceeds {MAX_INPUT_BYTES} bytes")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise BriefError(f"cannot read JSON brief: {exc}") from exc
+    if not isinstance(value, dict):
+        raise BriefError("brief root must be an object")
+    required_text(value.get("title"), "title", MAX_TITLE_CHARS)
+    slides = value.get("slides")
+    if not isinstance(slides, list) or not slides or len(slides) > MAX_SLIDES:
+        raise BriefError(f"slides must contain between 1 and {MAX_SLIDES} entries")
+    for index, slide in enumerate(slides):
+        if not isinstance(slide, dict):
+            raise BriefError(f"slides[{index}] must be an object")
+        if slide.get("layout") not in LAYOUTS:
+            raise BriefError(f"slides[{index}].layout is unsupported")
+    return value
+
+
+def resolve_theme(brief: dict[str, Any]) -> dict[str, RGBColor]:
+    overrides = brief.get("theme") or {}
+    if not isinstance(overrides, dict):
+        raise BriefError("theme must be an object")
+    unknown = set(overrides) - set(DEFAULT_THEME)
+    if unknown:
+        raise BriefError(f"unknown theme keys: {', '.join(sorted(unknown))}")
+    return {name: color(str(overrides.get(name, value))) for name, value in DEFAULT_THEME.items()}
+
+
+def fill_shape(shape: Any, value: RGBColor) -> None:
+    shape.fill.solid()
+    shape.fill.fore_color.rgb = value
+    shape.line.fill.background()
+
+
+def add_text(
+    slide: Any,
+    value: str,
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+    *,
+    size: int,
+    rgb: RGBColor,
+    bold: bool = False,
+    align: PP_ALIGN = PP_ALIGN.LEFT,
+    font: str = "Aptos",
+) -> Any:
+    box = slide.shapes.add_textbox(Inches(x), Inches(y), Inches(width), Inches(height))
+    frame = box.text_frame
+    frame.clear()
+    frame.word_wrap = True
+    frame.margin_left = frame.margin_right = Inches(0.03)
+    frame.margin_top = frame.margin_bottom = Inches(0.02)
+    frame.vertical_anchor = MSO_ANCHOR.MIDDLE
+    paragraph = frame.paragraphs[0]
+    paragraph.alignment = align
+    paragraph.space_after = Pt(0)
+    run = paragraph.add_run()
+    run.text = value
+    run.font.name = font
+    run.font.size = Pt(size)
+    run.font.bold = bold
+    run.font.color.rgb = rgb
+    return box
+
+
+def add_title(slide: Any, value: str, theme: dict[str, RGBColor]) -> None:
+    add_text(slide, required_text(value, "slide.title", MAX_TITLE_CHARS), 0.75, 0.55, 11.8, 0.65,
+             size=26, rgb=theme["text"], bold=True)
+    accent = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(0.75), Inches(1.28), Inches(0.7), Inches(0.06))
+    fill_shape(accent, theme["accent"])
+
+
+def add_footer(slide: Any, footer: str, number: int, theme: dict[str, RGBColor]) -> None:
+    add_text(slide, footer, 0.75, 7.05, 10.8, 0.22, size=8, rgb=theme["muted"])
+    add_text(slide, f"{number:02d}", 11.9, 7.02, 0.65, 0.25, size=8,
+             rgb=theme["muted"], align=PP_ALIGN.RIGHT)
+
+
+def add_bullet_list(slide: Any, bullets: list[str], x: float, y: float, width: float, height: float,
+                    theme: dict[str, RGBColor], size: int = 19) -> None:
+    box = slide.shapes.add_textbox(Inches(x), Inches(y), Inches(width), Inches(height))
+    frame = box.text_frame
+    frame.clear()
+    frame.word_wrap = True
+    frame.margin_left = frame.margin_right = Inches(0.04)
+    for index, item in enumerate(bullets):
+        paragraph = frame.paragraphs[0] if index == 0 else frame.add_paragraph()
+        paragraph.text = f"•  {item}"
+        paragraph.font.name = "Aptos"
+        paragraph.font.size = Pt(size)
+        paragraph.font.color.rgb = theme["text"]
+        paragraph.space_after = Pt(14)
+        paragraph.line_spacing = 1.12
+
+
+def render_title(slide: Any, spec: dict[str, Any], theme: dict[str, RGBColor]) -> None:
+    band = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, 0, 0, Inches(0.18), SLIDE_HEIGHT)
+    fill_shape(band, theme["accent"])
+    add_text(slide, text(spec.get("eyebrow") or "PRESENTATION", "eyebrow"), 0.9, 1.2, 5.5, 0.35,
+             size=11, rgb=theme["primary"], bold=True)
+    add_text(slide, required_text(spec.get("title"), "slide.title", MAX_TITLE_CHARS), 0.9, 1.75, 11.2, 1.7,
+             size=38, rgb=theme["text"], bold=True)
+    add_text(slide, text(spec.get("subtitle"), "slide.subtitle"), 0.95, 3.7, 10.5, 0.9,
+             size=19, rgb=theme["muted"])
+    rule = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(0.95), Inches(5.4), Inches(2.0), Inches(0.08))
+    fill_shape(rule, theme["primary"])
+
+
+def render_section(slide: Any, spec: dict[str, Any], theme: dict[str, RGBColor]) -> None:
+    panel = slide.shapes.add_shape(MSO_SHAPE.ROUNDED_RECTANGLE, Inches(0.7), Inches(0.75), Inches(11.9), Inches(5.9))
+    fill_shape(panel, theme["primary"])
+    add_text(slide, text(spec.get("eyebrow") or "SECTION", "eyebrow"), 1.25, 1.25, 5.0, 0.35,
+             size=11, rgb=theme["surface"], bold=True)
+    add_text(slide, required_text(spec.get("title"), "slide.title", MAX_TITLE_CHARS), 1.25, 2.0, 10.5, 1.5,
+             size=34, rgb=theme["surface"], bold=True)
+    add_text(slide, text(spec.get("subtitle"), "slide.subtitle"), 1.28, 4.0, 9.8, 1.1,
+             size=18, rgb=theme["surface"])
+
+
+def render_bullets(slide: Any, spec: dict[str, Any], theme: dict[str, RGBColor]) -> None:
+    add_title(slide, spec.get("title"), theme)
+    add_text(slide, text(spec.get("subtitle"), "slide.subtitle"), 0.78, 1.5, 11.4, 0.55,
+             size=14, rgb=theme["muted"])
+    bullets = string_list(spec.get("bullets"), "bullets", 7)
+    if not bullets:
+        raise BriefError("bullets layout requires at least one bullet")
+    add_bullet_list(slide, bullets, 1.0, 2.15, 11.0, 4.4, theme)
+
+
+def column(spec: Any, field: str) -> tuple[str, list[str]]:
+    if not isinstance(spec, dict):
+        raise BriefError(f"{field} must be an object")
+    title_value = required_text(spec.get("title"), f"{field}.title", MAX_TITLE_CHARS)
+    bullets = string_list(spec.get("bullets"), f"{field}.bullets", 6)
+    if not title_value or not bullets:
+        raise BriefError(f"{field} requires title and bullets")
+    return title_value, bullets
+
+
+def render_two_column(slide: Any, spec: dict[str, Any], theme: dict[str, RGBColor]) -> None:
+    add_title(slide, spec.get("title"), theme)
+    for index, field in enumerate(("left", "right")):
+        heading, bullets = column(spec.get(field), field)
+        x = 0.75 + index * 6.05
+        card = slide.shapes.add_shape(MSO_SHAPE.ROUNDED_RECTANGLE, Inches(x), Inches(1.7), Inches(5.65), Inches(4.9))
+        fill_shape(card, theme["surface"])
+        card.line.color.rgb = theme["primary"] if index else theme["accent"]
+        card.line.width = Pt(1.25)
+        add_text(slide, heading, x + 0.35, 2.05, 4.95, 0.55, size=20,
+                 rgb=theme["primary"] if index else theme["accent"], bold=True)
+        add_bullet_list(slide, bullets, x + 0.35, 2.85, 4.9, 3.15, theme, size=16)
+
+
+def render_metrics(slide: Any, spec: dict[str, Any], theme: dict[str, RGBColor]) -> None:
+    add_title(slide, spec.get("title"), theme)
+    metrics = spec.get("metrics")
+    if not isinstance(metrics, list) or not 1 <= len(metrics) <= 4:
+        raise BriefError("metrics must contain between 1 and 4 entries")
+    gap = 0.28
+    width = (11.8 - gap * (len(metrics) - 1)) / len(metrics)
+    for index, metric in enumerate(metrics):
+        if not isinstance(metric, dict):
+            raise BriefError(f"metrics[{index}] must be an object")
+        x = 0.75 + index * (width + gap)
+        card = slide.shapes.add_shape(MSO_SHAPE.ROUNDED_RECTANGLE, Inches(x), Inches(1.8), Inches(width), Inches(4.6))
+        fill_shape(card, theme["surface"])
+        add_text(slide, required_text(metric.get("value"), f"metrics[{index}].value", 32), x + 0.25, 2.15,
+                 width - 0.5, 1.05, size=31, rgb=theme["primary"], bold=True, align=PP_ALIGN.CENTER)
+        add_text(slide, required_text(metric.get("label"), f"metrics[{index}].label", 80), x + 0.25, 3.35,
+                 width - 0.5, 0.65, size=17, rgb=theme["text"], bold=True, align=PP_ALIGN.CENTER)
+        add_text(slide, text(metric.get("detail"), f"metrics[{index}].detail"), x + 0.3, 4.25,
+                 width - 0.6, 1.15, size=12, rgb=theme["muted"], align=PP_ALIGN.CENTER)
+
+
+RENDERERS = {
+    "title": render_title,
+    "section": render_section,
+    "bullets": render_bullets,
+    "two_column": render_two_column,
+    "metrics": render_metrics,
+}
+
+
+def build(brief: dict[str, Any], output: Path) -> None:
+    theme = resolve_theme(brief)
+    presentation = Presentation()
+    presentation.slide_width = SLIDE_WIDTH
+    presentation.slide_height = SLIDE_HEIGHT
+    presentation.core_properties.title = text(brief.get("title"), "title", MAX_TITLE_CHARS)
+    presentation.core_properties.subject = "Editable presentation generated by WeKnora"
+    presentation.core_properties.author = text(brief.get("author"), "author", 120)
+    footer = text(brief.get("footer"), "footer", 160)
+
+    for number, spec in enumerate(brief["slides"], 1):
+        slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+        background = slide.background.fill
+        background.solid()
+        background.fore_color.rgb = theme["background"]
+        RENDERERS[spec["layout"]](slide, spec, theme)
+        add_footer(slide, footer, number, theme)
+        notes = text(spec.get("notes"), f"slides[{number - 1}].notes", 2_000)
+        if notes:
+            slide.notes_slide.notes_text_frame.text = notes
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    presentation.save(output)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path, help="UTF-8 JSON brief")
+    parser.add_argument("--output", required=True, type=Path, help="destination .pptx")
+    args = parser.parse_args()
+    if args.output.suffix.lower() != ".pptx":
+        parser.error("--output must end with .pptx")
+    try:
+        brief = load_brief(args.input)
+        build(brief, args.output)
+    except (BriefError, OSError) as exc:
+        parser.error(str(exc))
+    print(json.dumps({
+        "output": str(args.output),
+        "slides": len(brief["slides"]),
+        "bytes": args.output.stat().st_size,
+    }, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/skills/presentation-generation/tests/test_build_presentation.py
+++ b/examples/skills/presentation-generation/tests/test_build_presentation.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+import zipfile
+from xml.etree import ElementTree
+from pathlib import Path
+
+from pptx import Presentation
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+BUILDER = SKILL_ROOT / "scripts" / "build_presentation.py"
+EXAMPLE = SKILL_ROOT / "assets" / "example.json"
+
+
+def load_builder():
+    spec = importlib.util.spec_from_file_location("presentation_builder", BUILDER)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load presentation builder")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+builder = load_builder()
+
+
+class PresentationBuilderTest(unittest.TestCase):
+    def build_example(self, directory: Path) -> tuple[Path, dict[str, object]]:
+        output = directory / "topic2.pptx"
+        completed = subprocess.run(
+            [sys.executable, str(BUILDER), "--input", str(EXAMPLE), "--output", str(output)],
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        return output, json.loads(completed.stdout)
+
+    def test_example_is_valid_editable_unicode_pptx(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output, summary = self.build_example(Path(tmp))
+            self.assertEqual(summary["slides"], 5)
+            self.assertEqual(summary["bytes"], output.stat().st_size)
+            self.assertGreater(output.stat().st_size, 10_000)
+
+            deck = Presentation(output)
+            self.assertEqual(len(deck.slides), 5)
+            for slide in deck.slides:
+                for shape in slide.shapes:
+                    self.assertGreaterEqual(shape.left, 0)
+                    self.assertGreaterEqual(shape.top, 0)
+                    self.assertLessEqual(shape.left + shape.width, deck.slide_width)
+                    self.assertLessEqual(shape.top + shape.height, deck.slide_height)
+            for slide in deck.slides:
+                for shape in slide.shapes:
+                    self.assertGreaterEqual(shape.left, 0)
+                    self.assertGreaterEqual(shape.top, 0)
+                    self.assertLessEqual(shape.left + shape.width, deck.slide_width)
+                    self.assertLessEqual(shape.top + shape.height, deck.slide_height)
+            slide_text = [
+                shape.text
+                for slide in deck.slides
+                for shape in slide.shapes
+                if getattr(shape, "has_text_frame", False)
+            ]
+            joined = "\n".join(slide_text)
+            self.assertIn("WeKnora 犀牛鸟课题二", joined)
+            self.assertIn("Safe Files", joined)
+            self.assertIn("跨租户与跨会话访问", joined)
+
+            editable = next(shape for shape in deck.slides[0].shapes if shape.has_text_frame and "WeKnora" in shape.text)
+            editable.text_frame.paragraphs[0].runs[0].text = "可编辑标题"
+            edited = Path(tmp) / "edited.pptx"
+            deck.save(edited)
+            self.assertIn("可编辑标题", "\n".join(
+                shape.text for shape in Presentation(edited).slides[0].shapes if shape.has_text_frame
+            ))
+
+    def test_package_contains_slide_parts_and_no_rasterized_text(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output, _ = self.build_example(Path(tmp))
+            with zipfile.ZipFile(output) as archive:
+                names = set(archive.namelist())
+                self.assertIn("[Content_Types].xml", names)
+                self.assertIn("ppt/presentation.xml", names)
+                self.assertEqual(len([
+                    name for name in names
+                    if name.startswith("ppt/slides/slide") and name.endswith(".xml")
+                ]), 5)
+                self.assertFalse(any(name.startswith("ppt/media/") for name in names))
+                drawing_namespace = "{http://schemas.openxmlformats.org/drawingml/2006/main}"
+                editable_text = []
+                for name in names:
+                    if name.startswith("ppt/slides/slide") and name.endswith(".xml"):
+                        root = ElementTree.fromstring(archive.read(name))
+                        editable_text.extend(node.text or "" for node in root.iter(f"{drawing_namespace}t"))
+                joined = "\n".join(editable_text)
+                self.assertIn("WeKnora", joined)
+                self.assertIn("\u7280\u725b\u9e1f", joined)
+
+    def test_validation_rejects_unknown_layout_and_oversized_deck(self):
+        valid = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+        valid["slides"][0]["layout"] = "arbitrary_code"
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad.json"
+            path.write_text(json.dumps(valid), encoding="utf-8")
+            with self.assertRaisesRegex(builder.BriefError, "unsupported"):
+                builder.load_brief(path)
+
+        valid = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+        valid["slides"] = valid["slides"] * 11
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "too-many.json"
+            path.write_text(json.dumps(valid), encoding="utf-8")
+            with self.assertRaisesRegex(builder.BriefError, "between 1 and 50"):
+                builder.load_brief(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/skills/presentation-generation/tests/verify_weknora_preview.ts
+++ b/examples/skills/presentation-generation/tests/verify_weknora_preview.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+
+const requireFromFrontend = createRequire(
+  new URL('../../../../frontend/package.json', import.meta.url),
+)
+const { DOMParser, XMLSerializer } = requireFromFrontend('@xmldom/xmldom')
+Object.assign(globalThis, { DOMParser, XMLSerializer })
+
+async function main() {
+  const input = process.argv[2]
+  const expectedSlides = Number(process.argv[3] || '5')
+  assert.ok(input, 'usage: verify_weknora_preview.ts <presentation.pptx> [slide-count]')
+  assert.ok(Number.isInteger(expectedSlides) && expectedSlides > 0, 'slide-count must be positive')
+
+  const { preparePptxPreview } = await import(
+    '../../../../frontend/src/utils/pptxPreview.ts'
+  )
+  const bytes = await readFile(input)
+  const source = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+  const prepared = await preparePptxPreview(source)
+
+  assert.equal(prepared.slideCount, expectedSlides)
+  assert.ok(prepared.data.byteLength > 10_000, 'preview input is unexpectedly small')
+  console.log(JSON.stringify({ preview: 'accepted', slides: prepared.slideCount, bytes: prepared.data.byteLength }))
+}
+
+void main()


### PR DESCRIPTION
## Description

Add a focused presentation-generation skill that produces polished, editable PowerPoint files through the existing skill install, sandbox execution, ArtifactCollector, preview, and download path.

- Add a bounded JSON-to-PPTX builder with five layouts (`title`, `section`, `bullets`, `two_column`, `metrics`).
- Pin the direct runtime dependency to `python-pptx==1.0.2`.
- Include a Chinese/English fixture and validation for malformed input, unknown layouts, excessive slide counts, invalid colors, and oversized text.
- Verify valid OOXML packaging, slide count, expected text, editable text, Unicode text, layout bounds, and absence of rasterized slide text.
- Verify a PPTX generated inside the real Docker sandbox is accepted by WeKnora's existing PPTX preview preprocessor.

This PR does not add an office platform, another renderer, or DOCX/XLSX/PDF generation. PR #3168 remains an unmerged conflicting draft and no code is copied from it.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Refactor
- [ ] ⚡ Performance improvement
- [x] 🧪 Test
- [ ] 🔧 Configuration / Build / CI

## Related Issue

N/A — Rhino Bird Topic 2 sandbox workbench.

## Testing

- PASS — isolated Python 3.14 environment: `python -m unittest discover -s examples/skills/presentation-generation/tests -v` (3/3).
- PASS — real Docker Engine 29.7.2 / API 1.55, Linux/amd64, `wechatopenai/weknora-sandbox:dev`:
  - installed `requirements.txt` in a clean Python 3.11.16 venv;
  - ran the same 3 tests successfully;
  - generated `/workspace/output/topic2-example.pptx`, 5 slides, 35,815 bytes;
  - SHA-256 `E9532EFC6DCF2559109165515C500DB472FA8C23534ED94110708FB9D5E97ADD`.
- PASS — `tsx examples/skills/presentation-generation/tests/verify_weknora_preview.ts <generated.pptx> 5`: `{"preview":"accepted","slides":5,"bytes":35815}`.
- PASS — `npm --prefix frontend test -- src/utils/pptxPreview.test.ts` (5/5).
- PASS — `go test ./internal/application/service ./internal/handler/session -run 'ArtifactCollector|Artifact|Pptx|PPTX' -count=1`.
- PASS — `git diff --check`.
- NOT_RUN — full frontend build; this PR changes no frontend production source or dependency.
- NOT_RUN — full repository test suite; focused skill, artifact, and preview paths were run instead.

## Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable (for Go: `golangci-lint run --new-from-rev=origin/main ./...`)
- [x] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [x] Updated related documentation (README, `docs/`, Swagger annotations, etc.)
- [x] Breaking changes are clearly called out in the description above

## Screenshots / Recordings

NOT_RUN — no new UI; generated PPTX validity and compatibility were verified programmatically.
