### PR TITLE
fix(initialization): keep VLM/ASR/chunking config on a partial config update

### DIFF
--- a/internal/handler/initialization.go
+++ b/internal/handler/initialization.go
@@ -294,7 +294,14 @@ func (h *InitializationHandler) UpdateKBConfig(c *gin.Context) {
 	}
 
 	// 处理多模态模型配置
-	kb.VLMConfig = types.VLMConfig{}
+	// An absent field means "no change". This endpoint is also used to patch a
+	// single field, and wiping VLM/ASR because the caller did not resend them
+	// loses configuration silently: the endpoint still answers 200, so the loss
+	// only surfaces on a later GET. A caller that wants multimodal off sends
+	// vlm_config with enabled=false.
+	if req.VLMConfig != nil || req.Multimodal.Enabled {
+		kb.VLMConfig = types.VLMConfig{}
+	}
 	if req.VLMConfig != nil && req.Multimodal.Enabled && req.VLMConfig.ModelID != "" {
 		vllmModel, err := h.modelService.GetModelByID(ctx, req.VLMConfig.ModelID)
 		if err != nil || vllmModel == nil {
@@ -308,8 +315,10 @@ func (h *InitializationHandler) UpdateKBConfig(c *gin.Context) {
 		kb.VLMConfig.ModelID = ""
 	}
 
-	// 处理ASR语音识别配置
-	kb.ASRConfig = types.ASRConfig{}
+	// 处理ASR语音识别配置 (same "absent means no change" rule as VLM above)
+	if req.ASRConfig != nil {
+		kb.ASRConfig = types.ASRConfig{}
+	}
 	if req.ASRConfig != nil && req.ASRConfig.Enabled && req.ASRConfig.ModelID != "" {
 		asrModel, err := h.modelService.GetModelByID(ctx, req.ASRConfig.ModelID)
 		if err != nil || asrModel == nil {
@@ -331,8 +340,15 @@ func (h *InitializationHandler) UpdateKBConfig(c *gin.Context) {
 	if len(req.DocumentSplitting.Separators) > 0 {
 		kb.ChunkingConfig.Separators = req.DocumentSplitting.Separators
 	}
-	kb.ChunkingConfig.ParserEngineRules = req.DocumentSplitting.ParserEngineRules
-	kb.ChunkingConfig.EnableParentChild = req.DocumentSplitting.EnableParentChild
+	// Both were assigned unconditionally, so a payload that omitted them reset
+	// the parser rules to nil and parent-child chunking to false. Only apply what
+	// the caller actually sent. EnableParentChild is a plain bool and carries no
+	// presence information, so it follows the rules field: the UI sends the two
+	// together.
+	if req.DocumentSplitting.ParserEngineRules != nil {
+		kb.ChunkingConfig.ParserEngineRules = req.DocumentSplitting.ParserEngineRules
+		kb.ChunkingConfig.EnableParentChild = req.DocumentSplitting.EnableParentChild
+	}
 	if req.DocumentSplitting.ParentChunkSize > 0 {
 		kb.ChunkingConfig.ParentChunkSize = req.DocumentSplitting.ParentChunkSize
 	}


### PR DESCRIPTION
## Problem

`PUT /api/v1/initialization/config` assigns three fields unconditionally:

```go
kb.VLMConfig = types.VLMConfig{}
kb.ASRConfig = types.ASRConfig{}
kb.ChunkingConfig.ParserEngineRules = req.DocumentSplitting.ParserEngineRules
kb.ChunkingConfig.EnableParentChild = req.DocumentSplitting.EnableParentChild
```

The endpoint is also used to patch a **single** setting. Updating only the summary model, for example, wipes the multimodal configuration and the parser engine rules — and the request still returns **200**, so the loss surfaces only on a later `GET`.

## Reproduce

1. Configure a knowledge base with multimodal enabled and custom `parser_engine_rules`.
2. `PUT /api/v1/initialization/config` with a body that carries only the fields you want to change (no `vlm_config`, no `asr_config`, no `document_splitting.parser_engine_rules`).
3. Response: `200`.
4. `GET` the knowledge base: `vlm_config` is empty, `parser_engine_rules` is `nil`, `enable_parent_child` is `false`.

## Change

An absent field now means *no change*:

| Field | Cleared when |
|---|---|
| `vlm_config` | the caller sent `vlm_config`, or asked for multimodal explicitly (`multimodal.enabled`) |
| `asr_config` | the caller sent `asr_config` |
| parser rules | `document_splitting.parser_engine_rules` is present |

Turning a feature off stays possible and explicit: send `vlm_config` / `asr_config` with `enabled=false`.

`EnableParentChild` is a plain `bool` and carries no presence information, so it follows the parser-rules field — the web UI sends the two together.

## Notes

- 21 insertions, 5 deletions, one file; no API or schema change.
- `go build ./...` and `go test ./internal/handler/...` pass.
- Found while running WeKnora in production, where a config-only update silently lost the multimodal setup.
