### PR TITLE
修复大型 PR 的增量 lint 差异获取限制

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,10 +1,8 @@
 name: Go Lint
 
-# The repository carries a large backlog of pre-existing golangci-lint findings,
-# so pull requests are only judged on the code they introduce (`only-new-issues`).
-# That filter needs a pull request diff, which is why this workflow has no other
-# trigger; the companion go-lint-cache.yml keeps the caches this job restores
-# from warm on main.
+# Pull requests are judged on diagnostics introduced relative to their base.
+# A complete local checkout supplies that diff, including PRs beyond the hosted
+# patch API's file-count limit. The companion go-lint-cache.yml warms caches.
 
 on:
   pull_request:
@@ -101,4 +99,7 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: ${{ matrix.module }}
-          only-new-issues: true
+          # The action's patch download has a 300-file limit. The linter reads
+          # the same base-to-checkout diff locally without that API limit.
+          only-new-issues: false
+          args: --new-from-rev=${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
## 问题

增量 lint 插件依赖 GitHub 返回完整 PR 差异。在一次实际包含 640 个文件的集成 PR 中，接口返回 HTTP 406：`diff exceeded the maximum number of files (300)`。插件随后运行 lint 时丢失新增问题过滤，报出仓库已有诊断。复现运行：https://github.com/Aokiuuz/WeKnora/actions/runs/34695347913 。

## 改动

利用现有完整 Git 检出，以事件中准确的目标提交执行 `--new-from-rev`，由 linter 在本地计算差异。关闭插件自身的远端差异下载；新增问题仍导致检查失败。模块检测、启用的 linter 和触发条件保持原有规则。

本 PR 只有 `.github/workflows/go-lint.yml` 一个文件，独立于完整课题功能 #3220，便于单独审阅。

## 验证

- 根模块、CLI、客户端按本地差异运行通过。
- 临时新增一个缺少说明的导出函数，检查以退出码 1 拒绝并指出该函数；探针已移除。
- 与工作流相同的根模块命令通过。
- 所有 lint 任务已有 `fetch-depth: 0`，目标提交可供本地比较。

未批量修改历史 lint 问题，未新增忽略规则，也未把检查错误设为可忽略。
