### PR TITLE
fix(agent): bound the runtime_context KB catalog and fail fast on over-window turns

### DIFF
--- a/internal/agent/context_guard_test.go
+++ b/internal/agent/context_guard_test.go
@@ -1,0 +1,76 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Tencent/WeKnora/internal/models/chat"
+	"github.com/Tencent/WeKnora/internal/types"
+)
+
+func newGuardTestEngine(t *testing.T, maxContextTokens int) *AgentEngine {
+	t.Helper()
+	return newTestEngine(t, nil, func(cfg *types.AgentConfig) {
+		cfg.MaxContextTokens = maxContextTokens
+	})
+}
+
+// TestEnsureTurnFitsContextWindow pins the fail-fast guard: a current turn
+// that cannot fit the window (no matter what compaction does) aborts with an
+// actionable error instead of resending the same oversized request for the
+// rest of maxIterations.
+func TestEnsureTurnFitsContextWindow(t *testing.T) {
+	var big strings.Builder
+	for big.Len() < 600_000 {
+		big.WriteString("回滚 SLA 为 45 分钟，发布窗口每周二与周四。")
+	}
+	bigMessage := []chat.Message{{Role: "user", Content: big.String()}}
+
+	t.Run("oversized turn is rejected", func(t *testing.T) {
+		engine := newGuardTestEngine(t, 100_000)
+		tokens := engine.tokenEstimator.EstimateMessages(bigMessage)
+		err := engine.ensureTurnFitsContextWindow(context.Background(), 1, tokens, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds the model context window")
+		require.Contains(t, err.Error(), "bound knowledge bases")
+	})
+
+	t.Run("fitting turn passes", func(t *testing.T) {
+		engine := newGuardTestEngine(t, 400_000)
+		tokens := engine.tokenEstimator.EstimateMessages(bigMessage)
+		err := engine.ensureTurnFitsContextWindow(context.Background(), 1, tokens, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("unknown window keeps provider-judged behaviour", func(t *testing.T) {
+		engine := newGuardTestEngine(t, 0)
+		err := engine.ensureTurnFitsContextWindow(context.Background(), 1, 1_000_000, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("tool schemas count when no usage baseline exists", func(t *testing.T) {
+		engine := newGuardTestEngine(t, 100_000)
+		// Messages alone fit comfortably…
+		msgTokens := engine.tokenEstimator.EstimateMessages(nil)
+		// …but a tool surface sized like the real one (~232 schemas) pushes
+		// the request over the window, and with no usage baseline the guard
+		// must add the schema cost itself.
+		schema := json.RawMessage(`{"type":"object","properties":{"q":{"type":"string"}},"required":["q"],"additionalProperties":false}`)
+		tools := make([]chat.Tool, 232)
+		for i := range tools {
+			tools[i] = chat.Tool{
+				Type: "function",
+				Function: chat.FunctionDef{
+					Name:        "tool_" + strings.Repeat("n", 100) + strings.Repeat(string(rune('a'+i%26)), 8),
+					Description: strings.Repeat("Retrieves passages from the bound knowledge bases. ", 60),
+					Parameters:  schema,
+				},
+			}
+		}
+		require.Error(t, engine.ensureTurnFitsContextWindow(context.Background(), 1, msgTokens, tools))
+	})
+}

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -222,6 +222,43 @@ func (e *AgentEngine) GetSkillsManager() *skills.Manager {
 	return e.skillsManager
 }
 
+// ensureTurnFitsContextWindow fails the turn before the LLM call when the
+// current request cannot fit the model's context window no matter what
+// compaction does. The recurring trigger is a birth defect rather than
+// accumulated history: the current turn's user message embeds a
+// runtime_context that alone exceeds the window (e.g. an oversized bound-KB
+// catalog), the compactor correctly declines to cut the current turn, and
+// every retry would resend the same oversized request for the rest of
+// maxIterations. One estimate check here replaces that entire futile run.
+// A zero/unknown MaxContextTokens keeps the previous behaviour: let the
+// provider judge.
+func (e *AgentEngine) ensureTurnFitsContextWindow(ctx context.Context, round, messageTokens int, tools []chat.Tool) error {
+	if e.config == nil || e.config.MaxContextTokens <= 0 {
+		return nil
+	}
+	requestTokens := messageTokens
+	// The pure message estimate excludes tool schemas (see
+	// estimateCurrentTokens); a usage baseline already billed them.
+	if contextTokensFromUsage(e.lastUsage) == 0 {
+		requestTokens += e.tokenEstimator.EstimateTools(tools)
+	}
+	window := e.config.MaxContextTokens - contextSafetyTokens
+	if requestTokens <= window {
+		return nil
+	}
+	logger.Warnf(ctx, "[Agent][Round-%d] Turn exceeds context window: est %d tokens (messages %d + tool schemas %d) vs %d available; aborting before the model call",
+		round, requestTokens, messageTokens, requestTokens-messageTokens, window)
+	common.PipelineWarn(ctx, "Agent", "context_window_exceeded", map[string]interface{}{
+		"round":          round,
+		"request_tokens": requestTokens,
+		"window_tokens":  window,
+	})
+	return fmt.Errorf(
+		"agent turn exceeds the model context window: estimated %d tokens against %d available and compaction cannot shrink the current turn; "+
+			"narrow the agent's bound knowledge bases or configure a model with a larger context window",
+		requestTokens, window)
+}
+
 // estimateCurrentTokens returns the best estimate of the current context token
 // count:
 //
@@ -663,6 +700,11 @@ func (e *AgentEngine) runReActIteration(
 	// updated (the injected text counts as new delta tokens for the next
 	// call), so the very next LLM call sees the user's addition.
 	e.drainSteerMessages(ctx, state, messagesPtr, sessionID, assistantMessageID)
+
+	if err := e.ensureTurnFitsContextWindow(ctx, round, currentTokens, tools); err != nil {
+		retErr = err
+		return iterOutcomeNext, err
+	}
 
 	logger.Infof(ctx, "[Agent][Round-%d/%s] Starting: %d messages, %d tools, est_tokens=%d",
 		round, e.maxIterationsDisplay(), len(*messagesPtr), len(tools), currentTokens)

--- a/internal/agent/prompts.go
+++ b/internal/agent/prompts.go
@@ -127,7 +127,28 @@ func AvailablePlaceholders() []PlaceholderDefinition {
 	return result
 }
 
-// formatKnowledgeBaseList formats knowledge base information as XML for the prompt
+// Catalog budget for formatKnowledgeBaseList. Each full-detail entry costs
+// ~1.2KB, so a tenant binding hundreds of knowledge bases to one agent would
+// otherwise render a catalog larger than the model's context window before
+// the conversation even starts — the runtime_context block is injected into
+// the first user message of every turn and compaction must not cut it.
+const (
+	// kbCatalogFullDetailChars is the character budget for full-detail
+	// entries (header + description + recent documents). Beyond it, the
+	// remaining knowledge bases degrade to single-line entries that keep
+	// their routing ids at roughly a tenth of the cost.
+	kbCatalogFullDetailChars = 20_000
+	// kbCatalogHardCeilingChars is the hard ceiling for the whole catalog.
+	// Single-line entries are cheap but not free; past this the tail is
+	// omitted entirely with a note. Retrieval still covers omitted bases
+	// whenever the model does not narrow the scope with knowledge_base_ids.
+	kbCatalogHardCeilingChars = 128_000
+)
+
+// formatKnowledgeBaseList formats knowledge base information as XML for the
+// prompt. Entries render in full detail until kbCatalogFullDetailChars is
+// exhausted, degrade to id-preserving single lines under
+// kbCatalogHardCeilingChars, and are then omitted with an explanatory note.
 func formatKnowledgeBaseList(kbInfos []*KnowledgeBaseInfo) string {
 	if len(kbInfos) == 0 {
 		return "<knowledge_bases />"
@@ -135,46 +156,71 @@ func formatKnowledgeBaseList(kbInfos []*KnowledgeBaseInfo) string {
 
 	var b strings.Builder
 	b.WriteString("<knowledge_bases>\n")
+	catalogStart := b.Len()
+	omitted := 0
 	for _, kb := range kbInfos {
 		if kb == nil {
 			continue
 		}
-		kbType := kb.Type
-		if kbType == "" {
-			kbType = "document"
+		catalogChars := b.Len() - catalogStart
+		if catalogChars >= kbCatalogHardCeilingChars {
+			omitted++
+			continue
 		}
-		fmt.Fprintf(&b, "<knowledge_base id=\"%s\" name=\"%s\" type=\"%s\" doc_count=\"%d\" capabilities=\"%s\">\n",
-			escapeXMLAttr(kb.ID), escapeXMLAttr(formatDocSummary(kb.Name, 160)), escapeXMLAttr(kbType), kb.DocCount,
-			escapeXMLAttr(strings.Join(kb.Capabilities, ",")))
-		if kb.Description != "" {
-			fmt.Fprintf(&b, "<description>%s</description>\n", escapeXMLAttr(formatDocSummary(kb.Description, 240)))
-		}
-		if len(kb.RecentDocs) > 0 {
-			b.WriteString("<recent_documents>\n")
-			for j, doc := range kb.RecentDocs {
-				if j >= 2 {
-					break
-				}
-				name := doc.Title
-				if kbType == "faq" {
-					name = doc.FAQStandardQuestion
-				}
-				if name == "" {
-					name = doc.FileName
-				}
-				fmt.Fprintf(&b,
-					"<document knowledge_id=\"%s\" chunk_id=\"%s\" type=\"%s\"><name>%s</name></document>\n",
-					escapeXMLAttr(doc.KnowledgeID),
-					escapeXMLAttr(doc.ChunkID),
-					escapeXMLAttr(doc.Type),
-					escapeXMLAttr(formatDocSummary(name, 160)))
+		if catalogChars >= kbCatalogFullDetailChars {
+			kbType := kb.Type
+			if kbType == "" {
+				kbType = "document"
 			}
-			b.WriteString("</recent_documents>\n")
+			fmt.Fprintf(&b, "<knowledge_base id=\"%s\" name=\"%s\" type=\"%s\" doc_count=\"%d\" />\n",
+				escapeXMLAttr(kb.ID), escapeXMLAttr(formatDocSummary(kb.Name, 160)), escapeXMLAttr(kbType), kb.DocCount)
+			continue
 		}
-		b.WriteString("</knowledge_base>\n")
+		writeKnowledgeBaseDetail(&b, kb)
+	}
+	if omitted > 0 {
+		fmt.Fprintf(&b, "<note>%d further knowledge bases are omitted to bound this catalog's size; "+
+			"searches without an explicit knowledge_base_ids scope still cover them.</note>\n", omitted)
 	}
 	b.WriteString("</knowledge_bases>")
 	return b.String()
+}
+
+// writeKnowledgeBaseDetail renders one full-detail <knowledge_base> entry.
+func writeKnowledgeBaseDetail(b *strings.Builder, kb *KnowledgeBaseInfo) {
+	kbType := kb.Type
+	if kbType == "" {
+		kbType = "document"
+	}
+	fmt.Fprintf(b, "<knowledge_base id=\"%s\" name=\"%s\" type=\"%s\" doc_count=\"%d\" capabilities=\"%s\">\n",
+		escapeXMLAttr(kb.ID), escapeXMLAttr(formatDocSummary(kb.Name, 160)), escapeXMLAttr(kbType), kb.DocCount,
+		escapeXMLAttr(strings.Join(kb.Capabilities, ",")))
+	if kb.Description != "" {
+		fmt.Fprintf(b, "<description>%s</description>\n", escapeXMLAttr(formatDocSummary(kb.Description, 240)))
+	}
+	if len(kb.RecentDocs) > 0 {
+		b.WriteString("<recent_documents>\n")
+		for j, doc := range kb.RecentDocs {
+			if j >= 2 {
+				break
+			}
+			name := doc.Title
+			if kbType == "faq" {
+				name = doc.FAQStandardQuestion
+			}
+			if name == "" {
+				name = doc.FileName
+			}
+			fmt.Fprintf(b,
+				"<document knowledge_id=\"%s\" chunk_id=\"%s\" type=\"%s\"><name>%s</name></document>\n",
+				escapeXMLAttr(doc.KnowledgeID),
+				escapeXMLAttr(doc.ChunkID),
+				escapeXMLAttr(doc.Type),
+				escapeXMLAttr(formatDocSummary(name, 160)))
+		}
+		b.WriteString("</recent_documents>\n")
+	}
+	b.WriteString("</knowledge_base>\n")
 }
 
 // renderPromptPlaceholders renders placeholders in the prompt template.

--- a/internal/agent/prompts_kbcatalog_test.go
+++ b/internal/agent/prompts_kbcatalog_test.go
@@ -1,0 +1,86 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func u14KB(i, total int) *KnowledgeBaseInfo {
+	return &KnowledgeBaseInfo{
+		ID:           fmt.Sprintf("kb-%05d-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", i),
+		Name:         fmt.Sprintf("部门知识库-%05d（产品线文档）", i),
+		Type:         "document",
+		DocCount:     120,
+		Capabilities: []string{"vector", "keyword"},
+		Description:  strings.Repeat("本知识库收录该产品线的需求文档、设计评审与运维手册，覆盖接入规范与发布流程。", 6),
+		RecentDocs: []RecentDocInfo{
+			{KnowledgeID: "k-11111111-2222-3333-4444-555555555555", Title: "2026-Q3 产品需求文档合集", Type: "file", ChunkID: "c-1"},
+			{KnowledgeID: "k-66666666-7777-8888-9999-000000000000", Title: "服务接入规范 v3", Type: "file", ChunkID: "c-2"},
+		},
+	}
+}
+
+func u14Corpus(n int) []*KnowledgeBaseInfo {
+	out := make([]*KnowledgeBaseInfo, n)
+	for i := range out {
+		out[i] = u14KB(i, n)
+	}
+	return out
+}
+
+// TestFormatKnowledgeBaseListSmallCatalogUnchanged pins that ordinary catalogs
+// (a handful of KBs) keep the full-detail rendering this list has always had.
+func TestFormatKnowledgeBaseListSmallCatalogUnchanged(t *testing.T) {
+	out := formatKnowledgeBaseList(u14Corpus(5))
+	require.Contains(t, out, "<description>")
+	require.Contains(t, out, "<recent_documents>")
+	require.NotContains(t, out, "omitted")
+	for i := 0; i < 5; i++ {
+		require.Contains(t, out, fmt.Sprintf("kb-%05d", i))
+	}
+}
+
+// TestFormatKnowledgeBaseListDegradesUnderBudget pins the two-layer budget:
+// full-detail entries stop at kbCatalogFullDetailChars, the rest degrade to
+// single-line entries that keep every routing id, and the total stays bounded
+// no matter how many knowledge bases are bound.
+func TestFormatKnowledgeBaseListDegradesUnderBudget(t *testing.T) {
+	const n = 541
+	out := formatKnowledgeBaseList(u14Corpus(n))
+
+	// The pre-budget rendering of this corpus was ~666KB / 392k chars; the
+	// budgeted one must stay an order of magnitude below that.
+	require.Less(t, len(out), 150_000, "catalog should stay bounded for 541 KBs")
+
+	// Every routing id must survive degradation: knowledge_search targets
+	// bases by these ids.
+	for i := 0; i < n; i++ {
+		require.Contains(t, out, fmt.Sprintf("kb-%05d", i), "routing id lost at %d", i)
+	}
+
+	// The head keeps full detail, the tail is compact: the degraded region
+	// carries ids but no descriptions.
+	head := strings.Index(out, "<description>")
+	require.GreaterOrEqual(t, head, 0)
+	tail := out[strings.LastIndex(out, "<knowledge_base "):]
+	require.NotContains(t, tail, "<description>")
+
+	// A 541-KB tenant fits inside the hard ceiling, so nothing is omitted.
+	require.NotContains(t, out, "omitted")
+}
+
+// TestFormatKnowledgeBaseListHardCeilingOmits pins the hard ceiling: past
+// kbCatalogHardCeilingChars the tail is dropped entirely and the note tells
+// the model those bases are still covered by unscoped searches.
+func TestFormatKnowledgeBaseListHardCeilingOmits(t *testing.T) {
+	out := formatKnowledgeBaseList(u14Corpus(3000))
+	require.Contains(t, out, "further knowledge bases are omitted")
+	require.Contains(t, out, "knowledge_base_ids scope still cover them")
+	// Total output stays near the ceiling, not near the 3.7MB unbounded form.
+	require.Less(t, len(out), kbCatalogHardCeilingChars+10_000)
+	// The very last bound base is one of the omitted ones.
+	require.NotContains(t, out, "kb-02999")
+}


### PR DESCRIPTION
Implements #3158.

Two independent guards against the unbounded bound-KB catalog described in the issue:

## 1. Catalog budget in `formatKnowledgeBaseList`

Entries render in full detail until `kbCatalogFullDetailChars` (20k) is exhausted, then degrade to
single-line entries that keep every routing id (`knowledge_search` targets bases by these ids), and are
omitted past `kbCatalogHardCeilingChars` (128k) with a note that unscoped searches still cover them.

Measured on this branch with the synthetic corpus from the issue (541 KBs, ~200-char descriptions):

| | before | after |
|---|---|---|
| 541-KB catalog | ~666 KB / 392k chars | ~110 KB, all 541 ids intact |
| 3000-KB catalog | ~3.7 MB | ~135 KB + omission note |

(The per-entry slimming that landed in #3193 already cut entry cost ~40%; this adds the missing total bound
so the catalog can no longer outgrow the window no matter how many bases are bound.)

## 2. Fail-fast guard before the model call

`ensureTurnFitsContextWindow` aborts the turn when the estimated request — messages, plus tool schemas
when no usage baseline exists yet — cannot fit `MaxContextTokens` minus the existing `contextSafetyTokens`
margin. This is the case compaction structurally cannot fix: the oversized payload is the current turn's
own user message, which the compactor correctly refuses to cut. Previously such a turn burned the full
`maxIterations` run resending the same oversized request; now it costs one estimate check and returns an
error naming the two levers an operator actually has: narrow the bound knowledge bases, or configure a
larger-window model.

Unknown/zero `MaxContextTokens` keeps the previous provider-judged behaviour.

## Tests

- `TestFormatKnowledgeBaseList*`: small catalogs unchanged; 541-KB degradation keeps all ids and stays
  bounded; 3000-KB hits the hard ceiling and emits the omission note.
- `TestEnsureTurnFitsContextWindow`: oversized turn rejected with the actionable message; fitting turn
  passes; unknown window no-ops; tool schemas counted when no usage baseline exists.

## Checklist

- [x] `gofmt` clean, `go build ./...` clean, `go vet` clean
- [x] full `internal/agent` package tests green